### PR TITLE
opsui/overview: remove set gauge color

### DIFF
--- a/ui/conductor/src/routes/ops/overview/pages/components/RightColumn.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/components/RightColumn.vue
@@ -8,7 +8,6 @@
     <environmental-card
         v-if="showWidget('showEnvironment')"
         class="mt-3"
-        gauge-color="#ffc432"
         :name="environmentalValues.indoor"
         :external-name="environmentalValues.outdoor"/>
   </div>


### PR DESCRIPTION
There was a prop which was setting the gauge color to other than the theme's `primary` value, which caused the gauge to not pick up theme color. This has been fixed.

Jira: PRJ-117