### PR TITLE
auto/meteremail: add configurable retries & backoff timing 

### DIFF
--- a/cmd/tools/test-meteremail/main.go
+++ b/cmd/tools/test-meteremail/main.go
@@ -73,7 +73,7 @@ func main() {
 		"timeout" : "9s",
 		"backoffStart" : "19s",
 		"backoffMax" : "59s",
-		"noRetries" : 7
+		"numRetries" : 7
 	}
 }`
 

--- a/cmd/tools/test-meteremail/main.go
+++ b/cmd/tools/test-meteremail/main.go
@@ -68,7 +68,13 @@ func main() {
 	"waterMeters" : [ 
 					"watermeter1",
 					"watermeter2"
-					]
+					],
+	"timing" : {
+		"timeout" : "9s",
+		"backoffStart" : "19s",
+		"backoffMax" : "59s",
+		"noRetries" : 7
+	}
 }`
 
 	_, err = lifecycle.Configure([]byte(cfg))

--- a/cmd/tools/test-meteremail/main.go
+++ b/cmd/tools/test-meteremail/main.go
@@ -86,5 +86,5 @@ func main() {
 		panic(err)
 	}
 
-	time.Sleep(60 * time.Second)
+	time.Sleep(5 * time.Second)
 }

--- a/cmd/tools/test-meteremail/main.go
+++ b/cmd/tools/test-meteremail/main.go
@@ -2,20 +2,31 @@
 package main
 
 import (
-	"context"
-	"os"
-	"os/signal"
 	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/vanti-dev/sc-bos/pkg/auto"
 	"github.com/vanti-dev/sc-bos/pkg/auto/meteremail"
+	"github.com/vanti-dev/sc-bos/pkg/gen"
+	"github.com/vanti-dev/sc-bos/pkg/gentrait/meter"
 	"github.com/vanti-dev/sc-bos/pkg/node"
 	"github.com/vanti-dev/sc-bos/pkg/node/alltraits"
 )
 
 var sampleNow = time.Date(2024, 01, 19, 0, 0, 0, 0, time.Local)
