### PR TITLE
zone/lights!: don't put `/lights/` between the base and key name for lightGroups

### DIFF
--- a/pkg/zone/feature/lighting/config/root.go
+++ b/pkg/zone/feature/lighting/config/root.go
@@ -9,5 +9,5 @@ type Root struct {
 
 	ReadOnlyLights bool                `json:"readOnlyLights,omitempty"`
 	Lights         []string            `json:"lights,omitempty"`      // Announces as {zone}
-	LightGroups    map[string][]string `json:"lightGroups,omitempty"` // Announced as {zone}/lights/{key}
+	LightGroups    map[string][]string `json:"lightGroups,omitempty"` // Announced as {zone}/{key}
 }

--- a/pkg/zone/feature/lighting/lighting.go
+++ b/pkg/zone/feature/lighting/lighting.go
@@ -67,7 +67,7 @@ func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
 			readOnly: cfg.ReadOnlyLights,
 			logger:   logger.With(zap.String("lightGroup", key)),
 		}
-		name := fmt.Sprintf("%s/lights/%s", cfg.Name, key)
+		name := fmt.Sprintf("%s/%s", cfg.Name, key)
 		f.devices.Add(lights...)
 		announce.Announce(name, node.HasTrait(trait.Light, node.WithClients(light.WrapApi(group))))
 	}


### PR DESCRIPTION
Before configuring lightGroups like `"lightGroups:{"foo": [...]}` would announce a device like `{base}/lights/foo`. This bucks the convention of all other zone features and reduced the utility of it.

This change it technically breaking but I found no uses of `"lightGroups"` outside example config in all our repos so I think we'll be ok.