### PR TITLE
auto/udmi/config: add set password to mqtt broker opts

### DIFF
--- a/pkg/auto/udmi/config/mqtt.go
+++ b/pkg/auto/udmi/config/mqtt.go
@@ -1,6 +1,11 @@
 package config
 
-import mqtt "github.com/eclipse/paho.mqtt.golang"
+import (
+	"os"
+	"strings"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+)
 
 type MQTTBroker struct {
 	Host         string `json:"host,omitempty"`
@@ -12,6 +17,23 @@ type MQTTBroker struct {
 func (b MQTTBroker) ClientOptions() (*mqtt.ClientOptions, error) {
 	opts := mqtt.NewClientOptions()
 	opts.AddBroker(b.Host)
+	password := b.Password
+	if password == "" {
+		if b.PasswordFile != "" {
+			var passFileBody []byte
+			passFileBody, err := os.ReadFile(b.PasswordFile)
+			if err != nil {
+				return nil, err
+			} else {
+				password = strings.TrimSpace(string(passFileBody))
+			}
+		}
+	}
+
+	if password != "" { // allow connection without password if no password provided
+		opts.SetPassword(password)
+	}
+
 	opts.SetUsername(b.Username)
 	opts.SetOrderMatters(false)
 	return opts, nil


### PR DESCRIPTION
The password and password file options were configurable, but nothing was using them. This PR just sets the password in the broker options if one was provided