### PR TITLE
opsui/util: add missing DAY case to formatTimeAgo

### DIFF
--- a/ui/conductor/src/util/date.js
+++ b/ui/conductor/src/util/date.js
@@ -56,5 +56,7 @@ export function formatTimeAgo(date, now, MINUTE, HOUR, DAY) {
     return rtf.format(-Math.floor(diffInSeconds / MINUTE), 'minute');
   } else if (Math.abs(diffInSeconds) < DAY) {
     return rtf.format(-Math.floor(diffInSeconds / HOUR), 'hour');
+  } else {
+    return rtf.format(-Math.floor(diffInSeconds / DAY), 'day');
   }
 }


### PR DESCRIPTION
This avoids the undefined response if the time is more than a day old.