### PR TITLE
opsui/stores: Refactor `useAccountStore`

### DIFF
--- a/ui/conductor/src/App.vue
+++ b/ui/conductor/src/App.vue
@@ -3,7 +3,7 @@
     <app-bar/>
     <navigation-drawer/>
 
-    <router-view v-if="isLoggedIn"/>
+    <router-view/>
     <error-view/>
   </v-app>
 </template>
@@ -13,21 +13,14 @@ import AppBar from '@/components/default/AppBar.vue';
 import NavigationDrawer from '@/components/default/NavigationDrawer.vue';
 import ErrorView from '@/components/ui-error/ErrorView.vue';
 
-import useAuthSetup from '@/composables/useAuthSetup';
-import {useAccountStore} from '@/stores/account.js';
-import {useControllerStore} from '@/stores/controller';
 import {onMounted} from 'vue';
+import {useControllerStore} from '@/stores/controller';
 
-
-const {isLoggedIn} = useAuthSetup();
 const controller = useControllerStore();
-const store = useAccountStore();
-
-store.loadLocalStorage();
-
 onMounted(() => {
   controller.sync();
 });
+
 </script>
 
 <style lang="scss" scoped>

--- a/ui/conductor/src/components/AccountBtn.vue
+++ b/ui/conductor/src/components/AccountBtn.vue
@@ -5,13 +5,10 @@
         elevation="0"
         v-if="!loggedIn"
         :class="btnClass"
-        @click.stop="toggleLoginDialog">
+        to="/login">
       <v-icon left>mdi-account-circle-outline</v-icon>
       Sign in
     </v-btn>
-    <v-dialog width="500" v-if="!loggedIn" persistent v-model="loginDialog">
-      <SignIn/>
-    </v-dialog>
     <v-menu v-else bottom left offset-y max-width="100%" tile>
       <template #activator="{ on, attrs }">
         <v-btn icon elevation="0" :class="btnClass" v-bind="attrs" v-on="on">
@@ -36,7 +33,7 @@
           {{ accountStore.email }}
         </v-card-subtitle>
         <v-card-actions>
-          <v-btn elevation="0" @click="logout" block>Sign out</v-btn>
+          <v-btn elevation="0" @click="accountStore.logout" block>Sign out</v-btn>
         </v-card-actions>
       </v-card>
     </v-menu>
@@ -44,8 +41,8 @@
 </template>
 
 <script setup>
-import {useAccountStore} from '@/stores/account.js';
 import {computed} from 'vue';
