### PR TITLE
auth: use protojson to marshal requests into policy inputs

### DIFF
--- a/pkg/auth/policy/grpc_test.go
+++ b/pkg/auth/policy/grpc_test.go
@@ -1,0 +1,101 @@
+package policy
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/trait/onoff"
+)
+
+func TestInterceptor(t *testing.T) {
+	lis := bufconn.Listen(1024 * 1024)
+
+	compiler, err := ast.CompileModules(regoFiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	interceptor := NewInterceptor(&static{compiler: compiler})
+	server := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(interceptor.GRPCUnaryInterceptor()),
+		grpc.ChainStreamInterceptor(interceptor.GRPCStreamingInterceptor()),
+	)
+	traits.RegisterOnOffApiServer(server, onoff.NewModelServer(onoff.NewModel()))
+	go func() {
+		if err := server.Serve(lis); err != nil {
+			t.Errorf("server stopped with error: %v", err)
+		}
+	}()
+
+	t.Cleanup(func() {
+		if err := lis.Close(); err != nil {
+			t.Logf("failed to close listener: %v", err)
+		}
+		server.Stop()
+	})
+
+	ctx := context.Background()
+	conn, err := grpc.DialContext(ctx, "",
+		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := traits.NewOnOffApiClient(conn)
+
+	// check simple name based auth, global for all smartcore.* apis
+	_, err = client.GetOnOff(ctx, &traits.GetOnOffRequest{Name: "allow"})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	_, err = client.GetOnOff(ctx, &traits.GetOnOffRequest{Name: "deny"})
+	if err == nil {
+		t.Error("expected error")
+	}
+	if c := status.Code(err); c != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", err)
+	}
+
+	// check action based auth, specific to this trait
+	_, err = client.UpdateOnOff(ctx, &traits.UpdateOnOffRequest{Name: "any", OnOff: &traits.OnOff{State: traits.OnOff_ON}})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	_, err = client.UpdateOnOff(ctx, &traits.UpdateOnOffRequest{Name: "any", OnOff: &traits.OnOff{State: traits.OnOff_OFF}})
+	if err == nil {
+		t.Error("expected error")
+	}
+	if c := status.Code(err); c != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", err)
+	}
+}
+
+var regoFiles = map[string]string{
+	"smartcore.rego": `package smartcore
+
+# This simple rule allows any request whose name is "allow", all other requests are denied
+allow {
+	input.request.name == "allow"
+}
+`,
+	"smartcore.traits.OnOffApi.rego": `package smartcore.traits.OnOffApi
+
+# This rule allows people to turn any device on (but not off)
+allow {
+	input.method == "UpdateOnOff"
+	input.request.onOff.state == "ON"
+}
+`,
+}

--- a/pkg/auth/policy/policy.go
+++ b/pkg/auth/policy/policy.go
@@ -25,6 +25,7 @@ type Attributes struct {
 	// gRPC request message for unary and server streaming calls.
 	// For client and bidirectional streaming calls, Request is initially nil, but will contain the latest stream
 	// message once Stream.Open is true.
+	// Request, when not nil, is guaranteed to work correctly with json.Marshal, no other guarantees are made.
 	Request any `json:"request"`
 
 	CertificatePresent bool              `json:"certificate_present"` // A client cert was provided

--- a/pkg/auth/policy/rego_test.go
+++ b/pkg/auth/policy/rego_test.go
@@ -2,9 +2,9 @@ package policy
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
-	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/vanti-dev/sc-bos/pkg/auth/token"
 )
 
@@ -12,7 +12,7 @@ func BenchmarkPolicy(b *testing.B) {
 	attrs := Attributes{
 		Service:    "smartcore.traits.OnOff",
 		Method:     "UpdateOnOff",
-		Request:    &traits.UpdateOnOffRequest{Name: "test", OnOff: &traits.OnOff{State: traits.OnOff_ON}},
+		Request:    json.RawMessage(`{"name":"test","onOff":{"state":"ON"}}`),
 		TokenValid: true,
 		TokenClaims: token.Claims{
 			Roles:  []string{"admin"},


### PR DESCRIPTION
To correctly convert proto messages to OPA policy data we need to reliably be able to convert those messages to json.
The protojson package is a much better fit for this than the json package, which is the default used by OPA.
Unfortunately there's no easy way to hook into specific type marshalling of inputs, so we convert it before passing to the OPA evaluation.

This PR is part of the work to enable user editable config, via supporting dynamic services in the gateway/proxy.