### PR TITLE
auto/meteremail: Meteremail multiple recipients

### DIFF
--- a/cmd/tools/test-meteremail/main.go
+++ b/cmd/tools/test-meteremail/main.go
@@ -57,7 +57,7 @@ func main() {
 	"destination": {
 	"host": "smtp.gmail.com",
 	"from": "OCW Paradise Build <vantiocwdev@gmail.com>",
-	"to": ["Dean Redfern <dean.redfern@vanti.co.uk>"],
+	"to": ["Dean Redfern <dean.redfern@vanti.co.uk>", "Vanti OCW Dev <vantiocwdev@gmail.com>"],
 	"passwordFile" : ".localpassword",
 	"sendTime": "* * * * MON-FRI"
 	},

--- a/pkg/auto/meteremail/email.go
+++ b/pkg/auto/meteremail/email.go
@@ -35,11 +35,13 @@ func sendEmail(dst config.Destination, attachment config.AttachmentCfg, attrs At
 
 	// To
 	var addrs []string
+	toString := ""
 	for _, a := range p.To {
 		addrs = append(addrs, a.Address)
-		fmt.Fprintf(buf, "To: %s\n", a.String())
+		toString += a.String() + ", "
 	}
 
+	fmt.Fprintf(buf, "To: %s\n", strings.TrimSuffix(toString, ", "))
 	fmt.Fprintf(buf, "MIME-Version: 1.0\n")
 
 	// Main message


### PR DESCRIPTION
Add support to send to multiple recipients, just wrap a loop around what we already have. 
Google no longers support multiple recipients in the to header https://westoahu.hawaii.edu/it/news/googleuh-gmail-will-reject-messages-with-non-compliant-headers-beginning-april-24-2023/ 
