### PR TITLE
opsui/overview: hide occupancy chart

### DIFF
--- a/ui/conductor/public/eg-config.json
+++ b/ui/conductor/public/eg-config.json
@@ -46,7 +46,8 @@
           "primary": {
             "base": "#ffcc00",
             "darken3": "#9c7c00"
-          }
+          },
+          "info": "#00c7b1"
         }
       }
     },
@@ -67,6 +68,7 @@
       {"name": "Floor 10", "svgPath": "/floorPlans/L10.svg"}
     ],
     "building": {
+      "showOccupancy": false,
       "children": [
         {
           "disabled": false,

--- a/ui/conductor/src/routes/ops/overview/pages/BuildingOverview.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/BuildingOverview.vue
@@ -7,7 +7,7 @@
       <v-row class="d-flex flex-row">
         <v-col cols="12">
           <energy-card :generated="supplyZone" :metered="energyZone"/>
-          <occupancy-card :name="occupancyZone"/>
+          <occupancy-card v-if="uiConfig.config.building?.showOccupancy" :name="occupancyZone"/>
         </v-col>
       </v-row>
     </v-col>


### PR DESCRIPTION
Hide occupancy bar chart if it's set in `building` config. This way we can hide the bar chart if there is no headcount history to be displayed on the bar chart.

Jira: N/A