### PR TITLE
opsui: use props.var instead of just var to avoid lint "unused variab…

### DIFF
--- a/ui/conductor/src/routes/automations/components/AutomationList.vue
+++ b/ui/conductor/src/routes/automations/components/AutomationList.vue
@@ -1,5 +1,5 @@
 <template>
-  <services-list :name="ServiceNames.Automations" :type="type"/>
+  <services-list :name="ServiceNames.Automations" :type="props.type"/>
 </template>
 
 <script setup>


### PR DESCRIPTION
…le" warnings