### PR TITLE
Update actions to stop Node version warning

### DIFF
--- a/.github/workflows/build-sc-bos.yml
+++ b/.github/workflows/build-sc-bos.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           cache: true
           go-version: '1.22.x'

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,8 +12,8 @@ jobs:
     env:
       GOPRIVATE: github.com/smart-core-os/*,github.com/vanti-dev/*
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           cache: true
           go-version: '^1.22.5'


### PR DESCRIPTION
We use some outdated actions, which run on Node 16. This produces a deprecation warning in Github.

Upgrade versions to latest to remove this warning.