### PR TITLE
Add explicit child devices in proxy driver

### DIFF
--- a/pkg/driver/proxy/config/root.go
+++ b/pkg/driver/proxy/config/root.go
@@ -48,11 +48,6 @@ type TLS struct {
 	InsecureSkipVerify   bool `json:"insecureSkipVerify,omitempty"`   // don't verify proxy server certificates
 }
 
-// type Trait struct {
-// 	Name  string     `json:"name,omitempty"`
-// 	Trait trait.Name `json:"trait,omitempty"`
-// }
-
 type Child struct {
 	Name   string       `json:"name,omitempty"`
 	Traits []trait.Name `json:"traits,omitempty"`

--- a/pkg/driver/proxy/config/root.go
+++ b/pkg/driver/proxy/config/root.go
@@ -26,6 +26,10 @@ type Node struct {
 	// If absent then the remote node should support empty/default names for Parent requests.
 	Name string `json:"name,omitempty"`
 
+	// Children is a list of children that should be announced by the proxy server.
+	// If empty then all devices on the proxy host will be available (provided the user has authorization)
+	Children []Child `json:"children,omitempty"`
+
 	// SkipChild skips associating the node and node children with this nodes parent trait.
 	// When true this doesn't stop clients of this node from communicating with the child, but it does stop discovery of
 	// this name from working.
@@ -44,9 +48,14 @@ type TLS struct {
 	InsecureSkipVerify   bool `json:"insecureSkipVerify,omitempty"`   // don't verify proxy server certificates
 }
 
-type Trait struct {
-	Name  string     `json:"name,omitempty"`
-	Trait trait.Name `json:"trait,omitempty"`
+// type Trait struct {
+// 	Name  string     `json:"name,omitempty"`
+// 	Trait trait.Name `json:"trait,omitempty"`
+// }
+
+type Child struct {
+	Name   string       `json:"name,omitempty"`
+	Traits []trait.Name `json:"traits,omitempty"`
 }
 
 type OAuth2 struct {

--- a/pkg/driver/proxy/driver.go
+++ b/pkg/driver/proxy/driver.go
@@ -175,12 +175,15 @@ func (p *proxy) announceExplicitChildren(children []config.Child) {
 				p.logger.Warn("tried to proxy unknown trait", zap.String("trait", tn.String()))
 				continue
 			}
+			withClients := []node.TraitOption{node.WithClients(client)}
+
 			infoClient := alltraits.InfoClient(p.conn, tn)
 			if infoClient == nil {
 				p.logger.Warn(fmt.Sprintf("remote child implements unknown info trait %s", tn))
-				continue
+			} else {
+				withClients = append(withClients, node.WithClients(infoClient))
 			}
-			p.announcer.Announce(c.Name, node.HasTrait(tn, node.WithClients(client), node.WithClients(infoClient)))
+			p.announcer.Announce(c.Name, node.HasTrait(tn, withClients...))
 		}
 	}
 }


### PR DESCRIPTION
If the list of children is not present of empty in config then we announce all children of the parent node.

We currently list the traits explicitly too. This could be avoided by calling the meta data trait on the child device.