### PR TITLE
Fix `airTemperature` api to allow mode control

### DIFF
--- a/ui/conductor/src/api/sc/traits/air-temperature.js
+++ b/ui/conductor/src/api/sc/traits/air-temperature.js
@@ -84,14 +84,15 @@ function stateFromObject(obj) {
   if (!obj) return undefined;
 
   const state = new AirTemperature();
-  setProperties(state, obj, 'ambient_humidity');
+  setProperties(state, obj, 'ambientHumidity', 'mode');
   state.setTemperatureSetPoint(temperatureFromObject(obj.temperatureSetPoint));
+  state.setMode(obj.mode);
   return state;
 }
 
 /**
  * @param {Temperature.AsObject} obj
- * @return {Temperature}
+ * @return {Temperature|undefined}
  */
 function temperatureFromObject(obj) {
   if (!obj) return undefined;


### PR DESCRIPTION
Similar to the `withAirTemperature` trait's `doUpdateAirTemperature` function, we send a `request (req)` as follows:

> This function should receive an object - see below:
```js
/**
 * @param {number|Partial<AirTemperature.AsObject>|Partial<UpdateAirTemperatureRequest.AsObject>} req
 */
function doUpdateAirTemperature(req) {
  if (typeof req === 'number') {
    req = {
      state: {temperatureSetPoint: {valueCelsius: /** @type {number} */ req}},
      updateMask: {pathsList: ['temperature_set_point']}
    };
  }
  if (!req.hasOwnProperty('state')) {
    req = {state: /** @type {AirTemperature.AsObject} */ req};
  }
  req.name = props.name;
  updateAirTemperature(req, updateTracker);
}
```

> The object (req) forwarded:
```js
  const newMode = {
    state: {mode: modeValue},
    updateMask: {pathsList: ['mode']}
  };

  emit('updateAirTemperature', newMode);
  ```