### PR TITLE
opsui/routes: Update `routing` logic

### DIFF
--- a/ui/conductor/src/routes/auth/route.js
+++ b/ui/conductor/src/routes/auth/route.js
@@ -12,9 +12,21 @@ export default [
       nav: () => import('./AuthNav.vue')
     },
     children: [
-      {path: 'users', component: () => import('./users/Users.vue')}
+      {
+        path: 'users',
+        component: () => import('./users/Users.vue'),
+        meta: {
+          authentication: {
+            rolesRequired: ['superAdmin', 'admin', 'viewer']
+          },
+          title: 'Users'
+        }
+      }
     ],
     meta: {
+      authentication: {
+        rolesRequired: ['superAdmin', 'admin', 'operator', 'viewer']
+      },
       title: 'Auth'
     },
     beforeEnter: async (to, from, next) => {

--- a/ui/conductor/src/routes/auth/third-party/route.js
+++ b/ui/conductor/src/routes/auth/third-party/route.js
@@ -18,10 +18,18 @@ export default [
         props: {
           default: false,
           sidebar: true
+        },
+        meta: {
+          authentication: {
+            rolesRequired: ['superAdmin', 'admin', 'operator', 'viewer']
+          }
         }
       }
     ],
     meta: {
+      authentication: {
+        rolesRequired: ['superAdmin', 'admin', 'operator', 'viewer']
+      },
       title: 'Auth'
     }
   }

--- a/ui/conductor/src/routes/automations/route.js
+++ b/ui/conductor/src/routes/automations/route.js
@@ -17,10 +17,18 @@ export default {
       },
       props: {
         default: true
+      },
+      meta: {
+        authentication: {
+          rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+        }
       }
     }
   ],
   meta: {
+    authentication: {
+      rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+    },
     title: 'Automations'
   }
 };

--- a/ui/conductor/src/routes/devices/route.js
+++ b/ui/conductor/src/routes/devices/route.js
@@ -18,10 +18,18 @@ export default {
       props: {
         default: true,
         sidebar: false
+      },
+      meta: {
+        authentication: {
+          rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+        }
       }
     }
   ],
   meta: {
-    title: 'Devices'
+    title: 'Devices',
+    authentication: {
+      rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+    }
   }
 };

--- a/ui/conductor/src/routes/ops/notifications/route.js
+++ b/ui/conductor/src/routes/ops/notifications/route.js
@@ -8,6 +8,11 @@ export default [
     props: {
       default: true,
       sidebar: false
+    },
+    meta: {
+      authentication: {
+        rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+      }
     }
   }
 ];

