### PR TITLE
opsui/overview: reorder widgets on overview-child path

### DIFF
--- a/ui/conductor/src/routes/ops/notifications/Notifications.vue
+++ b/ui/conductor/src/routes/ops/notifications/Notifications.vue
@@ -1,65 +1,73 @@
 <template>
-  <content-card>
-    <v-data-table
-        :headers="headers"
-        :items="alerts.pageItems"
-        disable-sort
-        :server-items-length="queryTotalCount"
-        :item-class="rowClass"
-        :options.sync="dataTableOptions"
-        :footer-props="setFooterProps"
-        :loading="alerts.loading"
-        class="pt-4"
-        :class="{ 'hide-pagination': modifyFooter }"
-        @click:row="showNotification">
-      <template #top>
-        <filters
-            v-if="!props.overviewPage"
-            :floor.sync="query.floor"
-            :floor-items="floors"
-            :zone.sync="query.zone"
-            :zone-items="zones"
-            :subsystem.sync="query.subsystem"
-            :subsystem-items="subsystems"
-            :acknowledged.sync="query.acknowledged"
-            :resolved.sync="query.acknowledged"/>
-      </template>
-      <template #item.createTime="{ item }">
-        {{ item.createTime.toLocaleString() }}
-      </template>
-      <template #item.subsystem="{ item }">
-        <subsystem-icon size="20px" :subsystem="item.subsystem" no-default/>
-      </template>
-      <template #item.source="{ item }">
-        <v-tooltip bottom>
-          <template #activator="{ on }">
-            <span v-on="on">{{ formatSource(item.source) }}</span>
-          </template>
-          <span>{{ item.source }}</span>
-        </v-tooltip>
-      </template>
-      <template #item.severity="{ item }">
-        <v-tooltip v-if="item.resolveTime" bottom>
-          <template #activator="{ on }">
-            <span v-on="on">RESOLVED</span>
-          </template>
-          Was:
-          <span :class="notifications.severityData(item.severity).color">
+  <div class="ml-3">
+    <v-row :class="['mt-0 ml-0 pl-0', {'pl-4 mt-1': props.overviewPage}]">
+      <h3 :class="['text-h3 pt-2 pb-6', {'text-h4': props.overviewPage}]">Notifications</h3>
+      <v-spacer/>
+    </v-row>
+
+    <content-card :class="['px-4', {'mt-8': !props.overviewPage}]">
+      <v-data-table
+          :headers="headers"
+          :items="alerts.pageItems"
+          disable-sort
+          :server-items-length="queryTotalCount"
+          :item-class="rowClass"
+          :options.sync="dataTableOptions"
+          :footer-props="setFooterProps"
+          :loading="alerts.loading"
+          class="pt-4"
+          :class="{ 'hide-pagination': modifyFooter }"
+          @click:row="showNotification">
+        <template #top>
+          <filters
+              v-if="!props.overviewPage"
+              class="mb-4 mt-n2"
+              :floor.sync="query.floor"
+              :floor-items="floors"
+              :zone.sync="query.zone"
+              :zone-items="zones"
+              :subsystem.sync="query.subsystem"
+              :subsystem-items="subsystems"
+              :acknowledged.sync="query.acknowledged"
+              :resolved.sync="query.acknowledged"/>
+        </template>
+        <template #item.createTime="{ item }">
+          {{ item.createTime.toLocaleString() }}
+        </template>
+        <template #item.subsystem="{ item }">
+          <subsystem-icon size="20px" :subsystem="item.subsystem" no-default/>
+        </template>
+        <template #item.source="{ item }">
+          <v-tooltip bottom>
+            <template #activator="{ on }">
+              <span v-on="on">{{ formatSource(item.source) }}</span>
+            </template>
+            <span>{{ item.source }}</span>
+          </v-tooltip>
+        </template>
+        <template #item.severity="{ item }">
+          <v-tooltip v-if="item.resolveTime" bottom>
+            <template #activator="{ on }">
+              <span v-on="on">RESOLVED</span>
+            </template>
+            Was:
+            <span :class="notifications.severityData(item.severity).color">
+              {{ notifications.severityData(item.severity).text }}
+            </span>
+          </v-tooltip>
+          <span v-else :class="notifications.severityData(item.severity).color">
             {{ notifications.severityData(item.severity).text }}
           </span>
