### PR TITLE
auth: add missing Content-Type header to client credential token responses

### DIFF
--- a/internal/auth/tenant/token_server.go
+++ b/internal/auth/tenant/token_server.go
@@ -196,6 +196,7 @@ func (s *TokenServer) passwordFlow(ctx context.Context, writer http.ResponseWrit
 		return errors.New("failed to marshal response")
 	}
 
+	writer.Header().Set("Content-Type", "application/json")
 	_, err = writer.Write(responseBytes)
 	if err != nil {
 		return errors.New("failed to write response body")

--- a/internal/auth/tenant/token_server.go
+++ b/internal/auth/tenant/token_server.go
@@ -156,6 +156,7 @@ func (s *TokenServer) clientCredentialsFlow(ctx context.Context, writer http.Res
 		return errors.New("failed to marshal response")
 	}
 
+	writer.Header().Set("Content-Type", "application/json")
 	_, err = writer.Write(responseBytes)
 	if err != nil {
 		return errors.New("failed to write response body")


### PR DESCRIPTION
Without this the clientcredentials package fails to parse the response, assuming it's a form body and not json.