### PR TITLE
opsui/auth: add 'login via external device' option

### DIFF
--- a/schema/ui-config.schema.json
+++ b/schema/ui-config.schema.json
@@ -134,6 +134,39 @@
               }
             }
           }
+        },
+        "auth": {
+          "description": "Configuration for user authentication",
+          "type": "object",
+          "properties": {
+            "deviceFlow": {
+              "oneOf": [
+                {
+                  "description": "A flag to enable the OAuth2 Device Flow. Settings are computed from the keycloak configuration",
+                  "type": "boolean"
+                },
+                {
+                  "description": "OAuth2 Device Flow configuration",
+                  "type": "object",
+                  "properties": {
+                    "clientId": {
+                      "description": "The client ID",
+                      "type": "string"
+                    },
+                    "tokenUrl": {
+                      "description": "The token URL",
+                      "type": "string"
+                    },
+                    "deviceCodeUrl": {
+                      "description": "The device code URL",
+                      "type": "string"
+                    }
+                  },
+                  "required": ["clientId", "tokenUrl", "deviceCodeUrl"]
+                }
+              ]
+            }
+          }
         }
       }
     }

--- a/ui/conductor/package.json
+++ b/ui/conductor/package.json
@@ -22,6 +22,7 @@
     "jwt-decode": "^3.1.2",
     "keycloak-js": "^19.0.1",
     "pinia": "^2.0.17",
+    "qrcode": "^1.5.3",
     "vue": "2.7",
     "vue-chartjs": "^5.2.0",
     "vue-router": "3.6",

