### PR TITLE
auth: allow operators to start/stop lighting tests

### DIFF
--- a/pkg/auth/policy/default/smartcore.bos.driver.dali.DaliApi.rego
+++ b/pkg/auth/policy/default/smartcore.bos.driver.dali.DaliApi.rego
@@ -1,0 +1,9 @@
+package smartcore.bos.driver.dali.DaliApi
+
+import future.keywords.in
+import data.scutil.token.token_has_role
+
+allow {
+  token_has_role("operator")
+  input.method in ["StartTest", "StopTest"]
+}

--- a/pkg/auth/policy/default/test_general.rego
+++ b/pkg/auth/policy/default/test_general.rego
@@ -59,6 +59,11 @@ test_operator_ConfigureService_zones {
   }, ["operator"])
   data.smartcore.bos.ServicesApi.allow with input as input
 }
+test_operator_DaliApi {
+  data.smartcore.bos.driver.dali.DaliApi.allow with input as user_request("smartcore.bos.driver.dali.DaliApi", "StartTest", {}, ["operator"])
+  data.smartcore.bos.driver.dali.DaliApi.allow with input as user_request("smartcore.bos.driver.dali.DaliApi", "StopTest", {}, ["operator"])
+  not data.smartcore.bos.driver.dali.DaliApi.allow with input as user_request("smartcore.bos.driver.dali.DaliApi", "DeleteTestResult", {}, ["operator"])
+}
 
 tenant_request(service, method, request, zones) := input {
   input := {


### PR DESCRIPTION
Adjust the OPA policies to grant access to these methods if you are an operator.

Issue: SC-540