### PR TITLE
expose alert admin api on hub

### DIFF
--- a/pkg/system/proxy/factory.go
+++ b/pkg/system/proxy/factory.go
@@ -150,7 +150,7 @@ func (s *System) announceHub(ctx context.Context, hubConn *grpc.ClientConn) (tas
 		// non-trait routed apis
 		undos = append(undos, announcer.Announce(hubName, node.HasMetadata(lastChange.Metadata), node.HasClient(
 			gen.NewAlertApiClient(hubConn),
-			// gen.NewAlertAdminApiClient(hubConn), // Don't do this, we don't want external control of this
+			gen.NewAlertAdminApiClient(hubConn), // Don't do this, we don't want external control of this // SC-469
 		)))
 
 		// this is the same logic that you find in announceNodeApis


### PR DESCRIPTION
:D can now access the hub's AlertAdminApi from the Edge Gateway

I have created this task SC-469  to re-undo this once we have a better way