--- a/ui/conductor/src/composables/authentication/useDeviceFlow.js
+++ b/ui/conductor/src/composables/authentication/useDeviceFlow.js
@@ -1,0 +1,345 @@
+import {useUiConfigStore} from '@/stores/ui-config';
+import {loadFromBrowserStorage, saveToBrowserStorage} from '@/util/browserStorage';
+import {toValue} from '@/util/vue';
+import jwtDecode from 'jwt-decode';
+import {computed, ref} from 'vue';
+
+
+/**
+ * @typedef TokenResponse
+ * @property {string} access_token
+ * @property {string} token_type
+ * @property {number} expires_in Seconds since the token was issued
+ * @property {number} refresh_expires_in Seconds since the token was issued
+ * @property {string} refresh_token
+ * @property {string} scope
+ * @property {number} timestamp Date.now() when the token was retrieved
+ */
+
+/**
+ * Code is the data we retrieve from the server to show to the user to complete the authentication.
+ *
+ * @typedef CodeResponse
+ * @property {string} device_code A temporary unique code for the device that initiated the flow, pass this code to
+ *  checkDeviceToken to see if the user has completed the flow.
+ * @property {string} user_code The code the user needs to enter.
+ * @property {string} verification_uri A url the user can visit to enter the user_code, can be displayed to the user
+ *  as is.
+ * @property {string} verification_uri_complete A url that auto fills the user_code, it typically too long to type,
+ *  encode as QR or similar image for scanning.
+ * @property {number} expires_in Seconds until device_code and user_code expire
+ * @property {number} interval In seconds, recommended polling interval for checkDeviceToken
+ * @property {number} timestamp Date.now() when the code was retrieved
+ */
+
+/**
+ * Context contains the information to show to the user to complete the authentication.
+ * The {@code complete} promise will be settled when the user has completed the authentication, or
+ * {@code code.expires_in} has passed.
+ *
+ * @typedef Context
+ * @property {CodeResponse} code The data to show to the user to complete the authentication.
+ * @property {Promise<AuthenticationDetails>} complete Settled when the user has completed the authentication, or
+ *  the flow has expired or been aborted.
+ * @property {function(): void} cancel Call to stop checking for the user to complete the authentication.
+ */
+/**
+ * @typedef Config
+ * @property {MaybeRefOrGetter<string>} clientId
+ * @property {MaybeRefOrGetter<string>} deviceUrl
+ * @property {MaybeRefOrGetter<string>} tokenUrl
+ */
+
+/**
+ * Implements AuthenticationProvider using the OAuth2 Device Flow.
+ *
+ * @param {MaybeRefOrGetter<Config>} config
+ * @return {AuthenticationProvider & {
+ *  begin: (function(string[]?): Promise<Context>),
+ * }}
+ */
+export default function useDeviceFlow(config) {
+  const clientId = computed(() => toValue(toValue(config)?.clientId));
+  const deviceUrl = computed(() => toValue(toValue(config)?.deviceUrl));
+  const tokenUrl = computed(() => toValue(toValue(config)?.tokenUrl));
+
+  const storageKey = 'deviceToken';
+  /**
+   * Read the token response from local storage.
+   *
+   * @return {Promise<TokenResponse|null>}
+   */
+  const readFromStorage = async () => {
+    return loadFromBrowserStorage(
+        'local',
+        storageKey,
+        null
+    )[0];
+  };
+
+  /**
+   * Write the token response to local storage.
+   *
+   * @param {TokenResponse} details
+   * @return {Promise<void>}
+   */
+  const writeToStorage = async (details) => {
+    saveToBrowserStorage('local', storageKey, details);
+  };
+
+  /**
+   * Clear the local storage.
+   *
+   * @return {Promise<void>}
+   */
+  const clearStorage = async () => {
+    await window.localStorage.removeItem(storageKey);
+  };
+
+  /**
+   * Convert a TokenResponse to AuthenticationDetails.
+   *
+   * @param {TokenResponse} tokenResponse
+   * @return {AuthenticationDetails}
+   */
+  const tokenResponseToAuthDetails = (tokenResponse) => {
+    return {
+      claims: jwtDecode(tokenResponse.access_token),
+      loggedIn: true,
+      token: tokenResponse.access_token
+    };
+  };
+
+  /**
+   * @param {number} issued Timestamp, unix nanos, aka Date.now()
+   * @param {number} expiresIn seconds after issued that the token expires
+   * @param {number} leeway seconds before the token expires that it is considered expired
+   * @return {boolean}
+   * @private
+   */
+  const _expired = (issued, expiresIn, leeway = 0) => {
+    return issued + expiresIn * 1000 < Date.now() + leeway * 1000;
+  };
+
+  /**
+   * Return if the given access token has expired.
+   *
+   * @param {TokenResponse} tokenResponse
+   * @param {number} [leeway] If the token expires within this many seconds, it is considered expired.
+   * @return {boolean}
+   */
+  const isAccessTokenExpired = (tokenResponse, leeway = 0) => {
+    return _expired(tokenResponse.timestamp, tokenResponse.expires_in, leeway);
+  };
+
+  /**
+   * @param {string[]} scopes
+   * @return {Promise<CodeResponse>}
+   */
+  const postBeginDeviceFlow = async (scopes) => {
+    return fetch(deviceUrl.value, {
+      method: 'POST',
+      body: new URLSearchParams({
+        client_id: clientId.value,
+        scope: scopes.join(' ')
+      })
+    })
+        .then(res => {
+          if (!res.ok) {
+            throw new Error(`Failed to start device auth flow: ${res.status} ${res.statusText}`);
+          }
+          return res.json();
+        })
+        .then(data => {
+          data.timestamp = Date.now();
+          return data;
+        });
+  };
+
+  /**
+   * @param {CodeResponse} lastResponse
+   * @return {Promise<TokenResponse>}
+   */
+  const postCheckDeviceToken = async (lastResponse) => {
+    return fetch(tokenUrl.value, {
+      method: 'POST',
+      body: new URLSearchParams({
+        client_id: clientId.value,
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: lastResponse.device_code
+      })
+    })
+        .then(res => {
+          if (!res.ok) {
+            throw new Error(`Failed to check device auth flow: ${res.status} ${res.statusText}`);
+          }
+          return res.json();
+        });
+  };
+
+  /**
+   * @param {TokenResponse} lastResponse
+   * @return {Promise<TokenResponse>}
+   */
+  const postRefreshToken = async (lastResponse) => {
+    if (!lastResponse.refresh_token) {
+      throw new Error('tokenResponse does not contain a refresh token');
+    }
+    return fetch(tokenUrl.value, {
+      method: 'POST',
+      body: new URLSearchParams({
+        client_id: clientId.value,
+        grant_type: 'refresh_token',
+        refresh_token: lastResponse.refresh_token
+      })
+    })
+        .then(res => {
+          if (!res.ok) {
+            throw new Error(`Failed to refresh token: ${res.status} ${res.statusText}`);
+          }
+          return res.json();
+        });
+  };
+
+  // An in-memory cache of the token response either from the server or from local storage.
+  const tokenResponse = ref(/** @type {TokenResponse | null} */ null);
+
+  /**
+   * Initialise state and cached data.
+   *
+   * @return {Promise<AuthenticationDetails|null>}
+   */
+  const init = async () => {
+    // check config
+    if (!clientId.value) throw new Error('clientId not configured');
+    if (!deviceUrl.value) throw new Error('deviceUrl not configured');
+    if (!tokenUrl.value) throw new Error('tokenUrl not configured');
+
+    const data = await readFromStorage();
+    if (!data) {
+      return null; // not authenticated
+    }
+    tokenResponse.value = data;
+    return tokenResponseToAuthDetails(data);
+  };
+
+  /**
+   * Begin the device login flow.
+   * The returned promise will be rejected if the flow could not be started.
+   *
+   * @param {string[]} [scopes]
+   * @return {Promise<Context>}
+   */
+  const begin = async (scopes = ['profile']) => {
+    const code = await postBeginDeviceFlow(scopes);
+    let cancel = () => {}; // filled in the promise below
+    const complete = new Promise((resolve, reject) => {
+      let lastError = null;
+      // this interval checks for the user to complete the authentication periodically
+      const poll = setInterval(async () => {
+        try {
+          const tokenResponse = await postCheckDeviceToken(code);
+          await writeToStorage(tokenResponse);
+          tokenResponse.value = tokenResponse;
+          cancel(); // success, stop any timeouts
+          resolve(tokenResponseToAuthDetails(tokenResponse));
+        } catch (e) {
+          lastError = e; // don't stop, only report the error if all attempts fail
+        }
+      }, code.interval * 1000);
+      // this timeout stops the interval and rejects the promise if the flow expires
+      const expired = setTimeout(() => {
+        cancel();
+        if (!lastError) {
+          lastError = new Error('User Code has expired');
+        }
+        reject(lastError);
+      }, code.expires_in * 1000);
+
+      // stop watching for completion (or timeout)
+      cancel = () => {
+        clearInterval(poll);
+        clearTimeout(expired);
+      };
+    });
+    return {code, complete, cancel};
+  };
+
+
+  /**
+   * Logout using the store reset function, then store the cleared store in local storage
+   *
+   * @return {Promise<void>}
+   */
+  const logout = async () => {
+    tokenResponse.value = null;
+    await clearStorage();
+  };
+
+  /**
+   * Refresh the local authentication details.
+   *
+   * @return {Promise<AuthenticationDetails>}
+   */
+  const refreshToken = async () => {
+    // type cast not strictly correct (can be null at this point) but prevents editor warnings.
+    const oldTokenResponse = /** @type {TokenResponse} */ tokenResponse.value;
+    if (!oldTokenResponse) {
+      throw new Error('Not authenticated');
+    }
+    // don't bother refreshing if the token is not close to expiry.
+    if (!isAccessTokenExpired(oldTokenResponse, 5)) return tokenResponseToAuthDetails(oldTokenResponse);
+
+    const newTokenResponse = await postRefreshToken(oldTokenResponse);
+    await writeToStorage(newTokenResponse);
+    tokenResponse.value = newTokenResponse;
+    return tokenResponseToAuthDetails(newTokenResponse);
+  };
+
+  return {
+    tokenResponse,
+    init,
+    begin,
+    logout,
+    refreshToken
+  };
+}
+
+/**
+ * Returns a {@link Config} that is based on the ui config in the store.
+ * Can be passed directly to {@link useDeviceFlow}.
+ *
+ * @return {MaybeRefOrGetter<Config>}
+ */
+export function useUiConfig() {
+  const uiConfig = useUiConfigStore();
+  return computed(() => {
+    const deviceFlowConfig = uiConfig.config?.auth?.deviceFlow;
+    if (!deviceFlowConfig) return {}; // invalid, device flow not configured
+    if (deviceFlowConfig === true) {
+      // use keycloak config as the basis for our config
+      const kcConfig = computed(() => uiConfig.config?.keycloak);
+      const kcRealmPath = (path) => {
+        let baseUrl = kcConfig.value?.url;
+        const realm = kcConfig.value?.realm;
+        if (!baseUrl || !realm) {
+          return null;
+        }
+        if (baseUrl.endsWith('/')) {
+          baseUrl = baseUrl.substring(0, baseUrl.length - 1);
+        }
+        if (path.startsWith('/')) {
+          path = path.substring(1);
+        }
+        return `${baseUrl}/realms/${realm}/${path}`;
+      };
+      return {
+        clientId: computed(() => kcConfig.value?.clientId),
+        deviceUrl: computed(() => kcRealmPath('/protocol/openid-connect/auth/device')),
+        tokenUrl: computed(() => kcRealmPath('/protocol/openid-connect/token'))
+      };
+    } else {
+      return deviceFlowConfig;
+    }
+  });
+}

