### PR TITLE
alerts/pgx: fix pagination in cases where create_time is the same

### DIFF
--- a/pkg/system/alerts/pgxalerts/pgx.go
+++ b/pkg/system/alerts/pgxalerts/pgx.go
@@ -393,7 +393,7 @@ func (s *Server) ListAlerts(ctx context.Context, request *gen.ListAlertsRequest)
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, "bad page token")
 		}
-		where = append(where, fmt.Sprintf(`create_time<=$%d OR (create_time=$%d AND id<=$%d)`, argIdx+1, argIdx+1, argIdx+2))
+		where = append(where, fmt.Sprintf(`create_time<$%d OR (create_time=$%d AND id<=$%d)`, argIdx+1, argIdx+1, argIdx+2))
 		args = append(args, pt.LastCreateTime, pt.LastID)
 		argIdx += 2
 	}


### PR DESCRIPTION
In the case where there are lots of alerts that share the same create_time we were returning the same page each time, even with a pageToken specified. Now we don't do that.