### PR TITLE
opsui/routes: Introducing a designated `Login` page

### DIFF
--- a/ui/conductor/src/routes/login/LocalLogin.vue
+++ b/ui/conductor/src/routes/login/LocalLogin.vue
@@ -1,0 +1,93 @@
+<template>
+  <div>
+    <v-form @submit.prevent="login">
+      <v-card-text>
+        <p class="text-center">Sign in locally.</p>
+      </v-card-text>
+      <v-text-field
+          autofocus
+          label="Username"
+          placeholder="Username"
+          :rules="[rules.required]"
+          outlined
+          v-model="username"
+          type="text"
+          required/>
+      <v-text-field
+          label="Password"
+          placeholder="Password"
+          :rules="[rules.required]"
+          outlined
+          v-model="password"
+          type="password"
+          required/>
+      <v-card-actions class="mx-2">
+        <v-btn
+            type="submit"
+            color="primary"
+            :disabled="disableSignIn"
+            block
+            large
+            class="text-body-1 font-weight-bold mb-4">
+          Sign In
+        </v-btn>
+      </v-card-actions>
+      <v-card-text v-if="displayLoginSwitch" class="d-flex justify-center">
+        <a
+            @click="accountStore.loginFormVisible = !accountStore.loginFormVisible"
+            class="text-center">
+          Use a different sign in method
+        </a>
+      </v-card-text>
+    </v-form>
+
+    <v-snackbar v-model="snackbar">
+      Failed to sign in, please try again.
+
+      <template #action="{ attrs }">
+        <v-btn color="pink" text v-bind="attrs" @click="snackbar = false">
+          Close
+        </v-btn>
+      </template>
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import {computed, ref} from 'vue';
+import {useAccountStore} from '@/stores/account.js';
+import {storeToRefs} from 'pinia';
+
+const accountStore = useAccountStore();
+const password = ref('');
+const username = ref('');
+const {snackbar} = storeToRefs(accountStore);
+const rules = {
+  required: (value) => !!value || 'Required.'
+};
+const login = () => {
+  // check if username and password are entered
+  if (username.value && password.value) {
+    accountStore
+        .loginWithLocalAuth({username: username.value, password: password.value})
+        .catch((err) => console.error('unable to log in', err));
+  } else {
+    console.error('username and password are required');
+  }
+};
+
+const disableSignIn = computed(() => {
+  const hasNone = !username.value && !password.value;
+  const hasOne = !username.value && password.value || username.value && !password.value;
+  return !!(hasNone || hasOne);
+});
+
+// Show/Hide the login switch depending on whether KeyCloak is enabled or not
+const displayLoginSwitch = computed(() => accountStore.availableAuthProviders.includes('keyCloakAuth'));
+</script>
+
+<style lang="scss" scoped>
+.v-input {
+  background-color: transparent;
+}
+</style>

--- a/ui/conductor/src/routes/login/LoginChoice.vue
+++ b/ui/conductor/src/routes/login/LoginChoice.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <v-card-text :class="[{'mb-8': appConfig.config.keycloak }, 'text-center mx-auto']" style="max-width: 320px;">
+      {{ keycloakMessage.top }}
+    </v-card-text>
+    <v-card-actions class="d-flex flex-column align-center justify-center">
+      <v-btn
+          v-if="appConfig.config.keycloak"
+          @click="store.loginWithKeyCloak(['profile', 'roles'])"
+          color="primary"
+          block
+          large
+          class="text-body-1 font-weight-bold">
+        Sign in
+      </v-btn>
+    </v-card-actions>
+    <v-card-text class="text-body-2 text-center mt-10 mx-auto" style="max-width: 350px;">
+      {{ keycloakMessage.bottom }}
+    </v-card-text>
+    <v-card-actions class="d-flex flex-column align-center justify-center mt-n2">
+      <v-btn
+          block
+          class="text-body-2 ma-0"
+          text
+          @click="store.loginFormVisible = !store.loginFormVisible">
+        Sign in with local Account
+      </v-btn>
+    </v-card-actions>
+  </div>
+</template>
+
+<script setup>
+import {computed} from 'vue';
+import {useAccountStore} from '@/stores/account.js';
+import {useAppConfigStore} from '@/stores/app-config';
+
+const appConfig = useAppConfigStore();
+const store = useAccountStore();
+
+// Tweak the message depending on whether KeyCloak is enabled or not
+const keycloakMessage = computed(() => {
+  if (appConfig.config.keycloak) {
+    return {
+      top: 'Please sign in to the Smart Core Operator App to unlock all features.',
+      // eslint-disable-next-line max-len
+      bottom: 'If you are an administrator or need to setup your building, please sign in with a local account.'
+    };
+  } else {
+    return {
+      top: 'Please sign in to the Smart Core Operator App with your local account to unlock all features.',
+      bottom: 'Local accounts are used to setup Smart Core.'
+    };
+  }
+});
+</script>

--- a/ui/conductor/src/routes/login/LoginPage.vue
+++ b/ui/conductor/src/routes/login/LoginPage.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="d-flex flex-column align-center my-auto">
+    <v-card class="ma-auto pa-4" min-width="450px" max-width="500px">
+      <v-card-title class="justify-center text-h1 font-weight-semibold">
+        <brand-logo outline="white" style="height: 65px;"/>
+        Smart Core
+      </v-card-title>
+
+      <LocalLogin v-if="displayLoginForm"/>
+      <LoginChoice v-else/>
+    </v-card>
+    <v-btn
+        v-if="appConfigStore.config.disableAuthentication"
+        class="mt-4"
+        color="neutral"
+        elevation="0"
+        to="/">
+      <v-icon class="ml-n2">mdi-chevron-left</v-icon>
+      Return to home
+    </v-btn>
+  </div>
+</template>
+<script setup>
+import BrandLogo from '@/components/BrandLogo.vue';
+import LocalLogin from '@/routes/login/LocalLogin.vue';
+import LoginChoice from '@/routes/login/LoginChoice.vue';
+import {useAccountStore} from '@/stores/account.js';
+import {useAppConfigStore} from '@/stores/app-config';
+import {computed} from 'vue';
+
+const appConfigStore = useAppConfigStore();
+const accountStore = useAccountStore();
+
+const displayLoginForm = computed(() => {
+  // If KeyCloak config available, we can toggle between login variants
+  if (appConfigStore.config.keycloak) {
+    return accountStore.loginFormVisible;
+
+    // If KeyCloak config not available, we can only use local login
+  } else {
+    return true;
+  }
+});
+</script>

--- a/ui/conductor/src/routes/router.js
+++ b/ui/conductor/src/routes/router.js
@@ -18,6 +18,12 @@ Vue.use(VueRouter);
 const router = new VueRouter({
   mode: 'history',
   routes: [
+    // {
+    //   path: '/login',
+    //   name: 'login',
+    //   component: () => import('./login/LoginPage.vue'),
+    //   meta: {authentication: {rolesRequired: false}, title: 'Login'}
+    // },
     ...route(auth),
     ...route(devices),
     ...route(ops),


### PR DESCRIPTION
Since we introduced the `status popup` at the top of the appBar, it wasn't available to use when the authentication wasn't disabled, because the login box was a persistent dialog, which blocked the user from clicking behind it.

This 'UX issue' is now solved.

> Note: the use of this PR content depends on other PR's content/functionality, this is the reason why - within the `router.js` - that route is commented.

Jira: SC-77