--- a/ui/conductor/src/routes/login/DeviceFlowLogin.vue
+++ b/ui/conductor/src/routes/login/DeviceFlowLogin.vue
@@ -1,0 +1,130 @@
+<template>
+  <div>
+    <template v-if="!code">
+      <v-card-title>Setting up device authentication...</v-card-title>
+    </template>
+    <template v-else>
+      <v-card-text class="instructions">
+        <div class="instructions--title text-h4 mb-6">Log in using your device</div>
+        <div class="activation-link--title">Go to:</div>
+        <div class="activation-link--a font-weight-bold mb-4">
+          <a :href="code.verification_uri" class="text-decoration-none" target="_blank">
+            {{ code.verification_uri }}
+          </a>
+        </div>
+        <div class="activation-code--title">Enter your unique activation code:</div>
+        <div class="activation-code text-h1 d-flex align-center">
+          <span>{{ code.user_code }}</span>
+          <v-progress-circular
+              v-if="showCodeExpiresPercentage"
+              class="ml-4"
+              color="warning"
+              :size="28"
+              :width="3"
+              :value="codeExpiresInPercentage"/>
+        </div>
+      </v-card-text>
+      <v-card-text class="qr d-flex flex-column align-center">
+        <a :href="code.verification_uri_complete" target="_blank">
+          <img :src="qrCodeDataUrl" alt="QR Code containing the url to login using your device" class="qr--container">
+        </a>
+        <div class="qr--text mt-2">Or scan this QR Code</div>
+      </v-card-text>
+    </template>
+  </div>
+</template>
+<script setup>
+import {SECOND, useNow} from '@/components/now';
+import {useAccountStore} from '@/stores/account';
+import QRCode from 'qrcode';
+import {computed, onBeforeUnmount, onMounted, ref, watch} from 'vue';
+
+const props = defineProps({
+  scopes: {
+    type: Array,
+    default: () => undefined
+  }
+});
+
+const accountStore = useAccountStore();
+
+const context = ref(
+    /** @type {import('@/composables/authentication/useDeviceFlow').Context | null} */
+    null
+);
+const cancelContext = () => {
+  if (context.value) {
+    context.value.cancel();
+  }
+};
+const code = computed(() => /** @type {CodeResponse} */ context.value?.code);
+
+const {now} = useNow(SECOND / 4); // this has a direct impact on how smooth the progress bar looks
+// at what time will the current user code expire.
+const expiresAt = computed(() => {
+  if (!code.value) {
+    return false;
+  }
+  return new Date(code.value.timestamp + code.value.expires_in * 1000);
+});
+
+// renew the user code whenever the old one expires - assuming the user hasn't completed the flow yet
+let oldBeginAgainHandle = 0;
+watch(expiresAt, (expiresAt) => {
+  clearTimeout(oldBeginAgainHandle);
+  if (expiresAt === false) {
+    return;
+  }
+  const expiresInMillis = expiresAt.getTime() - now.value.getTime();
+  oldBeginAgainHandle = setTimeout(async () => {
+    cancelContext();
+    context.value = await accountStore.beginDeviceFlow(props.scopes);
+  }, expiresInMillis);
+});
+
+// props that tell the user if their code is about to expire
+const expiresInSecs = computed(() => {
+  const at = expiresAt.value;
+  if (!at) {
+    return false;
+  }
+  return (at.getTime() - now.value.getTime()) / 1000;
+});
+const showCodeExpiresPercentageThreshold = ref(30); // in secs
+const showCodeExpiresPercentage = computed(() => expiresInSecs.value < showCodeExpiresPercentageThreshold.value);
+// counts down from 100 to 0 starting with 100$% being showCodeExpiresPercentageThreshold away from expiry.
+const codeExpiresInPercentage = computed(() => (expiresInSecs.value / showCodeExpiresPercentageThreshold.value) * 100);
+
+// QR code generation
+const qrCodeContent = computed(() => code.value?.verification_uri_complete);
+const qrCodeDataUrl = ref(';');
+watch(qrCodeContent, (qrCodeContent) => {
+  if (qrCodeContent) {
+    const opts = {
+      errorCorrectionLevel: 'M',
+      width: 200
+    };
+    QRCode.toDataURL(qrCodeContent, opts, (err, url) => {
+      if (err) {
+        console.error('Error generating QR code', err);
+      } else {
+        qrCodeDataUrl.value = url;
+      }
+    });
+  }
+});
+
+// kick off the flow
+onMounted(async () => {
+  context.value = await accountStore.beginDeviceFlow(props.scopes);
+});
+onBeforeUnmount(() => {
+  cancelContext();
+  clearTimeout(oldBeginAgainHandle);
+});
+</script>
+<style scoped>
+.qr--container {
+  vertical-align: middle;
+}
+</style>