-        </v-tooltip>
-        <span v-else :class="notifications.severityData(item.severity).color">
-          {{ notifications.severityData(item.severity).text }}
-        </span>
-      </template>
-      <template #item.acknowledged="{ item }">
-        <acknowledgement
-            :ack="item.acknowledgement"
-            @acknowledge="notifications.setAcknowledged(true, item, name)"
-            @unacknowledge="notifications.setAcknowledged(false, item, name)"/>
-      </template>
-    </v-data-table>
-  </content-card>
+        </template>
+        <template #item.acknowledged="{ item }">
+          <acknowledgement
+              :ack="item.acknowledgement"
+              @acknowledge="notifications.setAcknowledged(true, item, name)"
+              @unacknowledge="notifications.setAcknowledged(false, item, name)"/>
+        </template>
+      </v-data-table>
+    </content-card>
+  </div>
 </template>
 <script setup>
 import ContentCard from '@/components/ContentCard.vue';

--- a/ui/conductor/src/routes/ops/overview/pages/DynamicAreasOverview.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/DynamicAreasOverview.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid class="d-flex flex-column pt-0 pr-0">
+  <v-container fluid class="d-flex flex-column pt-0 pl-0 pr-3">
     <div class="d-flex flex-row flex-nowrap mb-2">
       <h3 class="text-h3 pt-2 pb-6">
         {{ overViewStore.getActiveOverview?.title }} Status Overview
@@ -9,7 +9,7 @@
       <v-col :class="[{ 'pr-0': !displayRightColumn }, 'ml-0 pl-0']" :style="graphWidth">
         <left-column v-if="displayLeftColumn" :item="overViewStore.getActiveOverview"/>
       </v-col>
-      <v-col v-if="displayRightColumn" cols="6" class="mr-0 pr-0 pt-0" style="width: 500px; max-width: 500px;">
+      <v-col v-if="displayRightColumn" cols="3" class="mr-0 pr-0 pt-0" style="width: 260px; max-width: 260px;">
         <right-column :item="overViewStore.getActiveOverview"/>
       </v-col>
     </v-row>

--- a/ui/conductor/src/routes/ops/overview/pages/components/LeftColumn.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/components/LeftColumn.vue
@@ -1,20 +1,25 @@
 <template>
   <div>
-    <!--    <TopRow-->
-    <!--        v-if="true"-->
-    <!--        class="pb-4 mb-7"-->
-    <!--        :item="props.item"/>-->
-
-    <ContentCard>
-      <h4 class="text-h4 pt-0 pt-lg-4 pl-4">Notifications</h4>
-      <notifications overview-page :zone="props.item?.widgets?.showNotification"/>
+    <content-card
+        v-if="props.item.widgets.showEnergyConsumption"
+        class="mt-1 pb-0 mb-8"
+        style="min-height:385px;">
+      <EnergyGraph
+          chart-title="Energy Consumption"
+          classes="pt-1 pb-2 ml-3 mr-5"
+          color="#ffc432"
+          color-middle="rgba(255, 196, 50, 0.35)"
+          :metered="props.item.widgets.showEnergyConsumption"/>
+    </content-card>
+    <ContentCard v-if="props.item.widgets.showNotifications" class="pt-4 pl-0">
+      <notifications overview-page :zone="props.item.widgets.showNotifications"/>
     </ContentCard>
   </div>
 </template>
 
 <script setup>
-// import TopRow from '@/routes/ops/overview/pages/components/TopRow.vue';
 import ContentCard from '@/components/ContentCard.vue';
