### PR TITLE
opsui/overview: fix an infinite component render loop

### DIFF
--- a/ui/conductor/src/routes/ops/overview/pages/DynamicAreasOverview.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/DynamicAreasOverview.vue
@@ -70,17 +70,15 @@ const displayRightColumn = computed(() => {
 });
 
 const findActiveOverview = computed(() => {
+  if (!props.pathSegments.length || !overviewChildren.value.length) return null;
+
   const encodePathSegments = props.pathSegments.map(encodeURIComponent);
 
   return findActiveItem(overviewChildren.value, encodePathSegments);
 });
 
-watch(() => props.pathSegments, () => {
-  // If no path segments are provided, we are on the root overview page
-  if (props.pathSegments.length === 0) {
-    activeOverview.value = null;
-  } else {
-    activeOverview.value = findActiveOverview.value;
-  }
+watch(findActiveOverview, (overviewChild) => {
+  // Set the active overview or null if not found
+  activeOverview.value = overviewChild;
 }, {immediate: true, deep: true, flush: 'sync'});
 </script>


### PR DESCRIPTION
While clicking between `overview-children` on the navigation bar, I've noticed in a console the following error:

`[Vue warn]: You may have an infinite update loop in a component render function.`

The cause of this error has been identified, and is now fixed.

Jira: PRJ-117