--- a/ui/conductor/src/routes/login/LoginChoice.vue
+++ b/ui/conductor/src/routes/login/LoginChoice.vue
@@ -1,41 +1,53 @@
 <template>
   <div>
-    <v-card-text :class="[{'mb-8': uiConfig.config.keycloak }, 'text-center mx-auto']" style="max-width: 320px;">
-      {{ keycloakMessage.top }}
-    </v-card-text>
-    <v-card-actions class="d-flex flex-column align-center justify-center">
-      <v-btn
-          v-if="uiConfig.config.keycloak"
-          @click="store.loginWithKeyCloak(['profile', 'roles'])"
-          color="primary"
-          block
-          large
-          class="text-body-1 font-weight-bold">
-        Sign in
-      </v-btn>
-    </v-card-actions>
-    <v-card-text class="text-body-2 text-center mt-10 mx-auto" style="max-width: 350px;">
-      {{ keycloakMessage.bottom }}
-    </v-card-text>
-    <v-card-actions class="d-flex flex-column align-center justify-center mt-n2">
-      <v-btn
-          block
-          class="text-body-2 ma-0"
-          text
-          @click="store.loginFormVisible = !store.loginFormVisible">
-        Sign in with local Account
-      </v-btn>
-    </v-card-actions>
+    <template v-if="usingDeviceFlow">
+      <device-flow-login :scopes="['profile', 'roles']"/>
+    </template>
+    <template v-else>
+      <v-card-text :class="[{'mb-8': uiConfig.config.keycloak }, 'text-center mx-auto']" style="max-width: 320px;">
+        {{ keycloakMessage.top }}
+      </v-card-text>
+      <v-card-actions class="d-flex flex-column align-center justify-center">
+        <v-btn
+            v-if="uiConfig.config.keycloak"
+            @click="store.loginWithKeyCloak(['profile', 'roles'])"
+            color="primary"
+            block
+            large
+            class="text-body-1 font-weight-bold">
+          Sign in
+        </v-btn>
+      </v-card-actions>
+      <v-card-text class="text-body-2 text-center mt-10 mx-auto" style="max-width: 350px;">
+        {{ keycloakMessage.bottom }}
+      </v-card-text>
+      <v-card-actions class="d-flex flex-column align-center justify-center mt-n2">
+        <v-btn
+            block
+            class="text-body-2 ma-0"
+            text
+            @click="store.loginFormVisible = !store.loginFormVisible">
+          Sign in with local Account
+        </v-btn>
+      </v-card-actions>
+    </template>
   </div>
 </template>
 
 <script setup>
