### PR TITLE
opsui/overview: set energy card title to be a prop

### DIFF
--- a/ui/conductor/src/components/charts/LineChart.vue
+++ b/ui/conductor/src/components/charts/LineChart.vue
@@ -1,9 +1,10 @@
 <template>
   <div style="height: 100%; max-height: 275px;">
-    <div class="d-flex flex-row flex-nowrap justify-end align-center mb-6">
+    <div class="d-flex flex-row flex-nowrap justify-end align-center mt-3 mb-6">
+      <v-card-title class="text-h4 pa-0 mr-auto pl-4">{{ props.chartTitle }}</v-card-title>
       <div v-if="!props.hideLegends" id="legend-container" class="mr-2"/>
       <template v-if="$slots.options">
-        <v-divider vertical class="mr-6" style="height: auto"/>
+        <v-divider v-if="!props.hideLegends" vertical class="mr-2" style="height: auto"/>
         <span>
           <slot name="options"/>
         </span>
@@ -57,6 +58,10 @@ const props = defineProps({
         height: ''
       };
     }
+  },
+  chartTitle: {
+    type: String,
+    default: ''
   },
   chartData: {
     type: Object,

--- a/ui/conductor/src/routes/ops/overview/pages/components/RightColumn.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/components/RightColumn.vue
@@ -16,9 +16,9 @@
         v-if="showTrait('showEnergyConsumption')"
         class="pb-0"
         style="min-height:385px;">
-      <v-card-title class="text-h4 pl-4">Energy Consumption</v-card-title>
       <EnergyGraph
-          classes="mt-n2 ml-n2 mr-1"
+          chart-title="Energy Consumption"
+          classes="pb-2 mr-1"
           color="#ffc432"
           color-middle="rgba(255, 196, 50, 0.35)"
           :hide-legends="true"

--- a/ui/conductor/src/routes/ops/overview/pages/widgets/energyAndDemand/EnergyGraph.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/widgets/energyAndDemand/EnergyGraph.vue
@@ -4,16 +4,17 @@
         :class="props.classes"
         :chart-options="chartOptions"
         :chart-data="chartData"
+        :chart-title="props.chartTitle"
         dataset-id-key="label"
         :hide-legends="props.hideLegends">
-      <template v-if="!props.hideLegends" #options>
+      <template #options>
         <v-switch
             v-model="showConversion"
             color="primary"
             dense
             hide-details
             inset
-            class="my-0">
+            class="my-0 ml-2 mr-3">
           <template #prepend>
             <span class="text-caption white--text">kW</span>
           </template>
@@ -35,6 +36,10 @@ import {useCarbonIntensity} from '@/stores/carbonIntensity';
 import {computed, ref} from 'vue';
 
 const props = defineProps({
+  chartTitle: {
+    type: String,
+    default: 'Power'
+  },
   classes: {
     type: String,
     default: 'mt-n10'
@@ -383,8 +388,4 @@ const chartOptions = computed(() => {
     type: 'line'
   };
 });
-/** -------------------------------------------- */
-/**
- * Lifecycle hooks
- */
 </script>


### PR DESCRIPTION
Sub-overview pages display different label on the `energyGraph`. To be able to set it, I moved the label into the actual component - instead of being set in the parent component.

Jira: PRJ-116, PRJ-117