+import EnergyGraph from '@/routes/ops/overview/pages/widgets/energyAndDemand/EnergyGraph.vue';
 import Notifications from '@/routes/ops/notifications/Notifications.vue';
 
 const props = defineProps({

--- a/ui/conductor/src/routes/ops/overview/pages/components/RightColumn.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/components/RightColumn.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="pt-1">
     <presence-card
         v-if="showWidget('showOccupancy')"
         class="mb-5"
@@ -11,25 +11,10 @@
         gauge-color="#ffc432"
         :name="environmentalValues.indoor"
         :external-name="environmentalValues.outdoor"/>
-
-    <content-card
-        v-if="showWidget('showEnergyConsumption')"
-        class="pb-0"
-        style="min-height:385px;">
-      <EnergyGraph
-          chart-title="Energy Consumption"
-          classes="pb-2 mr-1"
-          color="#ffc432"
-          color-middle="rgba(255, 196, 50, 0.35)"
-          :hide-legends="true"
-          :metered="widgets.showEnergyConsumption"/>
-    </content-card>
   </div>
 </template>
 
 <script setup>
-import ContentCard from '@/components/ContentCard.vue';
-import EnergyGraph from '@/routes/ops/overview/pages/widgets/energyAndDemand/EnergyGraph.vue';
 import EnvironmentalCard from '@/routes/ops/overview/pages/widgets/environmental/EnvironmentalCard.vue';
 import PresenceCard from '@/routes/ops/overview/pages/widgets/occupancy/PresenceCard.vue';
 import {computed} from 'vue';

--- a/ui/conductor/src/routes/ops/overview/pages/widgets/environmental/EnvironmentalCard.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/widgets/environmental/EnvironmentalCard.vue
@@ -1,6 +1,6 @@
 <template>
   <content-card class="mb-5 d-flex flex-column pt-7 pb-0">
-    <h4 class="text-h4 pl-4 pb-8 pt-0">Environmental</h4>
+    <h4 class="text-h4 pl-4 pb-8 pt-1">Environmental</h4>
     <div :class="['d-flex flex-row justify-center ml-n3', {'flex-wrap mb-4': props.shouldWrap}]">
       <v-col cols="auto" class="ma-0 pa-0">
         <circular-gauge

--- a/ui/conductor/src/routes/ops/overview/pages/widgets/occupancy/PresenceCard.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/widgets/occupancy/PresenceCard.vue
@@ -1,17 +1,16 @@
 <template>
-  <content-card class="mt-3 mb-3">
+  <content-card class="mt-3 pt-4 pb-5 mb-3">
     <div class="d-flex flex-row mb-2">
       <v-card-title class="text-h4 pl-4">Presence</v-card-title>
       <StatusAlert :resource="occupancyValue.streamError"/>
     </div>
     <v-col cols="12" class="d-flex flex-column pl-4">
       <v-row class="d-flex flex-row align-center px-3 pb-2">
-        <span v-if="occupancyValue.value" :class="[stateColor, 'text-h6 font-weight-bold']">
+        <span :class="[stateColor, 'text-h6 font-weight-bold pb-1 mt-n3']">
           {{ stateStr }}
         </span>
-        <v-spacer/>
-        <div class="d-flex flex-row ma-0 text-caption font-weight-regular">
-          <span class="mr-1">Last presence detected:</span>
+        <div class="d-flex flex-row align-start ma-0 text-caption font-weight-regular">
+          <span class="mr-1">Last updated:</span>
           <span>{{ timeAgo }}</span>
         </div>
       </v-row>


### PR DESCRIPTION
To make the `overview-child design` look more similar to the building overview page design, I've reordered the widgets we display on the page. Also contains label change _(on presence widget)_ and addition _(on notifications page)_

![Screenshot 2024-02-13 at 15 30 41](https://github.com/vanti-dev/sc-bos/assets/131772660/2d4968e2-5c7d-4bc7-9ec1-befba7f635b7)


Jira: N/A