### PR TITLE
Dockerfile to build sc-bos entirely

### DIFF
--- a/.github/docker/prebuilt.Dockerfile
+++ b/.github/docker/prebuilt.Dockerfile
@@ -1,0 +1,22 @@
+# This dockerfile is for copying in pre-built binaries and assets.
+# It is used by the GitHub Action docker-package.yml build process to create the release docker containers.
+
+FROM alpine:3.18
+LABEL vendor="Vanti Ltd"
+
+# automatically populated by the builder
+# will be 'linux/amd64' or 'linux/arm64' etc.
+ARG TARGETPLATFORM
+
+COPY .build/sc-bos/${TARGETPLATFORM} /app/
+COPY .build/ops-ui/ /app/ops-ui/
+COPY default/cfg/ /cfg/
+COPY default/ui-config/ /app/ui-config/
+
+EXPOSE 443
+EXPOSE 23557
+EXPOSE 7000-7999
+
+VOLUME ["/cfg", "/data"]
+
+ENTRYPOINT ["/app/sc-bos", "--appconf=/cfg/app.conf.json", "--sysconf=/cfg/system.conf.json", "--data=/data"]

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -112,6 +112,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: .github/docker/prebuilt.Dockerfile
           # only push if not running locally using act
           push: ${{ !env.ACT }}
           tags: ghcr.io/vanti-dev/sc-bos:${{ env.TAG_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,53 @@
-FROM alpine:3.18
+# Dockerfile for sc-bos
+# This dockerfile performs the entire build itself.
+# To enable fetching of private dependencies, an npmrc file must be be injected using a secret.
+#
+# To build, assuming your .npmrc is set up on your machine, run:
+#     docker/podman build --secret=id=npmrc,src=$HOME/.npmrc .
+
+FROM --platform=$BUILDPLATFORM node:20 AS build_ui
+
+WORKDIR /src
+
+ENV YARN_CACHE_FOLDER=/yarn-cache
+
+COPY ui/conductor/package.json ui/conductor/yarn.lock ./
+RUN --mount=type=cache,target=/yarn-cache \
+    --mount=type=secret,id=npmrc,target=/root/.npmrc \
+    yarn install --frozen-lockfile --check-files
+
+COPY ui/conductor ./
+ARG GIT_VERSION="(unknown)"
+ENV GIT_VERSION=$GIT_VERSION
+RUN yarn build
+
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine3.20 AS build_go
+
+RUN apk add --no-cache git
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download -x
+
+COPY cmd ./cmd/
+COPY internal ./internal/
+COPY pkg ./pkg/
+
+# set by the build engine
+ARG TARGETARCH
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=$TARGETARCH
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go build -o sc-bos ./cmd/bos
+
+FROM alpine:3.20
 LABEL vendor="Vanti Ltd"
 
-# automatically populated by the builder
-# will be 'linux/amd64' or 'linux/arm64' etc.
-ARG TARGETPLATFORM
-
-COPY .build/sc-bos/${TARGETPLATFORM} /app/
-COPY .build/ops-ui/ /app/ops-ui/
+COPY --from=build_go /src/sc-bos /app/
+COPY --from=build_ui /src/dist /app/ops-ui/
 COPY default/cfg/ /cfg/
 COPY default/ui-config/ /app/ui-config/
 

--- a/ui/conductor/package.json
+++ b/ui/conductor/package.json
@@ -47,7 +47,6 @@
     "eslint-plugin-jsdoc": "^48.1.0",
     "eslint-plugin-vue": "^9.8.0",
     "eslint-plugin-vuetify": "^1.1.0",
-    "git-revision-vite-plugin": "^0.0.11",
     "glob": "^8.0.3",
     "pkijs": "^3.0.15",
     "sass": "~1.32",

--- a/ui/conductor/yarn.lock
+++ b/ui/conductor/yarn.lock
@@ -1043,11 +1043,6 @@ get-caller-file@^2.0.1:
   resolved "https://nexus.vanti.co.uk/repository/npm-public/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-git-revision-vite-plugin@^0.0.11:
-  version "0.0.11"
-  resolved "https://nexus.vanti.co.uk/repository/npm-public/git-revision-vite-plugin/-/git-revision-vite-plugin-0.0.11.tgz#fc44d0679d0ba47f6b2533d47804e4faa47899f3"
-  integrity sha512-WEzkQ8y65y0LdYwDx+6YxQA4lFgSFXXo8femf1P9mvZzGrs6Jtr3hkb5uwnlCGaVcdKknOXQopZa9BK5R7MrQQ==
-
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"


### PR DESCRIPTION
This isn't part of a ticket, but I was doing some related work on another repo and though sc-bos could benefit from the same thing.

Add a new Dockerfile which performs the build process internally, instead of copying in prebuilt artifacts. Move the old Dockerfile, and use it in the Github Action as before, so there's no behaviour change to the CI here (we could modify this later).

The new Dockerfile allows the user to simply run `docker/podman build -t sc-bos --secret=id=npmrc,src=$HOME/.npmrc .` and they will have a working sc-bos docker container. This is a smoother developer experience.

Multi-stage builds are used to ensure the final image is minimal, and doesn't contain the build tools or secrets. Cross-compilation is supported (using the `--platform` argument to `docker build`).