### PR TITLE
all: add auto/driver service blocks

### DIFF
--- a/pkg/auto/azureiot/config.go
+++ b/pkg/auto/azureiot/config.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/smart-core-os/sc-golang/pkg/trait"
+	"github.com/vanti-dev/sc-bos/pkg/block"
 	"github.com/vanti-dev/sc-bos/pkg/util/jsontypes"
 )
 
@@ -126,4 +127,17 @@ func hostWithDefaultPort(s string, p int) string {
 		return net.JoinHostPort(s, fmt.Sprintf("%d", p))
 	}
 	return s
+}
+
+var Blocks = []block.Block{
+	{
+		Path: []string{"devices"},
+		Key:  "name",
+		Blocks: []block.Block{
+			{Path: []string{"children"}, Key: "name"},
+			{Path: []string{"registrationID"}},
+			{Path: []string{"connectionString"}},
+		},
+	},
+	{Path: []string{"remoteNode"}},
 }

--- a/pkg/auto/azureiot/factory.go
+++ b/pkg/auto/azureiot/factory.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vanti-dev/sc-bos/internal/iothub"
 	"github.com/vanti-dev/sc-bos/internal/iothub/auth"
 	"github.com/vanti-dev/sc-bos/pkg/auto"
+	"github.com/vanti-dev/sc-bos/pkg/block"
 	"github.com/vanti-dev/sc-bos/pkg/task/service"
 )
 
@@ -30,6 +31,10 @@ func (f factory) New(services auto.Services) service.Lifecycle {
 	a := &Auto{services: services}
 	a.Service = service.New(service.MonoApply(a.applyConfig), service.WithParser(ParseConfig))
 	return a
+}
+
+func (f factory) ConfigBlocks() []block.Block {
+	return Blocks
 }
 
 type Auto struct {

--- a/pkg/auto/meteremail/auto.go
+++ b/pkg/auto/meteremail/auto.go
@@ -16,6 +16,7 @@ import (
 	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/vanti-dev/sc-bos/pkg/auto"
 	"github.com/vanti-dev/sc-bos/pkg/auto/meteremail/config"
+	"github.com/vanti-dev/sc-bos/pkg/block"
 	"github.com/vanti-dev/sc-bos/pkg/gen"
 	"github.com/vanti-dev/sc-bos/pkg/task"
 	"github.com/vanti-dev/sc-bos/pkg/task/service"
@@ -38,6 +39,10 @@ func (f factory) New(services auto.Services) service.Lifecycle {
 	a.Service = service.New(service.MonoApply(a.applyConfig), service.WithParser(config.ReadBytes))
 	a.Logger = a.Logger.Named(AutoName)
 	return a
+}
+
+func (_ factory) ConfigBlocks() []block.Block {
+	return config.Blocks
 }
 
 // getMeterReadingAndSource gets the meter reading for the given meter and also the location metadata for the meter

--- a/pkg/auto/meteremail/config/root.go
+++ b/pkg/auto/meteremail/config/root.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/vanti-dev/sc-bos/pkg/auto"
+	"github.com/vanti-dev/sc-bos/pkg/block"
 	"github.com/vanti-dev/sc-bos/pkg/util/jsontypes"
 )
 
@@ -260,3 +261,14 @@ const DefaultEmailBody = `<html lang="en">
 </body>
 </html>
 `
+
+var Blocks = []block.Block{
+	{
+		Path: []string{"destination"},
+		Blocks: []block.Block{
+			{Path: []string{"to"}},
+			{Path: []string{"sendTime"}},
+		},
+	},
+	{Path: []string{"templateArgs"}},
+}

--- a/pkg/block/mdblock/md.go
+++ b/pkg/block/mdblock/md.go
@@ -1,0 +1,21 @@
+package mdblock
+
+import (
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/vanti-dev/sc-bos/pkg/block"
+)
+
+// Categories contains a block for each top level metadata category: location, membership, etc.
+var Categories = func() []block.Block {
+	msg := (&traits.Metadata{}).ProtoReflect()
+	desc := msg.Descriptor()
+	fields := desc.Fields()
+	blocks := make([]block.Block, 0, fields.Len())
+	for i := 0; i < fields.Len(); i++ {
+		field := fields.Get(i)
+		blocks = append(blocks, block.Block{
+			Path: []string{field.JSONName()},
+		})
+	}
+	return blocks
+}()

--- a/pkg/driver/airthings/config.go
+++ b/pkg/driver/airthings/config.go
@@ -9,6 +9,8 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 
 	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/vanti-dev/sc-bos/pkg/block"
+	"github.com/vanti-dev/sc-bos/pkg/block/mdblock"
 	"github.com/vanti-dev/sc-bos/pkg/driver"
 	"github.com/vanti-dev/sc-bos/pkg/util/jsontypes"
 )
@@ -123,4 +125,20 @@ func (c ClientSecret) Read() (string, error) {
 		return "", fmt.Errorf("%w: %q", err, c.ClientSecretFile)
 	}
 	return strings.TrimSpace(string(bs)), nil
+}
+
+var Blocks = []block.Block{
+	{
+		Path: []string{"locations"},
+		Key:  "id",
+		Blocks: []block.Block{
+			{
+				Path: []string{"devices"},
+				Key:  "id",
+				Blocks: []block.Block{
+					{Path: []string{"metadata"}, Blocks: mdblock.Categories},
+				},
+			},
+		},
+	},
 }

