### PR TITLE
opsui/theme: fix wrong string structure returned

### DIFF
--- a/ui/conductor/src/util/theme.js
+++ b/ui/conductor/src/util/theme.js
@@ -66,7 +66,7 @@ export const rgbaColor = (hex, alpha = 1) => {
     return ''; // early escape if hex is not defined
   }
 
-  return `rgba(${rgbColor(hex)}, ${alpha})`;
+  return rgbColor(hex).replace('rgb', 'rgba').replace(')', `, ${alpha})`);
 };
 
 /**


### PR DESCRIPTION
`rgbaColor` utility returned a string containing both rgba and rgb types - `rgba(rgb(...))`. This is fixed now.

Jira: N/A