--- a/ui/conductor/src/routes/ops/overview/route.js
+++ b/ui/conductor/src/routes/ops/overview/route.js
@@ -1,20 +1,89 @@
+import {useAppConfigStore} from '@/stores/app-config';
+import {findActiveItem} from '@/util/router.js';
+
 export default [
   {
     path: 'overview',
     component: () => import('@/routes/ops/OpsHome.vue'),
     redirect: 'overview/building',
+    meta: {
+      authentication: {
+        rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+      }
+    },
     children: [
       {
         name: 'building-overview',
         path: 'building', // Directly map to the building path
-        component: () => import('@/routes/ops/overview/pages/BuildingOverview.vue')
+        component: () => import('@/routes/ops/overview/pages/BuildingOverview.vue'),
+        meta: {
+          authentication: {
+            rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+          }
+        }
       },
       {
         name: 'dynamic-areas-overview',
         path: 'building/:pathMatch(.+)*', // Captures all segments after /building/
         component: () => import('@/routes/ops/overview/pages/DynamicAreasOverview.vue'),
-        props: route => ({pathSegments: route.params.pathMatch.split('/')}) // Splits segments into an array
+        // Splits segments into an array and passes it as a prop so the component can use it to find the active item
+        props: route => ({pathSegments: modifiedPath(route.params.pathMatch).split('/')}),
+        meta: {
+          authentication: {
+            rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+          }
+        }
       }
-    ]
+    ],
+    beforeEnter: async (to, from, next) => {
+      const appConfig = useAppConfigStore();
+      await appConfig.loadConfig();
+
+      // Get the building children from the app config
+      /**
+       * @typedef {Object} EnvironmentTrait
+       * @property {boolean|string} indoor - Flag or specific value for indoor environment.
+       * @property {boolean|string} outdoor - Flag or specific value for outdoor environment.
+       */
+
+      /**
+       * @typedef {Object} BuildingChild
+       * @property {boolean} disabled - Indicates if the item is disabled.
+       * @property {string} icon - Icon identifier, e.g., 'mdi-select-all'.
+       * @property {string} shortTitle - A short title for the item - for the mini sized navigation.
+       * @property {string} title - The full title of the item.
+       * @property {Object} traits - Object containing various trait flags.
+       * @property {boolean} traits.showAirQuality - Flag to show air quality.
+       * @property {boolean} traits.showEmergencyLighting - Flag to show emergency lighting.
+       * @property {boolean} traits.showEnergyConsumption - Flag to show energy consumption.
+       * @property {boolean|EnvironmentTrait} traits.showEnvironment - Flag to show environment,
+       *                            or an object detailing indoor and outdoor environment traits.
+       * @property {boolean} traits.showNotifications - Flag to show notifications.
+       * @property {boolean|string} traits.showOccupancy -
+       Flag to show occupancy, can be a string for specific occupancy.
+       * @property {boolean} traits.showPower - Flag to show power.
+       * @property {BuildingChild[]} [children] - Optional array of children, each following the same structure.
+       */
+      const buildingChildren = appConfig.config?.building?.children || [];
+
+      // Split the modified path into segments and remove empty segments then return an array of the segments
+      const currentPathSegments = modifiedPath(to.path).split('/').filter(segment => segment);
+
+      // Find active item based on the current path segments
+      const activeItem = findActiveItem(buildingChildren, currentPathSegments);
+
+      // If the path is '/ops/overview/building' and there is no active item, redirect to the building overview
+      const overviewPath = to.path === basePath;
+
+      if (!overviewPath && !activeItem) {
+        next(basePath);
+      } else {
+        next();
+      }
+    }
   }
 ];
+
+// Remove the specific beginning '/ops/overview/building' from the path, if it exists
+const basePath = '/ops/overview/building';
+const modifiedPath = (path) => path.startsWith(basePath) ? path.slice(basePath.length) : path;

--- a/ui/conductor/src/routes/ops/route.js
+++ b/ui/conductor/src/routes/ops/route.js
@@ -14,12 +14,39 @@ export default {
   },
   children: [
     ...route(overview),
-    {path: 'emergency-lighting', component: () => import('./emergency-lighting/EmergencyLighting.vue')},
-    {path: 'security', component: () => import('./security/SecurityHome.vue')},
-    {path: 'air-quality', component: () => import('./air-quality/AirQuality.vue')},
+    {
+      path: 'emergency-lighting',
+      component: () => import('./emergency-lighting/EmergencyLighting.vue'),
+      meta: {
+        authentication: {
+          rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+        }
+      }
+    },
+    {
+      path: 'security',
+      component: () => import('./security/SecurityHome.vue'),
+      meta: {
+        authentication: {
+          rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+        }
+      }
+    },
+    {
+      path: 'air-quality',
+      component: () => import('./air-quality/AirQuality.vue'),
+      meta: {
+        authentication: {
+          rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+        }
+      }
+    },
     ...route(notifications)
   ],
   meta: {
+    authentication: {
+      rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+    },
     title: 'Operations'
   },
   beforeEnter: async (to, from, next) => {

--- a/ui/conductor/src/routes/site/route.js
+++ b/ui/conductor/src/routes/site/route.js
@@ -9,9 +9,22 @@ export default {
     nav: () => import('./SiteNav.vue')
   },
   children: [
-    {name: 'zone', path: 'zone/:zone*', component: () => import('./zone/ZonePage.vue'), props: true}
+    {
+      name: 'zone',
+      path: 'zone/:zone*',
+      component: () => import('./zone/ZonePage.vue'),
+      props: true,
+      meta: {
+        authentication: {
+          rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+        }
+      }
+    }
   ],
   meta: {
+    authentication: {
+      rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+    },
     title: 'Site Config'
   }
 };

