### PR TITLE
opsui/router: reset sidebar display on nav change

### DIFF
--- a/ui/conductor/src/routes/router.js
+++ b/ui/conductor/src/routes/router.js
@@ -49,11 +49,9 @@ if (window) {
     // ------------------------ Data store logic ------------------------ //
 
     const pageStore = usePageStore();
-    const mainPathFrom = from.path.split('/')[1];
-    const mainPathTo = to.path.split('/')[1];
 
-    // Reset the sidebar to defaults if the main path has changed
-    if (mainPathFrom !== mainPathTo) {
+    // Reset the sidebar to defaults if the path has changed
+    if (to.path !== from.path) {
       pageStore.resetSidebarToDefaults();
     }
 

--- a/ui/conductor/src/stores/page.js
+++ b/ui/conductor/src/stores/page.js
@@ -33,6 +33,7 @@ export const usePageStore = defineStore('page', () => {
     sidebarData.value = {};
     listedDevice.value = {};
     sidebarTitle.value = '';
+    showSidebar.value = false;
   };
 
   //


### PR DESCRIPTION
The right hand sidebar stayed on screen with the previously selected data when we've navigated away from a page. This is fixed.

Jira: N/A