### PR TITLE
auto/azureiot: fix for nil pointer deref. error when not using RemoteNode

### DIFF
--- a/pkg/auto/azureiot/traits.go
+++ b/pkg/auto/azureiot/traits.go
@@ -309,10 +309,7 @@ func grpcClient[T any](a *Auto, c *T, f func(connInterface grpc.ClientConnInterf
 	// use local client config
 	rn := dev.RemoteNode
 	if rn == nil {
-		err := a.services.Node.Client(c)
-		if err != nil {
-			return err
-		}
+		return a.services.Node.Client(c)
 	}
 
 	a.connsMu.Lock()


### PR DESCRIPTION
Once we've established that there is no RemoteNode we shouldn't be continuing past this point, so just return here with or without error.