+import {useAccountStore} from '@/stores/account.js';
 
 defineProps({
   btnClass: {
@@ -55,22 +52,7 @@ defineProps({
 });
 
 const accountStore = useAccountStore();
-const loggedIn = computed(() => accountStore.loggedIn);
-const loginDialog = computed(() => accountStore.loginDialog);
-
-/**
- *
- */
-function logout() {
-  accountStore.logout().catch((err) => console.error('error during logout', err));
-}
-
-/**
- *
- */
-function toggleLoginDialog() {
-  accountStore.toggleLoginDialog();
-}
+const loggedIn = computed(() => accountStore.isLoggedIn);
 </script>
 
 

--- a/ui/conductor/src/components/default/AppBar.vue
+++ b/ui/conductor/src/components/default/AppBar.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app-bar app height="60" :clipped-left="hasNav" :clipped-right="hasSidebar" elevation="0" class="pr-7">
-    <app-menu v-if="isLoggedIn"/>
+    <app-menu v-if="accountStore.isLoggedIn"/>
     <brand-logo :theme="config.theme" outline="white" style="height: 35px; margin-left: 16px"/>
     <span class="heading">{{ appBarHeadingWithBrand }}</span>
 
@@ -10,8 +10,10 @@
 
     <router-view name="actions"/>
     <smart-core-status-card/>
-    <v-divider vertical class="mx-1" inset/>
-    <account-btn btn-class="mr-0"/>
+    <span v-if="!accountStore.isAuthenticationDisabled" class="d-flex flex-row">
+      <v-divider vertical class="mx-1 my-1" inset/>
+      <account-btn btn-class="mr-0"/>
+    </span>
   </v-app-bar>
 </template>
 <script setup>
@@ -24,23 +26,20 @@ import {computed} from 'vue';
 import {storeToRefs} from 'pinia';
 
 import {usePage} from '@/components/page';
-import useAuthSetup from '@/composables/useAuthSetup';
 import {useAccountStore} from '@/stores/account';
 import {useAppConfigStore} from '@/stores/app-config';
 
 const appConfigStore = useAppConfigStore();
 const {config} = storeToRefs(appConfigStore);
-const {isLoggedIn} = useAuthSetup();
+const accountStore = useAccountStore();
 
 const {pageTitle, hasSections, hasNav, hasSidebar} = usePage();
-
-const store = useAccountStore();
-store.loadLocalStorage();
 
 const appBarHeadingWithBrand = computed(() => {
   const brandName = config.value.theme?.appBranding.brandName ?? 'Smart Core';
 
-  return brandName + (isLoggedIn.value ? ' | ' + pageTitle.value : '');
+
+  return brandName + (accountStore.isLoggedIn ? ' | ' + pageTitle.value : '');
 });
 </script>
 
@@ -50,7 +49,7 @@ const appBarHeadingWithBrand = computed(() => {
 }
 
 .v-app-bar :deep(.v-toolbar__content) {
-  padding-right: 0px;
+  padding-right: 0;
 }
 
 .heading {

--- a/ui/conductor/src/stores/account.js
+++ b/ui/conductor/src/stores/account.js
@@ -1,126 +1,190 @@
-import {events, keycloak} from '@/api/keycloak.js';
-import localLogin from '@/api/localLogin.js';
-import jwtDecode from 'jwt-decode';
+import useKeyCloak from '@/composables/authentication/useKeyCloak';
+import useLocal from '@/composables/authentication/useLocal';
+import {useAppConfigStore} from '@/stores/app-config';
+import {loadFromBrowserStorage} from '@/util/browserStorage.js';
 import {defineStore} from 'pinia';
 import {computed, ref, watch} from 'vue';
-import {useAppConfigStore} from '@/stores/app-config';
 
 export const useAccountStore = defineStore('accountStore', () => {
   const appConfig = useAppConfigStore();
+  const keyCloak = useKeyCloak();
+  const localAuth = useLocal();
 
-  const kcp = keycloak();
-  const kcEvents = events;
-
-  const loggedIn = ref(false);
-  const token = ref('');
-  const claims = ref({});
-  const loginForm = ref(false);
-  const loginDialog = ref(false);
+  // Set up the storage for the login: authProvider, claims, login status and token
+  const authenticationDetails = ref({
+    authProvider: '',
+    claims: {},
+    loggedIn: false,
+    token: ''
+  });
+  const loginFormVisible = ref(false);
+  const redirect = ref(...loadFromBrowserStorage('session', 'redirect', ''));
   const snackbar = ref(false);
 
-  const updateRefs = () => {
-    kcp.then((kc) => {
-      loggedIn.value = kc.authenticated;
-      token.value = kc.token;
-      claims.value = kc.idTokenParsed;
-      localStorage.setItem('keyclock', true);
-      saveLocalStorage();
-    });
+  /**
+   * Reset the store values to defaults
+   *
+   * @return {void}
+   */
+  const resetStoreToDefaults = () => {
+    authenticationDetails.value = {
+      authProvider: '',
+      claims: {},
+      loggedIn: false,
+      token: ''
+    };
   };
+  //
+  // ----------------------------------- //
+  //
+  /**
+   * Check if authentication is disabled
+   *
+   * @type {import('vue').ComputedRef<boolean>}
+   */
+  const isAuthenticationDisabled = computed(() => {
+    return appConfig.config.disableAuthentication;
+  });
 
-  const toggleSnackbar = () => {
-    snackbar.value = !snackbar.value;
-  };
-
-  const toggleLoginForm = () => {
-    loginForm.value = !loginForm.value;
-  };
-
-  const toggleLoginDialog = () => {
-    loginDialog.value = !loginDialog.value;
-    loginForm.value = false;
-  };
-
-  const loginLocal = async (username, password) => {
-    try {
-      const res = await localLogin(username, password);
-      if (res.status === 200) {
-        const payload = await res.json();
-        token.value = payload.access_token;
-        loggedIn.value = true;
-        claims.value = {
-          email: username,
-          ...jwtDecode(payload.access_token)
-        };
-        toggleLoginDialog();
-        saveLocalStorage();
-        localStorage.setItem('keyclock', false);
-      } else {
-        snackbar.value = true;
-      }
-    } catch (err) {
-      snackbar.value = true;
+  /**
+   * Collect the available authentication providers
+   *
+   * @type {import('vue').ComputedRef<string[]>}
+   */
+  const availableAuthProviders = computed(() => {
+    if (appConfig.config.keycloak) {
+      return ['keyCloakAuth', 'localAuth'];
+    } else {
+      return ['localAuth'];
     }
+  });
+
+  /**
+   * Retrieve the authentication provider used for login
+   *
+   * @type {import('vue').ComputedRef<string|null>}
+   */
+  const activeAuthProvider = computed(() => {
+    return authenticationDetails.value.authProvider || null;
+  });
+
+  /**
+   * Set the authentication provider depending on the login form visibility
+   * If the login form is visible, use the local authentication provider, otherwise use KeyCloak
+   */
+  const watchSources = [availableAuthProviders, isAuthenticationDisabled];
+
+  watch(watchSources, ([availableProviders, authDisabled]) => {
+    if (!authDisabled) {
+      loginFormVisible.value = !availableProviders.includes('keyCloakAuth');
+    }
+  }, {immediate: true, deep: true});
+
+  /**
+   * Returns the login status depending on the authentication provider
+   *
+   * @type {import('vue').ComputedRef<boolean>}
+   */
+  const isLoggedIn = computed(() => {
+    const detailsAvailable = !!(
+      authenticationDetails.value.authProvider &&
+        authenticationDetails.value.claims &&
+        authenticationDetails.value.loggedIn &&
+        authenticationDetails.value.token
+    );
+
+    return detailsAvailable || isAuthenticationDisabled.value;
+  });
+
+  /**
+   * Returns the full name of the logged in user
+   *
+   * @type {import('vue').ComputedRef<string>}
+   */
+  const fullName = computed(() => authenticationDetails.value.claims?.name || '');
+
+  /**
+   * Returns the email of the logged in user
+   *
+   * @type {import('vue').ComputedRef<string>}
+   */
+  const email = computed(() => authenticationDetails.value.claims?.email || '');
+
+  /**
+   * Returns the roles of the logged in user
+   *
+   * @type {import('vue').ComputedRef<string[]>}
+   */
+  const roles = computed(() => authenticationDetails.value.claims?.roles || []);
+
+  /**
+   * Returns the redirect path if it exists
+   *
+   * @type {import('vue').ComputedRef<string|null>}
+   */
+  const activeRedirect = computed(() => redirect.value || null);
+  //
+  // ----------------------------------- //
+  //
+  // Dynamic controls - depending on the active authentication provider
+  //
+  /** @typedef {{ username: string, password: string }} LocalAuthLoginValues */
+
+  /**
+   * Login to the active authentication provider
+   *
+   * @param {LocalAuthLoginValues|string[]} values
+   */
+  const loginWithLocalAuth = async (values) => {
+    await localAuth.login(values.username, values.password);
   };
 
-  const saveLocalStorage = () => {
-    localStorage.setItem('loggedIn', loggedIn.value);
-    localStorage.setItem('token', token.value);
-    localStorage.setItem('loggedIn', loggedIn.value);
-    localStorage.setItem('claims', JSON.stringify(claims.value));
+  const loginWithKeyCloak = async (scopes) => {
+    await keyCloak.login(scopes);
   };
 
-  const loadLocalStorage = () => {
-    token.value = localStorage.getItem('token');
-    loggedIn.value = JSON.parse(localStorage.getItem('loggedIn'));
-    claims.value = JSON.parse(localStorage.getItem('claims'));
-  };
-
+  /**
+   * Logout of the active authentication provider, then reset the store to defaults
+   *
+   * @return {Promise<void>}
+   */
   const logout = async () => {
-    localStorage.getItem('keyclock') === 'true' &&
-    kcp.then((kc) => kc.logout());
-    loggedIn.value = false;
-    token.value = '';
-    claims.value = {};
-    saveLocalStorage();
+    if (activeAuthProvider.value === 'keyCloakAuth') {
+      await keyCloak.logout();
+    } else {
+      localAuth.logout();
+    }
+
+    resetStoreToDefaults();
   };
 
-  kcEvents.addEventListener('authSuccess', updateRefs);
-
-  // Keep login modal permanently on screen if user is not logged in and we require authentication
-  watch(
-      [loggedIn, token, () => appConfig.config?.disableAuthentication],
-      () => {
-        if (!appConfig.config?.disableAuthentication) {
-          if (!loggedIn.value || !token.value) loginDialog.value = true;
-        } else {
-          loginDialog.value = false;
-        }
-      },
-      {immediate: true, deep: true}
-  );
+  const refreshToken = async () => {
+    if (activeAuthProvider.value === 'keyCloakAuth') {
+      await keyCloak.refreshToken();
+    }
+    // else {
+    //   localAuth.refreshToken();
+    // }
+  };
 
   return {
-    loggedIn,
-    token,
-    claims,
-    loginForm,
-    loginDialog,
-    toggleSnackbar,
-    toggleLoginForm,
-    toggleLoginDialog,
-    loginLocal,
-    loadLocalStorage,
+    authenticationDetails,
+    loginFormVisible,
     snackbar,
+    resetStoreToDefaults,
 
-    isLoggedIn: computed(() => loggedIn.value),
-    fullName: computed(() => claims.value?.name || ''),
-    email: computed(() => claims.value?.email || ''),
-    roles: computed(() => claims.value?.roles || []),
+    isAuthenticationDisabled,
+    availableAuthProviders,
+    activeAuthProvider,
+    activeRedirect,
+    isLoggedIn,
+    fullName,
+    email,
+    roles,
 
-    login: (scopes) => {
-      return kcp.then((kc) => kc.login({scope: scopes.join(' ')}));
-    },
-    logout
+    loginWithLocalAuth,
+    loginWithKeyCloak,
+    logout,
+    refreshToken
   };
 });

--- a/ui/conductor/src/util/browserStorage.js
+++ b/ui/conductor/src/util/browserStorage.js
@@ -1,0 +1,90 @@
+/**
+ * This utility is used to save values to browser storage.
+ * It takes in sources, keys, and values. Each can be a single value or an array.
+ * Loops through the keys and values and saves them to the specified browser storage(s).
+ * If the value is not a string, it will be stringified.
+ *
+ * @example
+ * Suppose you want to store user data and a theme preference
+ * const user = { name: 'Alice', age: 30 };
+ * const theme = 'dark';
+ * saveToBrowserStorage('local', ['user', 'theme'], [user, theme]);
+ * This will save the user object and theme string to localStorage
+ *
+ * @param {string | string[]} sources - 'local', 'session', or array of both
+ * @param {string | string[]} keys - Key or array of keys for storage
+ * @param {*} values - Value or array of values corresponding to the keys
+ */
+export const saveToBrowserStorage = (sources, keys, values) => {
+  const normalizedSources = Array.isArray(sources) ? sources : [sources];
+  const normalizedKeys = Array.isArray(keys) ? keys : [keys];
+  const normalizedValues = Array.isArray(values) ? values : [values];
+
+  normalizedSources.forEach(source => {
+    const storage = source === 'local' ? window.localStorage : window.sessionStorage;
+
+    normalizedKeys.forEach((key, index) => {
+      if (index < normalizedValues.length) {
+        const value = normalizedValues[index];
+        const valueToStore = typeof value === 'string' ? value : JSON.stringify(value);
+        storage.setItem(key, valueToStore);
+      }
+    });
+  });
+};
+
+
+/**
+ * This utility is used to retrieve values from browser storage.
+ * It takes in sources, keys, and default values. Each can be a single value or an array.
+ * Retrieves each item by key from the specified browser storage(s) and returns them in an array.
+ *
+ * @example
+ * Suppose you have stored user and theme in localStorage and want to retrieve them
+ * with 'defaultUser' and 'light' as their respective default values
+ * const [user, theme] = loadFromBrowserStorage(
+ *   'local',
+ *   ['user', 'theme'],
+ *   [{ name: 'defaultUser' }, 'light']
+ * );
+ * This will load the 'user' and 'theme' from localStorage, or use the provided default values
+ *
+ * @param {string | string[]} sources - 'local', 'session', or array of both
+ * @param {string | string[]} keys - Key or array of keys to retrieve from storage
+ * @param {MaybeRefOrGetter | MaybeRefOrGetter[]} defaults - Default value or array of default values
+ * @return {any[]} - Array of retrieved values
+ */
+export const loadFromBrowserStorage = (sources, keys, defaults) => {
+  const normalizedSources = Array.isArray(sources) ? sources : [sources];
+  const normalizedKeys = Array.isArray(keys) ? keys : [keys];
+  const normalizedDefaults = Array.isArray(defaults) ? defaults : [defaults];
+
+  return normalizedSources.map(source => {
+    const storage = source === 'local' ? window.localStorage : window.sessionStorage;
+
+    return normalizedKeys.map((key, index) => {
+      const storedValue = storage.getItem(key);
+
+      // If stored value is null, use default value
+      if (storedValue === null) {
+        if (index < normalizedDefaults.length) {
+          if (typeof normalizedDefaults[index] === 'function') {
+            return normalizedDefaults[index]();
+          } else {
+            return normalizedDefaults[index];
+          }
+        }
+        return null; // In case there's no default value for this index
+      }
+
+      // Parse the value if it's JSON, otherwise return it as is
+      try {
+        return JSON.parse(storedValue);
+      } catch (e) {
+        return storedValue;
+      }
+    });
+  }).flat(); // Flatten the array because each source maps to an array of values, resulting in an array of arrays.
+};
+
+


### PR DESCRIPTION
Refactored and updated the `account` pinia store - separating authentication logic and provider logic into their own composable/store for better readability and future-proofing _(maintainability)_.

> Note: this PR's functionality heavily relies on: https://github.com/vanti-dev/sc-bos/pull/139 https://github.com/vanti-dev/sc-bos/pull/141 https://github.com/vanti-dev/sc-bos/pull/142

Jira: SC-79