+import DeviceFlowLogin from '@/routes/login/DeviceFlowLogin.vue';
 import {useAccountStore} from '@/stores/account.js';
 import {useUiConfigStore} from '@/stores/ui-config';
 import {computed} from 'vue';
 
 const uiConfig = useUiConfigStore();
 const store = useAccountStore();
+
+// If device flow is configured, use it always.
+// Otherwise devices that have no input methods won't be able to pick it.
+const usingDeviceFlow = computed(() => {
+  return Boolean(uiConfig.config?.auth?.deviceFlow);
+});
 
 // Tweak the message depending on whether KeyCloak is enabled or not
 const keycloakMessage = computed(() => {

--- a/ui/conductor/yarn.lock
+++ b/ui/conductor/yarn.lock
@@ -1578,7 +1578,7 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://nexus.vanti.co.uk/repository/npm-public/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -1821,6 +1821,15 @@ cli-spinners@^2.5.0:
   resolved "https://nexus.vanti.co.uk/repository/npm-public/cli-spinners/-/cli-spinners-2.7.0.tgz#f815fd30b5f9eaac02db604c7a231ed7cb2f797a"
   integrity sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==
 
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://nexus.vanti.co.uk/repository/npm-public/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -1939,6 +1948,11 @@ debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
+decamelize@^1.2.0:
+  version "1.2.0"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
+
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://nexus.vanti.co.uk/repository/npm-public/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
@@ -1969,6 +1983,11 @@ define-properties@^1.1.4:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
+dijkstrajs@^1.0.1:
+  version "1.0.3"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/dijkstrajs/-/dijkstrajs-1.0.3.tgz#4c8dbdea1f0f6478bff94d9c49c784d623e4fc23"
+  integrity sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://nexus.vanti.co.uk/repository/npm-public/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -1986,10 +2005,20 @@ electron-to-chromium@^1.4.251:
   resolved "https://nexus.vanti.co.uk/repository/npm-public/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
   integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
 
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
 emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://nexus.vanti.co.uk/repository/npm-public/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
+encode-utf8@^1.0.3:
+  version "1.0.3"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/encode-utf8/-/encode-utf8-1.0.3.tgz#f30fdd31da07fb596f281beb2f6b027851994cda"
+  integrity sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -2430,7 +2459,7 @@ find-cache-dir@^3.3.1:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
-find-up@^4.0.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://nexus.vanti.co.uk/repository/npm-public/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -2478,6 +2507,11 @@ gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://nexus.vanti.co.uk/repository/npm-public/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
   version "1.1.3"
@@ -2687,6 +2721,11 @@ is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
@@ -3231,6 +3270,11 @@ pkijs@^3.0.15:
     pvutils "^1.1.3"
     tslib "^2.4.0"
 
+pngjs@^5.0.0:
+  version "5.0.0"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
+  integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
+
 postcss-selector-parser@^6.0.9:
   version "6.0.11"
   resolved "https://nexus.vanti.co.uk/repository/npm-public/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz#2e41dc39b7ad74046e1615185185cd0b17d0c8dc"
@@ -3277,6 +3321,16 @@ pvutils@^1.1.3:
   version "1.1.3"
   resolved "https://nexus.vanti.co.uk/repository/npm-public/pvutils/-/pvutils-1.1.3.tgz#f35fc1d27e7cd3dfbd39c0826d173e806a03f5a3"
   integrity sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==
+
+qrcode@^1.5.3:
+  version "1.5.3"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/qrcode/-/qrcode-1.5.3.tgz#03afa80912c0dccf12bc93f615a535aad1066170"
+  integrity sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==
+  dependencies:
+    dijkstrajs "^1.0.1"
+    encode-utf8 "^1.0.3"
+    pngjs "^5.0.0"
+    yargs "^15.3.1"
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -3368,6 +3422,16 @@ regjsparser@^0.9.1:
   integrity sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==
   dependencies:
     jsesc "~0.5.0"
+
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
 requireindex@^1.2.0:
   version "1.2.0"
@@ -3483,6 +3547,11 @@ serialize-javascript@^6.0.0:
   dependencies:
     randombytes "^2.1.0"
 
+set-blocking@^2.0.0:
+  version "2.0.0"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+  integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://nexus.vanti.co.uk/repository/npm-public/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -3565,6 +3634,15 @@ spdx-license-ids@^3.0.0:
   version "3.0.12"
   resolved "https://nexus.vanti.co.uk/repository/npm-public/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz#69077835abe2710b65f03969898b6637b505a779"
   integrity sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==
+
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -3927,6 +4005,11 @@ whatwg-url@^5.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
+which-module@^2.0.0:
+  version "2.0.1"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
+  integrity sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==
+
 which@^1.2.9:
   version "1.3.1"
   resolved "https://nexus.vanti.co.uk/repository/npm-public/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -3946,6 +4029,15 @@ word-wrap@^1.2.3:
   resolved "https://nexus.vanti.co.uk/repository/npm-public/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
@@ -3956,10 +4048,40 @@ xml-name-validator@^4.0.0:
   resolved "https://nexus.vanti.co.uk/repository/npm-public/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
 
+y18n@^4.0.0:
+  version "4.0.3"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
 yallist@^4.0.0:
   version "4.0.0"
   resolved "https://nexus.vanti.co.uk/repository/npm-public/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs@^15.3.1:
+  version "15.4.1"
+  resolved "https://nexus.vanti.co.uk/repository/npm-public/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This PR adds a new auth provider to the account store that allows you to login on a different device to authenticate the ops ui. This is called the OAuth Device Authentication Flow. This PR makes the following changes:

1. Add new configuration options to ui-config to allow specifying that the new flow can be used and how to set it up (client ID, etc)
2. Add a new composable that implements the account.AuthenticationProvider interface
3. Add new vue component that invokes and displays information to the user to aid them with their login process: QR Code, url, user code, etc.

To complete 3 I've also added qrcode dependency which can generate QR codes for us.

I'm not expecting the Ops UI to actually use this auth mechanism any time soon, however I am planning on copy-pasting the auth code over to various signage and touch panel uis in different projects so thought _why not_ add it here first.

The configuration changes I've made are backwards compatible. I've introduced a new "auth" section to the ui config, I'm hoping at some time in the future other config options relating to auth will migrate here too.

![image](https://github.com/vanti-dev/sc-bos/assets/708746/a978cb01-641e-4e50-b2b8-6ac5b4552f88)