--- a/ui/conductor/src/routes/system/route.js
+++ b/ui/conductor/src/routes/system/route.js
@@ -14,6 +14,11 @@ export default {
       components: {
         default: () => import('./components/pages/DriversList.vue'),
         sidebar: () => import('./components/ServicesSideBar.vue')
+      },
+      meta: {
+        authentication: {
+          rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+        }
       }
     },
     {
@@ -21,16 +26,29 @@ export default {
       components: {
         default: () => import('./components/pages/FeaturesList.vue'),
         sidebar: () => import('./components/ServicesSideBar.vue')
+      },
+      meta: {
+        authentication: {
+          rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+        }
       }
     },
     {
       path: 'components',
       components: {
         default: () => import('./components/pages/ComponentsList.vue')
+      },
+      meta: {
+        authentication: {
+          rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+        }
       }
     }
   ],
   meta: {
+    authentication: {
+      rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+    },
     title: 'System'
   },
   beforeEnter: async (to, from, next) => {

--- a/ui/conductor/src/util/router.js
+++ b/ui/conductor/src/util/router.js
@@ -20,3 +20,67 @@ export function route(route) {
   }
   return [route];
 }
+
+/**
+ * Finds active items in the building structure based on a list of titles.
+ * It iterates through the provided titles, searching for corresponding items in the building structure.
+ * If an item matching a title is found, it's added to the result. The search continues into the children of
+ * the found item for the next title. If any title in the sequence is not found, the search stops and returns
+ * the items found up to that point.
+ *
+ * If all titles are found, the last item in the result is the active item and is returned.
+ * If any title is not found, the active item is null and is returned.
+ *
+ * Example:
+ * const buildingChildren = [
+ *    {
+ *      title: 'Area 1',
+ *      children: [
+ *        {
+ *          title: 'Area 2',
+ *          children: [
+ *            {
+ *              title: 'Area 3'
+ *            }
+ *          ]
+ *        }
+ *      ]
+ *    }
+ *  ];
+ *
+ * // Returns the item with title 'Area 3'
+ * findActiveItem(buildingChildren, ['Area 1', 'Area 2', 'Area 3']);
+ *
+ * // Returns the item with title 'Area 2'
+ * findActiveItem(buildingChildren, ['Area 1', 'Area 2']);
+ *
+ * // Returns null
+ * findActiveItem(buildingChildren, ['Area 1', 'Area 2', 'Area 4']);
+ *
+ *
+ * @param {BuildingChild[]} children - Array of building children, each following the structure of BuildingChild.
+ * @param {string[]} childTitles - Array of titles to find in sequence.
+ * @return {BuildingChild[]|null} - Array of found items in the order of the titles provided. If a title is not found,
+ *                             the array includes items up to the last found title.
+ */
+export const findActiveItem = (children, childTitles) => {
+  let currentItems = children;
+  const result = [];
+
+  // Iterate through the titles, searching for the corresponding item in the current items
+  for (const title of childTitles) {
+    const formatTitle = (title) => encodeURIComponent(title);
+
+    const foundItem = currentItems.find(item =>
+      formatTitle(item.title) === formatTitle(title)
+    );
+    if (!foundItem) break;
+    result.push(foundItem);
+    currentItems = foundItem.children || [];
+  }
+
+  // If the result array is the same length as the childTitles array, then all titles were found
+  // and the last item in the result array is the active item,
+  // otherwise the active item is null
+  return result.length === childTitles.length ? result[result.length - 1] : null;
+};


### PR DESCRIPTION
This PR contains changes regarding routing logic.
Mainly focusing on the `building overview` page and navigating on it's sub-pages. See the additional changes below:

- added reusable logic to `util/router` with the logic's JSDoc
- moved value storing logic to component _(activeOverview)_
- added `meta.authentication.rolesRequired: []/boolean` tag _(boolean would require strict or no-auth)_
- updated `ops/overview/route.js` navigationGuard so it only allows child paths which are exists _(see note)_, otherwise it redirects to building

> Notes: Root-paths also being checked: /ops/overview/building/Floor%2003/Left%20Wing - in this case, Left Wing only accessible if both - Floor 03 and Left Wing - exists.
> https://github.com/vanti-dev/sc-bos/pull/135 depends on this PR

Jira: SC-80