--- a/pkg/driver/airthings/driver.go
+++ b/pkg/driver/airthings/driver.go
@@ -17,6 +17,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/vanti-dev/sc-bos/pkg/block"
 	"github.com/vanti-dev/sc-bos/pkg/driver"
 	"github.com/vanti-dev/sc-bos/pkg/driver/airthings/api"
 	"github.com/vanti-dev/sc-bos/pkg/driver/airthings/local"
@@ -39,6 +40,10 @@ func (f factory) New(services driver.Services) service.Lifecycle {
 	}
 	d.Service = service.New(service.MonoApply(d.applyConfig))
 	return d
+}
+
+func (_ factory) ConfigBlocks() []block.Block {
+	return Blocks
 }
 
 type Driver struct {

--- a/pkg/driver/bacnet/config/root.go
+++ b/pkg/driver/bacnet/config/root.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/smart-core-os/sc-api/go/traits"
 	bactypes "github.com/vanti-dev/gobacnet/types"
+	"github.com/vanti-dev/sc-bos/pkg/block"
+	"github.com/vanti-dev/sc-bos/pkg/block/mdblock"
 
 	"github.com/vanti-dev/sc-bos/pkg/driver"
 )
@@ -155,4 +157,29 @@ func (d DestinationAddress) Bytes() ([]byte, error) {
 		addr = append(addr, byte(value))
 	}
 	return addr, nil
+}
+
+var Blocks = []block.Block{
+	{Path: []string{"metadata"}, Blocks: mdblock.Categories},
+	{
+		Path: []string{"devices"},
+		Key:  "id",
+		Blocks: []block.Block{
+			{Path: []string{"metadata"}, Blocks: mdblock.Categories},
+			{
+				Path: []string{"objects"},
+				Key:  "id",
+				Blocks: []block.Block{
+					{Path: []string{"metadata"}, Blocks: mdblock.Categories},
+				},
+			},
+		},
+	},
+	{
+		Path: []string{"traits"},
+		Key:  "name",
+		Blocks: []block.Block{
+			{Path: []string{"metadata"}, Blocks: mdblock.Categories},
+		},
+	},
 }

--- a/pkg/driver/bacnet/driver.go
+++ b/pkg/driver/bacnet/driver.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vanti-dev/gobacnet"
 	bactypes "github.com/vanti-dev/gobacnet/types"
 	"github.com/vanti-dev/gobacnet/types/objecttype"
+	"github.com/vanti-dev/sc-bos/pkg/block"
 	"github.com/vanti-dev/sc-bos/pkg/driver"
 	"github.com/vanti-dev/sc-bos/pkg/driver/bacnet/adapt"
 	"github.com/vanti-dev/sc-bos/pkg/driver/bacnet/config"
@@ -39,6 +40,10 @@ type factory struct{}
 
 func (_ factory) New(services driver.Services) service.Lifecycle {
 	return NewDriver(services)
+}
+
+func (_ factory) ConfigBlocks() []block.Block {
+	return config.Blocks
 }
 
 func (_ factory) AddSupport(supporter node.Supporter) {

--- a/pkg/driver/mock/config/root.go
+++ b/pkg/driver/mock/config/root.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/vanti-dev/sc-bos/pkg/block"
+	"github.com/vanti-dev/sc-bos/pkg/block/mdblock"
 	"github.com/vanti-dev/sc-bos/pkg/driver"
 )
 
@@ -12,4 +14,12 @@ type Root struct {
 
 type Device struct {
 	*traits.Metadata
+}
+
+var Blocks = []block.Block{
+	{
+		Path:   []string{"devices"},
+		Key:    "name",
+		Blocks: mdblock.Categories,
+	},
 }

--- a/pkg/driver/mock/driver.go
+++ b/pkg/driver/mock/driver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/smart-core-os/sc-golang/pkg/trait/parent"
 	"github.com/smart-core-os/sc-golang/pkg/trait/publication"
 	"github.com/smart-core-os/sc-golang/pkg/trait/vending"
+	"github.com/vanti-dev/sc-bos/pkg/block"
 	"github.com/vanti-dev/sc-bos/pkg/driver"
 	"github.com/vanti-dev/sc-bos/pkg/driver/mock/auto"
 	"github.com/vanti-dev/sc-bos/pkg/driver/mock/config"
@@ -49,6 +50,10 @@ type factory struct{}
 
 func (_ factory) New(services driver.Services) service.Lifecycle {
 	return NewDriver(services)
+}
+
+func (_ factory) ConfigBlocks() []block.Block {
+	return config.Blocks
 }
 
 func NewDriver(services driver.Services) *Driver {


### PR DESCRIPTION
This PR adds a few config blocks to some autos and drivers as a sample for how this should be done.

The blocks aren't added to all built in services, as the block system can be updated over time when we need to. However, I feel like these are a good starting point and should make the user config editing a bit more useful.

If we find in the future that we're writing tools that update only a small part of this config we can update the blocks then.
Similarly if/when we write dedicated forms for each of the drivers to edit the config outside a json editor, we can update them then too.

Fixes SC-629