+
+func addDummyMeters(root *node.Node) {
+	var models []*meter.Model
+	meterNames := []string{"elecmeter1", "elecmeter2", "watermeter1", "watermeter2"}
+	for _, meterName := range meterNames {
+		m := meter.NewModel()
+		m.RecordReading(123.45)
+		models = append(models, m)
+		client := node.WithClients(gen.WrapMeterApi(meter.NewModelServer(m)))
+		root.Announce(meterName, node.HasTrait(meter.TraitName, client))
+	}
+}
 
 func main() {
 	logger, err := zap.NewDevelopment()
@@ -24,6 +35,7 @@ func main() {
 	}
 	root := node.New("test")
 	alltraits.AddSupport(root)
+	addDummyMeters(root)
 
 	now, _ := time.Parse(time.DateTime, "2023-11-15 11:36:00")
 	now = now.Round(time.Second) // get rid of millis, etc
@@ -40,35 +52,23 @@ func main() {
 	lifecycle := meteremail.Factory.New(serv)
 	defer lifecycle.Stop()
 	cfg := `{
-	"name": "emails", "type": "meteremail",
+	"name": "emails", 
+	"type": "meteremail",
 	"destination": {
 	"host": "smtp.gmail.com",
 	"from": "OCW Paradise Build <vantiocwdev@gmail.com>",
 	"to": ["Dean Redfern <dean.redfern@vanti.co.uk>"],
 	"passwordFile" : ".localpassword",
-	"sendTime": "0 0 * * MON-FRI"
+	"sendTime": "* * * * MON-FRI"
 	},
-	"serverAddr" : "172.16.100.10:23557",
 	"electricMeters" : [
-					"uk-ocw/floors/01/devices/CE1-electric-meter/WestDBA/T1HVACTotalEnergy",
-					"uk-ocw/floors/01/devices/CE1-electric-meter/WestDBA/T1LightingTotalEnergy",
-					"uk-ocw/floors/01/devices/CE1-electric-meter/WestDBA/T1TotalLoadTotalEnergy",
-					"uk-ocw/floors/01/devices/CE2-electric-meter/SouthSideDBB/T1LPHVACTotalEnergy",
-					"uk-ocw/floors/01/devices/CE2-electric-meter/SouthSideDBB/T1LPLightingTotalEnergy",
-					"uk-ocw/floors/01/devices/CE2-electric-meter/SouthSideDBB/T1LPTotalLoadTotalEnergy",
-					"uk-ocw/floors/06/devices/CE11-electric-meter/WestDBA/T6HVACTotalEnergy",
-					"uk-ocw/floors/06/devices/CE11-electric-meter/WestDBA/T6LightingTotalEnergy",
-					"uk-ocw/floors/06/devices/CE11-electric-meter/WestDBA/T6TotalLoadTotalEnergy",
-					"uk-ocw/floors/06/devices/CE12-electric-meter/EASTSideDBB/T6HVACTotalEnergy",
-					"uk-ocw/floors/06/devices/CE12-electric-meter/EASTSideDBB/T6LightingTotalEnergy",
-					"uk-ocw/floors/06/devices/CE12-electric-meter/EASTSideDBB/T6TotalLoadTotalEnergy"
+					"elecmeter1",
+					"elecmeter2"
 					],
 	"waterMeters" : [ 
-					"uk-ocw/floors/01/devices/CE1-water-meter/FirstFloorWestBCWSMeter",
-					"uk-ocw/floors/01/devices/CE2-water-meter/1stFloorEastBCWSMeter",
-					"uk-ocw/floors/06/devices/CE11-water-meter/SixthFloorWestBCWSMeter",
-					"uk-ocw/floors/06/devices/CE12-water-meter/6thFloorEastBCWSMeter"],
-	"insecureSkipVerify" : true
+					"watermeter1",
+					"watermeter2"
+					]
 }`
 
 	_, err = lifecycle.Configure([]byte(cfg))
@@ -80,7 +80,5 @@ func main() {
 		panic(err)
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer stop()
-	<-ctx.Done()
+	time.Sleep(60 * time.Second)
 }

--- a/pkg/auto/meteremail/auto.go
+++ b/pkg/auto/meteremail/auto.go
@@ -187,8 +187,8 @@ func applyDefaults(timing *config.Timing) {
 	if timing.Timeout.Duration == 0 {
 		timing.Timeout = jsontypes.Duration{Duration: 10 * time.Second}
 	}
-	if timing.NoRetries == 0 {
-		timing.NoRetries = 3
+	if timing.NumRetries == 0 {
+		timing.NumRetries = 3
 	}
 	if timing.BackoffStart.Duration == 0 {
 		timing.BackoffStart = jsontypes.Duration{Duration: 2 * time.Second}
@@ -293,7 +293,7 @@ func (a *autoImpl) applyConfig(ctx context.Context, cfg config.Root) error {
 func retry(ctx context.Context, timing *config.Timing, f func(context.Context) error) error {
 	return task.Run(ctx, func(ctx context.Context) (task.Next, error) {
 		return 0, f(ctx)
-	}, task.WithBackoff(timing.BackoffStart.Duration, timing.BackoffMax.Duration), task.WithRetry(timing.NoRetries))
+	}, task.WithBackoff(timing.BackoffStart.Duration, timing.BackoffMax.Duration), task.WithRetry(timing.NumRetries))
 }
 
 func retryT[T any](ctx context.Context, timing *config.Timing, f func(context.Context) (T, error)) (T, error) {

--- a/pkg/auto/meteremail/config/root.go
+++ b/pkg/auto/meteremail/config/root.go
@@ -52,10 +52,10 @@ type Source struct {
 }
 
 type Timing struct {
-	Timeout      time.Duration `json:"timeout,omitempty"`
-	BackoffStart time.Duration `json:"backoffStart,omitempty"`
-	BackoffMax   time.Duration `json:"backoffMax,omitempty"`
-	NoRetries    int           `json:"noRetries,omitempty"`
+	Timeout      jsontypes.Duration `json:"timeout,omitempty"`
+	BackoffStart jsontypes.Duration `json:"backoffStart,omitempty"`
+	BackoffMax   jsontypes.Duration `json:"backoffMax,omitempty"`
+	NoRetries    int                `json:"noRetries,omitempty"`
 }
 
 type Root struct {

--- a/pkg/auto/meteremail/config/root.go
+++ b/pkg/auto/meteremail/config/root.go
@@ -51,20 +51,22 @@ type Source struct {
 	Subsystem string `json:"subsystem,omitempty"`
 }
 
+type Timing struct {
+	Timeout      time.Duration `json:"timeout,omitempty"`
+	BackoffStart time.Duration `json:"backoffStart,omitempty"`
+	BackoffMax   time.Duration `json:"backoffMax,omitempty"`
+	NoRetries    int           `json:"noRetries,omitempty"`
+}
+
 type Root struct {
 	auto.Config
 	// Configuration information for how to send the email.
-	Destination Destination `json:"destination,omitempty"`
-
-	Source Source `json:"source,omitempty"`
-
-	Now func() time.Time `json:"-"`
-
-	ElectricMeters []string `json:"electricMeters,omitempty"`
-
-	WaterMeters []string `json:"waterMeters,omitempty"`
-
-	Timeout time.Duration `json:"timeout,omitempty"`
+	Destination    Destination      `json:"destination,omitempty"`
+	Source         Source           `json:"source,omitempty"`
+	Now            func() time.Time `json:"-"`
+	ElectricMeters []string         `json:"electricMeters,omitempty"`
+	WaterMeters    []string         `json:"waterMeters,omitempty"`
+	Timing         Timing           `json:"timing,omitempty"`
 }
 
 type AttachmentCfg struct {

--- a/pkg/auto/meteremail/config/root.go
+++ b/pkg/auto/meteremail/config/root.go
@@ -55,7 +55,7 @@ type Timing struct {
 	Timeout      jsontypes.Duration `json:"timeout,omitempty"`
 	BackoffStart jsontypes.Duration `json:"backoffStart,omitempty"`
 	BackoffMax   jsontypes.Duration `json:"backoffMax,omitempty"`
-	NoRetries    int                `json:"noRetries,omitempty"`
+	NumRetries   int                `json:"numRetries,omitempty"`
 }
 
 type Root struct {


### PR DESCRIPTION
Removes hardcoded backoffStart, backoffMax and noRetries when sending meteremails and allows these to be configured from config. If not present in config then default values are set.

Fixes test-meteremail program & adds new timing config to test program