### PR TITLE
feat(auto/light): add DisableAuto option for modes

### DIFF
--- a/pkg/auto/lights/config/root.go
+++ b/pkg/auto/lights/config/root.go
@@ -120,7 +120,8 @@ type Mode struct {
 }
 
 type ModeOption struct {
-	Name string `json:"name,omitempty"`
+	Name        string `json:"name,omitempty"`
+	DisableAuto bool   `json:"disableAuto,omitempty"` // causes the automation to no do anything
 	Mode
 	Start *Schedule `json:"start,omitempty"`
 	End   *Schedule `json:"end,omitempty"`


### PR DESCRIPTION
Add a new mode option for disabling the lighting automation in a less disruptive way than turning it off completely.

I'll be using this new mode for a `manual` mode of operation via the tenant touch panels for when someone wants to manually adjust the lighting independently of brightness levels and pir or button actions.