### PR TITLE
opsui/auth: allow explicit configuration of authn providers

### DIFF
--- a/schema/ui-config.schema.json
+++ b/schema/ui-config.schema.json
@@ -150,6 +150,13 @@
           "description": "Configuration for user authentication",
           "type": "object",
           "properties": {
+            "providers": {
+              "description": "A list of named providers that the ui should use for authentication. If absent any successfully initialised provider can be used.",
+              "type": "array",
+              "items": {
+                "enum": ["keyCloakAuth", "deviceFlow", "localAuth"]
+              }
+            },
             "deviceFlow": {
               "oneOf": [
                 {

--- a/ui/conductor/src/routes/login/LocalLogin.vue
+++ b/ui/conductor/src/routes/login/LocalLogin.vue
@@ -32,36 +32,17 @@
           Sign In
         </v-btn>
       </v-card-actions>
-      <v-card-text v-if="displayLoginSwitch" class="d-flex justify-center">
-        <a
-            @click="accountStore.loginFormVisible = !accountStore.loginFormVisible"
-            class="text-center">
-          Use a different sign in method
-        </a>
-      </v-card-text>
     </v-form>
-
-    <v-snackbar v-model="snackbar.visible">
-      {{ snackbar.message }}
-
-      <template #action="{ attrs }">
-        <v-btn color="pink" text v-bind="attrs" @click="snackbar.visible = false">
-          Close
-        </v-btn>
-      </template>
-    </v-snackbar>
   </div>
 </template>
 
 <script setup>
 import {useAccountStore} from '@/stores/account.js';
-import {storeToRefs} from 'pinia';
 import {computed, ref} from 'vue';
 
 const accountStore = useAccountStore();
 const password = ref('');
 const username = ref('');
-const {snackbar} = storeToRefs(accountStore);
 const rules = {
   required: (value) => !!value || 'Required.'
 };
@@ -82,9 +63,6 @@ const disableSignIn = computed(() => {
   const hasOne = !username.value && password.value || username.value && !password.value;
   return !!(hasNone || hasOne);
 });
-
-// Show/Hide the login switch depending on whether KeyCloak is enabled or not
-const displayLoginSwitch = computed(() => accountStore.availableAuthProviders.includes('keyCloakAuth'));
 </script>
 
 <style lang="scss" scoped>

--- a/ui/conductor/src/routes/login/LoginChoice.vue
+++ b/ui/conductor/src/routes/login/LoginChoice.vue
@@ -1,16 +1,12 @@
 <template>
   <div>
-    <template v-if="usingDeviceFlow">
-      <device-flow-login :scopes="['profile', 'roles']"/>
-    </template>
-    <template v-else>
-      <v-card-text :class="[{'mb-8': uiConfig.config.keycloak }, 'text-center mx-auto']" style="max-width: 320px;">
-        {{ keycloakMessage.top }}
+    <template v-if="canChooseKeyCloak">
+      <v-card-text class="text-center mx-auto" style="max-width: 320px;">
+        Please sign in to the Smart Core Operator App to unlock all features.
       </v-card-text>
-      <v-card-actions class="d-flex flex-column align-center justify-center">
+      <v-card-actions class="justify-center mt-4">
         <v-btn
-            v-if="uiConfig.config.keycloak"
-            @click="store.loginWithKeyCloak(['profile', 'roles'])"
+            @click="emit('choose', 'keyCloakAuth')"
             color="primary"
             block
             large
@@ -18,15 +14,43 @@
           Sign in
         </v-btn>
       </v-card-actions>
+      <template v-if="canChooseDevice">
+        <v-card-actions class="justify-center">
+          <a
+              @click="emit('choose', 'deviceFlow')"
+              class="text-body-1">
+            Or sign in using your device
+          </a>
+        </v-card-actions>
+      </template>
+    </template>
+
+    <template v-else-if="canChooseDevice">
+      <v-card-text class="text-center mx-auto" style="max-width: 320px;">
+        Please sign in to the Smart Core Operator App to unlock all features.
+      </v-card-text>
+      <v-card-actions class="justify-center mt-4">
+        <v-btn
+            @click="emit('choose', 'deviceFlow')"
+            color="primary"
+            block
+            large
+            class="text-body-1 font-weight-bold">
+          Sign in using your device
+        </v-btn>
+      </v-card-actions>
+    </template>
+
+    <template v-if="canChooseLocal">
       <v-card-text class="text-body-2 text-center mt-10 mx-auto" style="max-width: 350px;">
-        {{ keycloakMessage.bottom }}
+        If you are an administrator or need to setup your building, please sign in with a local account.
       </v-card-text>
       <v-card-actions class="d-flex flex-column align-center justify-center mt-n2">
         <v-btn
             block
             class="text-body-2 ma-0"
             text
-            @click="store.loginFormVisible = !store.loginFormVisible">
+            @click="emit('choose', 'localAuth')">
           Sign in with local Account
         </v-btn>
       </v-card-actions>
@@ -35,33 +59,13 @@
 </template>
 
 <script setup>
-import DeviceFlowLogin from '@/routes/login/DeviceFlowLogin.vue';
-import {useAccountStore} from '@/stores/account.js';
-import {useUiConfigStore} from '@/stores/ui-config';
+import {useAccountStore} from '@/stores/account';
 import {computed} from 'vue';
 
-const uiConfig = useUiConfigStore();
-const store = useAccountStore();
+const emit = defineEmits(['choose']);
+const accountStore = useAccountStore();
 
-// If device flow is configured, use it always.
-// Otherwise devices that have no input methods won't be able to pick it.
-const usingDeviceFlow = computed(() => {
-  return Boolean(uiConfig.config?.auth?.deviceFlow);
-});
-
-// Tweak the message depending on whether KeyCloak is enabled or not
-const keycloakMessage = computed(() => {
-  if (uiConfig.config?.keycloak) {
-    return {
-      top: 'Please sign in to the Smart Core Operator App to unlock all features.',
-      // eslint-disable-next-line max-len
-      bottom: 'If you are an administrator or need to setup your building, please sign in with a local account.'
-    };
-  } else {
-    return {
-      top: 'Please sign in to the Smart Core Operator App with your local account to unlock all features.',
-      bottom: 'Local accounts are used to setup Smart Core.'
-    };
-  }
-});
+const canChooseKeyCloak = computed(() => accountStore.hasProvider('keyCloakAuth'));
+const canChooseDevice = computed(() => accountStore.hasProvider('deviceFlow'));
+const canChooseLocal = computed(() => accountStore.hasProvider('localAuth'));
 </script>

--- a/ui/conductor/src/routes/login/LoginPage.vue
+++ b/ui/conductor/src/routes/login/LoginPage.vue
@@ -7,7 +7,12 @@
       </v-card-title>
 
       <LocalLogin v-if="displayLoginForm"/>
-      <LoginChoice v-else/>
+      <device-flow-login v-else-if="displayDeviceLogin"/>
+      <login-choice v-else @choose="chooseProvider"/>
+
+      <v-card-actions v-if="choiceExists && !displayChoice" class="d-flex justify-center mt-8">
+        <a @click="showChoice" class="text-center">Use a different sign in method</a>
+      </v-card-actions>
     </v-card>
     <v-btn
         v-if="uiConfig.config.disableAuthentication"
@@ -18,27 +23,68 @@
       <v-icon class="ml-n2">mdi-chevron-left</v-icon>
       Return to home
     </v-btn>
+
+    <v-snackbar v-model="snackbar.visible">
+      {{ snackbar.message }}
+
+      <template #action="{ attrs }">
+        <v-btn color="pink" text v-bind="attrs" @click="snackbar.visible = false">
+          Close
+        </v-btn>
+      </template>
+    </v-snackbar>
   </div>
 </template>
 <script setup>
 import BrandLogo from '@/components/BrandLogo.vue';
+import DeviceFlowLogin from '@/routes/login/DeviceFlowLogin.vue';
 import LocalLogin from '@/routes/login/LocalLogin.vue';
 import LoginChoice from '@/routes/login/LoginChoice.vue';
 import {useAccountStore} from '@/stores/account.js';
 import {useUiConfigStore} from '@/stores/ui-config';
-import {computed} from 'vue';
+import {storeToRefs} from 'pinia';
+import {computed, ref} from 'vue';
 
 const uiConfig = useUiConfigStore();
 const accountStore = useAccountStore();
+const {snackbar} = storeToRefs(accountStore);
 
+const manualDisplayLoginForm = ref(false);
 const displayLoginForm = computed(() => {
-  // If KeyCloak config available, we can toggle between login variants
-  if (uiConfig.config?.keycloak) {
-    return accountStore.loginFormVisible;
-
-    // If KeyCloak config not available, we can only use local login
-  } else {
-    return true;
-  }
+  return manualDisplayLoginForm.value || accountStore.isOnlyProvider('localAuth');
 });
+
+const manualDisplayDeviceLogin = ref(false);
+const displayDeviceLogin = computed(() => {
+  return manualDisplayDeviceLogin.value || accountStore.isOnlyProvider('deviceFlow');
+});
+
+// don't need a display ref for keycloak because it uses redirect, aka there is no page for it
+
+const choiceExists = computed(() => {
+  return accountStore.availableAuthProviders.length > 1;
+});
+const displayChoice = computed(() => {
+  return !displayLoginForm.value && !displayDeviceLogin.value;
+});
+
+const showChoice = () => {
+  manualDisplayLoginForm.value = false;
+  manualDisplayDeviceLogin.value = false;
+};
+const chooseProvider = (p) => {
+  switch (p) {
+    case 'localAuth':
+      manualDisplayLoginForm.value = true;
+      break;
+    case 'deviceFlow':
+      manualDisplayDeviceLogin.value = true;
+      break;
+    case 'keyCloakAuth':
+      // no page to display, redirect instead
+      accountStore.loginWithKeyCloak(['profile', 'roles']);
+      break;
+  }
+};
+
 </script>

--- a/ui/conductor/src/routes/router.js
+++ b/ui/conductor/src/routes/router.js
@@ -41,7 +41,7 @@ if (window) {
     // Initialize Local and Keycloak auth instances,
     // so we can check if the user is logged in and/or manage the login flow
     try {
-      await accountStore.initialise();
+      await accountStore.initialise(uiConfig.config?.auth?.providers);
     } catch (e) {
       console.error('Failed to initialize the account store', e);
     }


### PR DESCRIPTION
Before the list of options for logging in was determined by the setup process for those providers, i.e. if local succeeded but keycloak failed to init then you'd only see the u/p form. Now that behaviour is the default but you can explicitly mention the auth providers you want to use if you want to.

As part of this I've reorganised how auth is handled by the LoginPage. Before there were some very specific conditional code blocks for handling edge cases between local, keycloak, and device auth. These have all (mostly) been removed now and replaced with a more flexible mechanism to show choices or specific pages depending on the number of auth providers available.

Technically I could have split this PR into two changes:
1. Introduce the providers ui-config options and update account.js to use it
2. Refactor LoginPage and the rest of the ui to better support different auth provider combos

However the two are really only useful together, especially the testing part of it.

Jira: PRJ-140, PRJ-139