### PR TITLE
fix intermittent test failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ results_*.csv
 .secret/
 .secrets/
 .build/
+.vscode

--- a/pkg/auto/lights/auto_test.go
+++ b/pkg/auto/lights/auto_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/olebedev/emitter"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -75,7 +76,7 @@ func TestPirsTurnLightsOn(t *testing.T) {
 		t.Fatalf("Configure: %v", err)
 	}
 
-	processComplete := automation.bus.On("process-complete")
+	processComplete := automation.bus.On("process-complete", emitter.Sync)
 	waitForState := func(test func(state *ReadState) bool) (time.Duration, error) {
 		t.Helper()
 		timeout := time.NewTimer(500 * time.Millisecond)


### PR DESCRIPTION
fix: order emitter bus elements to prevent rare test failure condition
  `pkg/auto/lights/auto_test.go` -> the lack of ordering on the bus means some states were being played later than usual causing the `waitForState()` call on line 158 to race ahead to the next assertion before the **_**actual**_** call to updateBrightness had been issued.


fix: move config changes up to mitigate risk of config not yet being applied before states are processed
  sometimes, in very rare cases, the config passed from the test isn't applied before calls to `setOccupancy` are issued, meaning the timestamps look at real time instead of unix zero time. There is still a very very low risk this can happen, but trying to sync the config with the first call to `setOccupancy` seemed like overkill for now.