### PR TITLE
actions: fix multiarch container builds

### DIFF
--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -91,28 +91,19 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Untar sc-bos (amd64)
         run: |
-          mkdir -p .build/sc-bos
-          tar -xzf .downloads/sc-bos_*_linux-amd64.tar.gz -C .build/sc-bos
-      - name: Build and push Docker image (amd64)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          # only push if not running locally using act
-          push: ${{ !env.ACT }}
-          tags: ghcr.io/vanti-dev/sc-bos:${{ env.TAG_NAME }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
+          mkdir -p .build/sc-bos/linux/amd64
+          tar -xzf .downloads/sc-bos_*_linux-amd64.tar.gz -C .build/sc-bos/linux/amd64
 
       - name: Untar sc-bos (arm64)
         run: |
-          rm -rf .build/sc-bos
-          mkdir -p .build/sc-bos
-          tar -xzf .downloads/sc-bos_*_linux-arm64.tar.gz -C .build/sc-bos
+          mkdir -p .build/sc-bos/linux/arm64
+          tar -xzf .downloads/sc-bos_*_linux-arm64.tar.gz -C .build/sc-bos/linux/arm64
+
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image (amd64)
         uses: docker/build-push-action@v5
         with:
@@ -121,4 +112,4 @@ jobs:
           push: ${{ !env.ACT }}
           tags: ghcr.io/vanti-dev/sc-bos:${{ env.TAG_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM alpine:3.18
 LABEL vendor="Vanti Ltd"
 
-COPY .build/sc-bos /app/
+# automatically populated by the builder
+# will be 'linux/amd64' or 'linux/arm64' etc.
+ARG TARGETPLATFORM
+
+COPY .build/sc-bos/${TARGETPLATFORM} /app/
 COPY .build/ops-ui/ /app/ops-ui/
 COPY default/cfg/ /cfg/
 COPY default/ui-config/ /app/ui-config/


### PR DESCRIPTION
Multiarch containers are only uploaded correctly by docker/build-push-action if they are all done together.

If uploaded in multiple steps, the newest will overwrite the oldest and the image is not multiarch.

Tweak Dockerfile to look in arch-specific directory for copying in build artifacts. Modify action to extract to the correct directories.

Fixes the code introduced in #242 