### PR TITLE
util/fetch: allow multi-level sub domains when using wildcard in cert

### DIFF
--- a/internal/util/fetch/json.go
+++ b/internal/util/fetch/json.go
@@ -2,9 +2,13 @@ package fetch
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
+	"strings"
 )
 
 func JSON(ctx context.Context, url string, into any, options ...Option) error {
@@ -16,6 +20,57 @@ func JSON(ctx context.Context, url string, into any, options ...Option) error {
 	}
 
 	client := o.httpClient
+	client.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+
+				roots := x509.NewCertPool()
+
+				// this loop performs the normal verification of all certs in the chain starting with the root
+				for i := len(rawCerts) - 1; i >= 0; i-- {
+					rawCert := rawCerts[i]
+					c, _ := x509.ParseCertificate(rawCert)
+					certItem, _ := x509.ParseCertificate(rawCert)
+
+					if i == len(rawCerts)-1 {
+						// this is the root cert, verify this using the system defaults, no custom Roots
+						opts := x509.VerifyOptions{}
+						if _, err := certItem.Verify(opts); err != nil {
+							return err
+						}
+					} else {
+						opts := x509.VerifyOptions{
+							Roots: roots,
+						}
+						if _, err := certItem.Verify(opts); err != nil {
+							return err
+						}
+					}
+
+					roots.AddCert(c)
+				}
+
+				// now we verify the host name on the leaf, allowing for a wildcard which spans n-level subdomains
+				leafCert, _ := x509.ParseCertificate(rawCerts[0])
+				if err := leafCert.VerifyHostname(url); err != nil {
+					if strings.HasPrefix(leafCert.Subject.CommonName, "*") {
+						domainSuffix := leafCert.Subject.CommonName[1:]
+						trimmedProtocol := strings.TrimPrefix(url, "https://")
+						host, _, _ := net.SplitHostPort(trimmedProtocol)
+
+						if !strings.HasSuffix(host, domainSuffix) {
+							return err
+						}
+					} else {
+						return err
+					}
+				}
+
+				return nil
+			},
+		},
+	}
 	response, err := client.Do(request)
 	if err != nil {
 		return err


### PR DESCRIPTION
Allows validation of certifcates that use single wildcards for hosts with multiple sub-domain prefixes. More detail in the link below:

https://vanti.youtrack.cloud/issue/SC-528/Add-ability-for-http-client-to-validate-certificate-that-uses-wildcard