### PR TITLE
opsui/overview: change `ops/overview` page template to have right `sidebar`

### DIFF
--- a/ui/conductor/src/routes/ops/overview/route.js
+++ b/ui/conductor/src/routes/ops/overview/route.js
@@ -4,7 +4,10 @@ import {findActiveItem} from '@/util/router.js';
 export default [
   {
     path: 'overview',
-    component: () => import('@/routes/ops/OpsHome.vue'),
+    components: {
+      default: () => import('@/routes/ops/OpsHome.vue'),
+      sidebar: () => import('@/routes/ops/notifications/NotificationSideBar.vue')
+    },
     redirect: 'overview/building',
     meta: {
       authentication: {


### PR DESCRIPTION
With the addition of the `notifications` table, we require a different layout template - so we can show/hide the past 10 notification / device details on the table row click.

Jira: PRJ-117