### PR TITLE
driver/bacnet/marge: Add artus unit support

### DIFF
--- a/pkg/driver/bacnet/merge/air_temperature.go
+++ b/pkg/driver/bacnet/merge/air_temperature.go
@@ -152,7 +152,6 @@ func (t *airTemperature) pollPeer(ctx context.Context) (*traits.AirTemperature, 
 			if err != nil {
 				return comm.ErrReadProperty{Prop: "setPoint", Cause: err}
 			}
-			t.logger.Debug("DEAN: got set point: ", zap.Float64("setPoint", setPoint))
 			data.TemperatureGoal = &traits.AirTemperature_TemperatureSetPoint{
 				TemperatureSetPoint: &types.Temperature{ValueCelsius: setPoint},
 			}


### PR DESCRIPTION
Adds in support for setting high/low deadband config regisiters required to control the Artus unit at Arup. Appreciate this might  not be the best way of doing this but it pretty clean and it works on site. Happy to create another ticket to refactor this to a more generalised solution after Arup's done. Closes [SC-447]