### PR TITLE
opsui/overview: fix overview children navigation

### DIFF
--- a/ui/conductor/src/routes/ops/overview/pages/DynamicAreasOverview.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/DynamicAreasOverview.vue
@@ -36,7 +36,7 @@ const overViewStore = useOverviewStore();
 const {activeOverview} = storeToRefs(overViewStore);
 
 const uiConfig = useUiConfigStore();
-const overviewChildren = computed(() => uiConfig.config?.ops?.overview?.children || []);
+const overviewChildren = computed(() => uiConfig.config?.ops?.overview?.children);
 
 const pageStore = usePageStore();
 const graphWidth = computed(() => `min-width: calc(100% - 500px - ${pageStore.drawerWidth}px)`);
@@ -70,7 +70,9 @@ const displayRightColumn = computed(() => {
 });
 
 const findActiveOverview = computed(() => {
-  return findActiveItem(overviewChildren.value, props.pathSegments);
+  const encodePathSegments = props.pathSegments.map(encodeURIComponent);
+
+  return findActiveItem(overviewChildren.value, encodePathSegments);
 });
 
 watch(() => props.pathSegments, () => {
@@ -80,5 +82,5 @@ watch(() => props.pathSegments, () => {
   } else {
     activeOverview.value = findActiveOverview.value;
   }
-}, {immediate: true, deep: true});
+}, {immediate: true, deep: true, flush: 'sync'});
 </script>

--- a/ui/conductor/src/routes/ops/overview/route.js
+++ b/ui/conductor/src/routes/ops/overview/route.js
@@ -52,7 +52,7 @@ export default [
        * @property {string} icon - Icon identifier, e.g., 'mdi-select-all'.
        * @property {string} shortTitle - A short title for the item - for the mini sized navigation.
        * @property {string} title - The full title of the item.
-       * @property {Object} traits - Object containing various trait flags.
+       * @property {Object} widgets - Object containing various trait flags.
        * @property {boolean} widgets.showAirQuality - Flag to show air quality.
        * @property {boolean} widgets.showEmergencyLighting - Flag to show emergency lighting.
        * @property {boolean} widgets.showEnergyConsumption - Flag to show energy consumption.
@@ -64,7 +64,7 @@ export default [
        * @property {boolean} widgets.showPower - Flag to show power.
        * @property {OverviewChild[]} [children] - Optional array of children, each following the same structure.
        */
-      const overviewChildren = uiConfig.config?.ops?.overview?.children || [];
+      const overviewChildren = uiConfig.config?.ops?.overview?.children;
 
       // Split the modified path into segments and remove empty segments then return an array of the segments
       const currentPathSegments = modifiedPath(to.path).split('/').filter(segment => segment);

--- a/ui/conductor/src/util/router.js
+++ b/ui/conductor/src/util/router.js
@@ -72,8 +72,9 @@ export const findActiveItem = (children, childTitles) => {
     const formatTitle = (title) => encodeURIComponent(title);
 
     const foundItem = currentItems.find(
-        item => formatTitle(item.title) === formatTitle(title)
+        item => formatTitle(item.title) === title
     );
+
     if (!foundItem) break;
     result.push(foundItem);
     currentItems = foundItem.children || [];


### PR DESCRIPTION
During development, I've noticed that when we visit an existing overview-child path, or we navigate from a different main-path to an overview-child path, we end up being redirected to the overview page, instead of its child path.
This is fixed now.

Jira: N/A