### PR TITLE
SC-606: Fix case of calling stop in task.PollErr and more tasks running

### DIFF
--- a/pkg/task/poll.go
+++ b/pkg/task/poll.go
@@ -147,6 +147,11 @@ func (p poller) poll(ctx context.Context, run func(context.Context) error) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			if ctx.Err() != nil {
+				// If both <-ctx.Done() and <-ticker.C are ready, <-ticker.C could be selected, which we don't want.
+				// If the context is complete, we want to stop the poll immediately.
+				return
+			}
 		}
 	}
 }

--- a/pkg/task/poll_test.go
+++ b/pkg/task/poll_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestPollErr(t *testing.T) {
 	t.Run("repeats", func(t *testing.T) {
-		runCount := 0
+		var runCount atomic.Int32
 		action := func(ctx context.Context) error {
-			runCount++
+			runCount.Add(1)
 			return nil
 		}
 		ctx, stop := context.WithCancel(context.Background())
@@ -25,8 +25,8 @@ func TestPollErr(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		stop()
 
-		if runCount < 2 {
-			t.Errorf("expected at least 2 runs, got %d", runCount)
+		if c := runCount.Load(); c < 2 {
+			t.Errorf("expected at least 2 runs, got %d", c)
 		}
 	})
 
@@ -55,9 +55,9 @@ func TestPollErr(t *testing.T) {
 	})
 
 	t.Run("uses err backoff", func(t *testing.T) {
-		runCount := 0
+		var runCount atomic.Int32
 		action := func(ctx context.Context) error {
-			runCount++
+			runCount.Add(1)
 			return errors.New("expected test error")
 		}
 		ctx, stop := context.WithCancel(context.Background())
@@ -70,8 +70,8 @@ func TestPollErr(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		stop()
 
-		if runCount < 2 {
-			t.Errorf("expected at least 2 runs, got %d", runCount)
+		if c := runCount.Load(); c < 2 {
+			t.Errorf("expected at least 2 runs, got %d", c)
 		}
 	})
 }


### PR DESCRIPTION
Because select is nondeterministic when multiple cases are ready, Poll/PollErr might run one time extra after the context is cancelled. This is because the ticker channel may already contain an element sent during the previous poll operation. Add an explicit check for a completed context before checking for a tick.