### PR TITLE
opsui/overview: export `raw meter readings` in CSV format

### DIFF
--- a/ui/conductor/src/routes/ops/overview/pages/widgets/energyAndDemand/EnergyGraph.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/widgets/energyAndDemand/EnergyGraph.vue
@@ -11,7 +11,7 @@
         <EnergyGraphOptionsMenu
             :duration-option.sync="durationOption"
             :show-conversion.sync="showConversion"
-            @exportCSV="exportMeteredData"/>
+            @exportCSV="meteredExportData('Meter Readings')"/>
       </template>
     </LineChart>
   </div>
@@ -124,7 +124,7 @@ const getIntensityValue = (range) => range.intensity.actual ?? range.intensity.f
 const yAxisUnit = computed(() => showConversion.value ? 'Grams of CO₂ / hour' : 'kW');
 
 // Fetch the metered and generated data based on the periodStart and periodEnd values and the durationOption's span
-const {seriesData: meteredSeriesData, exportData: exportMeteredData} =
+const {seriesData: meteredSeriesData, exportData: meteredExportData} =
     useMeterHistory(() => props.metered, periodStart, periodEnd, () => durationOption.value.span);
 const {seriesData: generatedSeriesData} =
     useMeterHistory(() => props.generated, periodStart, periodEnd, () => durationOption.value.span);

--- a/ui/conductor/src/routes/ops/overview/pages/widgets/energyAndDemand/EnergyGraph.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/widgets/energyAndDemand/EnergyGraph.vue
@@ -10,7 +10,8 @@
       <template #options>
         <EnergyGraphOptionsMenu
             :duration-option.sync="durationOption"
-            :show-conversion.sync="showConversion"/>
+            :show-conversion.sync="showConversion"
+            @exportCSV="exportMeteredData"/>
       </template>
     </LineChart>
   </div>
@@ -123,7 +124,7 @@ const getIntensityValue = (range) => range.intensity.actual ?? range.intensity.f
 const yAxisUnit = computed(() => showConversion.value ? 'Grams of CO₂ / hour' : 'kW');
 
 // Fetch the metered and generated data based on the periodStart and periodEnd values and the durationOption's span
-const {seriesData: meteredSeriesData} =
+const {seriesData: meteredSeriesData, exportData: exportMeteredData} =
     useMeterHistory(() => props.metered, periodStart, periodEnd, () => durationOption.value.span);
 const {seriesData: generatedSeriesData} =
     useMeterHistory(() => props.generated, periodStart, periodEnd, () => durationOption.value.span);

--- a/ui/conductor/src/routes/ops/overview/pages/widgets/energyAndDemand/EnergyGraphOptionsMenu.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/widgets/energyAndDemand/EnergyGraphOptionsMenu.vue
@@ -40,7 +40,7 @@
                 </template>
               </v-switch>
             </v-list-item>
-            <v-list-item class="pa-0 d-flex flex-row justify-center pt-1 px-3" dense>
+            <v-list-item class="pa-0 d-flex flex-row justify-center px-3" dense>
               <v-subheader class="text-body-2 pa-0">Duration</v-subheader>
               <v-spacer/>
               <v-btn-toggle
@@ -58,6 +58,12 @@
                   <span class="text-caption">{{ option.text }}</span>
                 </v-btn>
               </v-btn-toggle>
+            </v-list-item>
+            <v-list-item
+                class="pa-0 d-flex flex-row align-left align-center px-3 mb-n1"
+                dense
+                @click="emits('exportCSV')">
+              <v-subheader class="text-body-2 pa-0">Export CSV...</v-subheader>
             </v-list-item>
           </v-list>
         </v-menu>
@@ -82,7 +88,7 @@ const props = defineProps({
     default: false
   }
 });
-const emits = defineEmits(['update:durationOption', 'update:showConversion']);
+const emits = defineEmits(['update:durationOption', 'update:showConversion', 'exportCSV']);
 
 // Defining the options for the duration type buttons
 const durationOptions = [

--- a/ui/conductor/src/routes/ops/overview/pages/widgets/energyAndDemand/useMeterHistory.js
+++ b/ui/conductor/src/routes/ops/overview/pages/widgets/energyAndDemand/useMeterHistory.js
@@ -21,7 +21,8 @@ import {computed, ref, watch, watchEffect} from 'vue';
  *  now: import('vue').Ref<Date>,
  *  shouldFetch: import('vue').ComputedRef<boolean>,
  *  firstRecordTime: import('vue').ComputedRef<Date|null>,
- *  lastRecordTime: import('vue').ComputedRef<Date|null>
+ *  lastRecordTime: import('vue').ComputedRef<Date|null>,
+ *  exportData: () => Promise<void>
  * }}
  */
 export default function(name, periodStart, periodEnd, spanSize) {
@@ -273,6 +274,18 @@ export default function(name, periodStart, periodEnd, spanSize) {
     return data;
   });
 
+  // --------- Download data as CSV --------- //
+  // At the moment, we are only going to support the export of metered data
+  // as this is being billed, not like the generated data.
+  // The export will be done in a CSV format.
+  const exportData = async () => {
+    if (toValue(name) === '') {
+      return;
+    }
+
+    console.log('Exporting data as CSV');
+  };
+
   return {
     // the important data
     seriesData,
@@ -288,7 +301,8 @@ export default function(name, periodStart, periodEnd, spanSize) {
     lastFetchTime,
     fetchPeriod,
     now,
-    shouldFetch
+    shouldFetch,
+    exportData
   };
 };
 


### PR DESCRIPTION
This PR adds an app functionality, which gives the user the ability to **export raw meter readings in a CSV format**.
The change comes with a menu option on _Power/Energy Consumption widget -> Options button_, and is called **Export CSV...**.

When the user clicks this option, it triggers the following process:
**Existing records (raw meter readings)** are being grouped into span groups - where the `span` is being provided **by the active duration option** -, then **the last reading of each span groups** are being collected and processed for export into a CSV format, using the existing `downloadCSV` utility.

![Screenshot 2024-02-09 at 15 17 33](https://github.com/vanti-dev/sc-bos/assets/131772660/ad0c3d44-9c43-47ac-8c12-b74e253c4e32)

Jira: PRJ-117