### PR TITLE
SC-547: build container with arm64 support

### DIFF
--- a/.github/workflows/build-sc-bos.yml
+++ b/.github/workflows/build-sc-bos.yml
@@ -31,11 +31,18 @@ jobs:
       - name: Test
         run: go test -v ./...
 
-      - name: Build for Linux (use with Docker)
+      - name: Build for Linux amd64 (use with Docker)
         run: go build -o .build/linux-amd64/sc-bos github.com/vanti-dev/sc-bos/cmd/bos
         env:
           GOOS: linux
           GOARCH: amd64
+          CGO_ENABLED: 0
+
+      - name: Build for Linux arm64 (use with Docker)
+        run: go build -o .build/linux-arm64/sc-bos github.com/vanti-dev/sc-bos/cmd/bos
+        env:
+          GOOS: linux
+          GOARCH: arm64
           CGO_ENABLED: 0
 
       - name: Build for Beckhoff
@@ -56,6 +63,7 @@ jobs:
         run: |
           mkdir -p .out
           tar -czf .out/sc-bos_${{ github.ref_name }}_linux-amd64.tar.gz -C .build/linux-amd64 .
+          tar -czf .out/sc-bos_${{ github.ref_name }}_linux-arm64.tar.gz -C .build/linux-arm64 .
           tar -czf .out/sc-bos_${{ github.ref_name }}_freebsd-amd64.tar.gz -C .build/freebsd-amd64 .
           tar -czf .out/sc-bos_${{ github.ref_name }}_win-amd64.tar.gz -C .build/win-amd64 .
 

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -70,11 +70,6 @@ jobs:
           mv .downloads/ops-ui/* .downloads/
         if: ${{ env.ACT }}
 
-      - name: Untar sc-bos
-        run: |
-          mkdir -p .build/sc-bos
-          tar -xzf .downloads/sc-bos_*_linux-amd64.tar.gz -C .build/sc-bos
-
       - name: Untar ops-ui
         run: |
           mkdir -p .build/ops-ui
@@ -99,7 +94,11 @@ jobs:
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
-      - name: Build and push Docker image
+      - name: Untar sc-bos (amd64)
+        run: |
+          mkdir -p .build/sc-bos
+          tar -xzf .downloads/sc-bos_*_linux-amd64.tar.gz -C .build/sc-bos
+      - name: Build and push Docker image (amd64)
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -107,3 +106,19 @@ jobs:
           push: ${{ !env.ACT }}
           tags: ghcr.io/vanti-dev/sc-bos:${{ env.TAG_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+
+      - name: Untar sc-bos (arm64)
+        run: |
+          rm -rf .build/sc-bos
+          mkdir -p .build/sc-bos
+          tar -xzf .downloads/sc-bos_*_linux-arm64.tar.gz -C .build/sc-bos
+      - name: Build and push Docker image (amd64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          # only push if not running locally using act
+          push: ${{ !env.ACT }}
+          tags: ghcr.io/vanti-dev/sc-bos:${{ env.TAG_NAME }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64


### PR DESCRIPTION
Build sc-bos and the sc-bos container image for arm64 Linux.

Good for testing on Macs.