### PR TITLE
opsui/overview: fix `environmental` widget gauge alignment

### DIFF
--- a/ui/conductor/src/routes/ops/overview/pages/widgets/environmental/EnvironmentalCard.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/widgets/environmental/EnvironmentalCard.vue
@@ -1,7 +1,7 @@
 <template>
   <content-card class="mb-5 d-flex flex-column pt-7 pb-0">
     <h4 class="text-h4 pl-4 pb-8 pt-1">Environmental</h4>
-    <div :class="['d-flex flex-row justify-center ml-n3', {'flex-wrap mb-4': props.shouldWrap}]">
+    <div class="d-flex flex-column align-center mb-4">
       <v-col cols="auto" class="ma-0 pa-0">
         <circular-gauge
             v-if="indoorTemperature > 0 || props.shouldWrap"


### PR DESCRIPTION
From this:
![to be fixed](https://github.com/vanti-dev/sc-bos/assets/131772660/b8ab01d2-82d3-4980-8d8b-f3a45b92e9d2)


To this:
![fixed](https://github.com/vanti-dev/sc-bos/assets/131772660/60c22138-bfc8-4429-93d6-e1d48f27bef0)


Jira: PRJ-117