### PR TITLE
opsui/notifications: add ability to export `Notifications` into CSV

### DIFF
--- a/ui/conductor/src/routes/ops/notifications/Notifications.vue
+++ b/ui/conductor/src/routes/ops/notifications/Notifications.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="ml-3">
-    <v-row :class="['mt-0 ml-0 pl-0', {'pl-4 mt-1': props.overviewPage}]">
-      <h3 :class="['text-h3 pt-2 pb-6', {'text-h4': props.overviewPage}]">Notifications</h3>
+    <v-row v-if="!props.overviewPage" class="mt-0 ml-0 pl-0">
+      <h3 class="text-h3 pt-2 pb-6">Notifications</h3>
       <v-spacer/>
+      <v-btn class="mt-2 mr-3" color="neutral" @click="alerts.exportData('Notifications')">
+        Export CSV...
+      </v-btn>
     </v-row>
 
-    <content-card :class="['px-4', {'mt-8': !props.overviewPage}]">
+    <content-card :class="['px-8', {'mt-8 px-4': !props.overviewPage}]">
       <v-data-table
           :headers="headers"
           :items="alerts.pageItems"
@@ -19,17 +22,26 @@
           :class="{ 'hide-pagination': modifyFooter }"
           @click:row="showNotification">
         <template #top>
-          <filters
-              v-if="!props.overviewPage"
-              class="mb-4 mt-n2"
-              :floor.sync="query.floor"
-              :floor-items="floors"
-              :zone.sync="query.zone"
-              :zone-items="zones"
-              :subsystem.sync="query.subsystem"
-              :subsystem-items="subsystems"
-              :acknowledged.sync="query.acknowledged"
-              :resolved.sync="query.acknowledged"/>
+          <v-row :class="['mt-1 mb-2 ml-0 pl-0', {'mt-n4 mb-2 mr-2': props.overviewPage}]">
+            <h3 v-if="props.overviewPage" :class="['text-h3 pt-2 pb-6', {'text-h4': props.overviewPage}]">
+              Notifications
+            </h3>
+            <v-spacer/>
+            <filters
+                v-if="!props.overviewPage"
+                class="mb-4 mt-n2"
+                :floor.sync="query.floor"
+                :floor-items="floors"
+                :zone.sync="query.zone"
+                :zone-items="zones"
+                :subsystem.sync="query.subsystem"
+                :subsystem-items="subsystems"
+                :acknowledged.sync="query.acknowledged"
+                :resolved.sync="query.acknowledged"/>
+            <v-btn v-if="props.overviewPage" class="mt-2" color="primary" @click="alerts.exportData('Notifications')">
+              Export CSV...
+            </v-btn>
+          </v-row>
         </template>
         <template #item.createTime="{ item }">
           {{ item.createTime.toLocaleString() }}

--- a/ui/conductor/src/routes/ops/overview/pages/components/LeftColumn.vue
+++ b/ui/conductor/src/routes/ops/overview/pages/components/LeftColumn.vue
@@ -2,16 +2,14 @@
   <div>
     <content-card
         v-if="props.item.widgets.showEnergyConsumption"
-        class="mt-1 pb-0 mb-8"
+        class="mt-1 pb-0 mb-7"
         style="min-height:385px;">
       <EnergyGraph
           chart-title="Energy Consumption"
           classes="pt-1 pb-2 ml-3 mr-5"
-          color="#ffc432"
-          color-middle="rgba(255, 196, 50, 0.35)"
           :metered="props.item.widgets.showEnergyConsumption"/>
     </content-card>
-    <ContentCard v-if="props.item.widgets.showNotifications" class="pt-4 pl-0">
+    <ContentCard v-if="props.item.widgets.showNotifications" class="mt-1 pt-4 pl-0">
       <notifications overview-page :zone="props.item.widgets.showNotifications"/>
     </ContentCard>
   </div>

--- a/ui/conductor/src/util/downloadCSV.js
+++ b/ui/conductor/src/util/downloadCSV.js
@@ -44,7 +44,7 @@ export const csvDownload = async (params) => {
       const label = params.acronyms[key]?.label || camelToSentence(key);
       // Add unit if it exists
       const unit = params.acronyms[key]?.unit ? `(${params.acronyms[key].unit})` : '';
-      headerMap[key] = `${capitalize(label)} ${unit}`;
+      headerMap[key] = `${capitalize(label)}${unit !== '' ? ' ' + unit : ''}`;
     });
     return headerMap;
   };


### PR DESCRIPTION
As per a client request, now we have the ability to export notifications in CSV format.
The functionality is available for `all` _(under `Notifications` nav option)_ or `per overview page` _(when selecting an available sub-overview page within `Building Overview`)_.

![Exporting notifications](https://github.com/vanti-dev/sc-bos/assets/131772660/d993b4c9-7ee4-40df-b5ed-47cf21eb7f05)


Jira: PRJ-115