### PR TITLE
auto/meteremail: make email title configurable

### DIFF
--- a/cmd/tools/test-meteremail/main.go
+++ b/cmd/tools/test-meteremail/main.go
@@ -74,6 +74,10 @@ func main() {
 		"backoffStart" : "19s",
 		"backoffMax" : "59s",
 		"numRetries" : 7
+	},
+	"templateArgs" : {
+		"emailTitle" : "hello title",
+		"subjectTemplate" : "hello subject"
 	}
 }`
 

--- a/pkg/auto/meteremail/auto.go
+++ b/pkg/auto/meteremail/auto.go
@@ -240,8 +240,9 @@ func (a *autoImpl) applyConfig(ctx context.Context, cfg config.Root) error {
 			}
 
 			attrs := Attrs{
-				Now:   t,
-				Stats: []Stats{},
+				Now:          t,
+				Stats:        []Stats{},
+				TemplateArgs: cfg.TemplateArgs,
 			}
 
 			logger.Debug("Meter email is being generated...", zap.Duration("timeout", cfg.Timing.Timeout.Duration))

--- a/pkg/auto/meteremail/template.go
+++ b/pkg/auto/meteremail/template.go
@@ -18,6 +18,7 @@ type Attrs struct {
 	ReadingsByFloorZone  map[string]map[string][]Stats // map floor -> zone -> reading
 	EnergySummaryReports []SummaryReport
 	WaterSummaryReports  []SummaryReport
+	TemplateArgs         config.TemplateArgs
 }
 
 // grab the floors and sort them so we can iterate over consistently


### PR DESCRIPTION
Removes the hardcoded OCW from sc-bos auto & adds template args to config.

https://vanti.youtrack.cloud/issue/SC-479/remove-client-string-from-meteremail-auto-body