### PR TITLE
actions: use buildx to enable multiplatform builds

### DIFF
--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -75,6 +75,10 @@ jobs:
           mkdir -p .build/ops-ui
           tar -xzf .downloads/ops-ui*.tar.gz -C .build/ops-ui
 
+      # Buildx is necessary for multi-platform builds
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         if: ${{ !env.ACT }}


### PR DESCRIPTION
I realised I can test this before it's in main and I promise [it works now](https://github.com/vanti-dev/sc-bos/pkgs/container/sc-bos/226947343?tag=v0.0.0-test-multiarch)