### PR TITLE
opsui/auth: have both the keycloak and local auth providers implement the same api

### DIFF
--- a/ui/conductor/src/composables/authentication/useKeyCloak.js
+++ b/ui/conductor/src/composables/authentication/useKeyCloak.js
@@ -1,34 +1,32 @@
 import {events, keycloak} from '@/api/keycloak.js';
-import {useAccountStore} from '@/stores/account';
 
 /**
  * Keycloak composable
  * This composable is responsible for handling all Keycloak related functionality
  *
- * @return {{
+ * @return {AuthenticationProvider & {
  *  kcp: Promise<import('keycloak-js').KeycloakInstance>,
  *  kcEvents: import('keycloak-js').KeycloakEventEmitter,
- *  initializeKeycloak: (function(): Promise<void>),
- *  login: (function(*=): Promise<void>),
- *  logout: (function(): Promise<void>)
+ *  login: (function(string[]?): Promise<AuthenticationDetails>),
  * }}
  */
 export default function() {
-  const accountStore = useAccountStore();
   const kcp = keycloak();
   const kcEvents = events;
 
 
   /**
-   * Update the auth status and save to local storage
+   * Convert a keycloak instance to AuthenticationDetails.
    *
-   * @return {Promise<void>}
+   * @param {import('keycloak-js').Keycloak} kc
+   * @return {Promise<AuthenticationDetails>}
    */
-  const updateAuthStatus = async () => {
-    const kc = await kcp;
-    accountStore.authenticationDetails.claims = kc.idTokenParsed;
-    accountStore.authenticationDetails.loggedIn = kc.authenticated;
-    accountStore.authenticationDetails.token = kc.token;
+  const kcToAuthDetails = (kc) => {
+    return {
+      claims: kc.idTokenParsed,
+      loggedIn: kc.authenticated,
+      token: kc.token
+    };
   };
   //
   // ----------------------------------- //
@@ -36,26 +34,27 @@ export default function() {
   /**
    * Initialize the Keycloak instance and event listeners
    *
-   * @return {Promise<import('keycloak-js').KeycloakInstance>}
+   * @return {Promise<AuthenticationDetails|null>}
    */
   const initializeKeycloak = async () => {
     const kc = await kcp;
-    if (kc.authenticated) {
-      await updateAuthStatus();
+    if (!kc.authenticated) {
+      return null;
     }
-
-    return kc;
+    return kcToAuthDetails(kc);
   };
 
   /**
    * Login to Keycloak with the given scopes
    *
-   * @param {string[]} scopes
-   * @return {Promise<void>}
+   * @param {string[]} [scopes]
+   * @return {Promise<AuthenticationDetails>}
    */
   const loginKeyCloak = async (scopes) => {
     const kc = await kcp;
     kc.login({scope: scopes.join(' ')});
+    // not needed as login will redirect the page, but helpful for js type checking
+    return kcToAuthDetails(kc);
   };
 
   /**
@@ -71,26 +70,13 @@ export default function() {
   /**
    * Update the token if it is close to expiring (15 seconds)
    *
-   * @return {Promise<void>}
+   * @return {Promise<AuthenticationDetails>}
    */
   const refreshToken = async () => {
     const kc = await kcp;
     await kc.updateToken(15);
+    return kcToAuthDetails(kc);
   };
-  //
-  // ----------------------------------- //
-  //
-  /**
-   * AuthSuccess event listener
-   * This event listener is responsible for updating the authenticationDetails on a successful login
-   */
-  kcEvents.addEventListener('authSuccess', async () => await updateAuthStatus());
-
-  /**
-   * AuthRefreshSuccess event listener
-   * This event listener is responsible for updating the authenticationDetails on a successful token refresh
-   */
-  kcEvents.addEventListener('onAuthRefreshSuccess', async () => await updateAuthStatus());
 
   return {
     kcp,

--- a/ui/conductor/src/composables/authentication/useLocal.js
+++ b/ui/conductor/src/composables/authentication/useLocal.js
@@ -1,5 +1,4 @@
 import {localLogin} from '@/api/localLogin.js';
-import {useAccountStore} from '@/stores/account';
 import {loadFromBrowserStorage, saveToBrowserStorage} from '@/util/browserStorage';
 import jwtDecode from 'jwt-decode';
 import {ref} from 'vue';
@@ -8,36 +7,58 @@ import {ref} from 'vue';
  * Local authentication composable
  * This composable is responsible for handling all local authentication related functionality
  *
- * @return {{
- *  login: (function(string, string): Promise<void>),
- *  logout: (function(): void)
+ * @return {AuthenticationProvider & {
+ *  login: (function(string, string): Promise<AuthenticationDetails>),
  * }}
  */
 export default function() {
-  const accountStore = useAccountStore();
-
-  // ----------------- //
-
   /**
    * Load the local authentication details from local storage
    *
-   * @type {import('vue').Ref<import('@/stores/account').AuthenticationDetails|null>}
+   * @type {import('vue').Ref<AuthenticationDetails|null>}
    */
   const existingLocalAuth = ref(null);
+
+  /**
+   * Read the local authentication details from local storage.
+   *
+   * @return {Promise<AuthenticationDetails|null>}
+   */
+  const readFromStorage = async () => {
+    return loadFromBrowserStorage(
+        'local',
+        'authenticationDetails',
+        null
+    )[0];
+  };
+
+  /**
+   * Write the local authentication details to local storage.
+   *
+   * @param {AuthenticationDetails} details
+   * @return {Promise<void>}
+   */
+  const writeToStorage = async (details) => {
+    saveToBrowserStorage('local', 'authenticationDetails', details);
+  };
+
+  /**
+   * Clear the local storage.
+   *
+   * @return {Promise<void>}
+   */
+  const clearStorage = async () => {
+    await window.localStorage.removeItem('authenticationDetails');
+  };
 
   /**
    * Initialize local authentication - set the existing local authentication details
    * or the default store values
    *
-   * @return {import('@/stores/account').AuthenticationDetails|null}
+   * @return {Promise<AuthenticationDetails|null>}
    */
-  const initializeLocal = () => {
-    existingLocalAuth.value = loadFromBrowserStorage(
-        'local',
-        'authenticationDetails',
-        accountStore.authenticationDetails
-    )[0];
-
+  const initializeLocal = async () => {
+    existingLocalAuth.value = await readFromStorage();
     return existingLocalAuth.value;
   };
 
@@ -46,7 +67,7 @@ export default function() {
    *
    * @param {string} username
    * @param {string} password
-   * @return {Promise<void>}
+   * @return {Promise<AuthenticationDetails>}
    */
   const loginLocal = async (username, password) => {
     try {
@@ -56,48 +77,54 @@ export default function() {
         const payload = await res.json();
 
         if (payload?.access_token) {
-          accountStore.authenticationDetails.claims = {
-            email: username,
-            ...jwtDecode(payload.access_token)
+          const details = /** @type {AuthenticationDetails} */ {
+            claims: {
+              email: username,
+              ...jwtDecode(payload.access_token)
+            },
+            loggedIn: true,
+            token: payload.access_token
           };
-          accountStore.authenticationDetails.loggedIn = !!payload.access_token;
-          accountStore.authenticationDetails.token = payload.access_token;
-
-          accountStore.snackbar = {
-            message: 'Failed to sign in, please try again.',
-            visible: false
-          };
+          await writeToStorage(details);
+          existingLocalAuth.value = details;
+          return details;
         }
       } else {
-        accountStore.snackbar = {
-          visible: true,
-          message: 'Failed to sign in, please try again.'
-        };
+        existingLocalAuth.value = null;
+        await clearStorage();
+        return Promise.reject(new Error('Failed to sign in, please try again.'));
       }
-
-      saveToBrowserStorage('local', 'authenticationDetails', accountStore.authenticationDetails);
     } catch (err) {
-      accountStore.snackbar = {
-        visible: true,
-        message: 'Failed to sign in, please try again.'
-      };
-      saveToBrowserStorage('local', 'authenticationDetails', accountStore.authenticationDetails);
+      existingLocalAuth.value = null;
+      await clearStorage();
+      return Promise.reject(new Error('Failed to sign in, please try again.'));
     }
   };
 
   /**
    * Logout using the store reset function, then store the cleared store in local storage
    *
-   * @return {void}
+   * @return {Promise<void>}
    */
   const logoutLocal = async () => {
-    await window.localStorage.removeItem('authenticationDetails');
+    existingLocalAuth.value = null;
+    await clearStorage();
+  };
+
+  /**
+   * Refresh the local authentication details.
+   *
+   * @return {Promise<AuthenticationDetails>}
+   */
+  const refreshToken = async () => {
+    return existingLocalAuth.value;
   };
 
   return {
     existingLocalAuth,
     init: initializeLocal,
     login: loginLocal,
-    logout: logoutLocal
+    logout: logoutLocal,
+    refreshToken
   };
 }


### PR DESCRIPTION
Before there were subtle differences between how refresh or init would work for each provider. The account store would mask over these differences in it's functions to provide a consistent API. There's no need for this anymore, both providers now implement the AuthenticationProvider type.

Similarly there was a cyclic dependency between the providers and the account store:
1. account depended on the providers to invoke login or init, etc
2. the providers depended on the account to update authenticationDetails and snackbar

I've reworked things so that this cycle is no longer present and instead errors and response values are used to communicate between account and providers.