### PR TITLE
appconf: correctly handle empty type when updating service config

### DIFF
--- a/pkg/app/appconf/store.go
+++ b/pkg/app/appconf/store.go
@@ -104,6 +104,10 @@ func updateServiceConfig[T any](services []T, name, typ string, data []byte, ops
 				return services, errors.New("type cannot be changed")
 			}
 		}
+		// when updating an existing service, use the existing type if not provided
+		if typ == "" {
+			_, typ = ops.getMetadata(serviceCfg)
+		}
 		serviceCfg = ops.update(serviceCfg, typ, data)
 		services[idx] = serviceCfg
 	}

--- a/pkg/app/appconf/store_test.go
+++ b/pkg/app/appconf/store_test.go
@@ -1,0 +1,150 @@
+package appconf
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap"
+
+	"github.com/vanti-dev/sc-bos/pkg/auto"
+	"github.com/vanti-dev/sc-bos/pkg/driver"
+	"github.com/vanti-dev/sc-bos/pkg/zone"
+)
+
+func TestDriverStore_SaveConfig(t *testing.T) {
+	store := setupStoreServiceTest(t)
+	driverStore := store.Drivers()
+	err := driverStore.SaveConfig(context.TODO(), "foodriver", "",
+		[]byte(`{"name": "foodriver", "type": "bar", "property": "bazmodified"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := Config{
+		Drivers: []driver.RawConfig{
+			{
+				BaseConfig: driver.BaseConfig{Name: "foodriver", Type: "bar"},
+				Raw:        []byte(`{"name": "foodriver", "type": "bar", "property": "bazmodified"}`),
+			},
+		},
+		Automation: []auto.RawConfig{
+			{
+				Config: auto.Config{Name: "fooauto", Type: "bar"},
+				Raw:    []byte(`{"name": "fooauto", "type": "bar", "property": "baz"}`),
+			},
+		},
+		Zones: []zone.RawConfig{
+			{
+				Config: zone.Config{Name: "foozone", Type: "bar"},
+				Raw:    []byte(`{"name": "foozone", "type": "bar", "property": "baz"}`),
+			},
+		},
+	}
+
+	active := store.Active()
+	if diff := cmp.Diff(expect, active); diff != "" {
+		t.Fatalf("unexpected active config (-want +got)\n: %s", diff)
+	}
+}
+
+func TestAutomationStore_SaveConfig(t *testing.T) {
+	store := setupStoreServiceTest(t)
+	autoStore := store.Automations()
+
+	err := autoStore.SaveConfig(context.TODO(), "fooauto", "",
+		[]byte(`{"name": "fooauto", "type": "bar", "property": "bazmodified"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := Config{
+		Drivers: []driver.RawConfig{
+			{
+				BaseConfig: driver.BaseConfig{Name: "foodriver", Type: "bar"},
+				Raw:        []byte(`{"name": "foodriver", "type": "bar", "property": "baz"}`),
+			},
+		},
+		Automation: []auto.RawConfig{
+			{
+				Config: auto.Config{Name: "fooauto", Type: "bar"},
+				Raw:    []byte(`{"name": "fooauto", "type": "bar", "property": "bazmodified"}`),
+			},
+		},
+		Zones: []zone.RawConfig{
+			{
+				Config: zone.Config{Name: "foozone", Type: "bar"},
+				Raw:    []byte(`{"name": "foozone", "type": "bar", "property": "baz"}`),
+			},
+		},
+	}
+
+	if diff := cmp.Diff(expect, store.Active()); diff != "" {
+		t.Fatalf("unexpected active config (-want +got)\n: %s", diff)
+	}
+}
+
+func TestZoneStore_SaveConfig(t *testing.T) {
+	store := setupStoreServiceTest(t)
+	zoneStore := store.Zones()
+	err := zoneStore.SaveConfig(context.TODO(), "foozone", "",
+		[]byte(`{"name": "foozone", "type": "bar", "property": "bazmodified"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := Config{
+		Drivers: []driver.RawConfig{
+			{
+				BaseConfig: driver.BaseConfig{Name: "foodriver", Type: "bar"},
+				Raw:        []byte(`{"name": "foodriver", "type": "bar", "property": "baz"}`),
+			},
+		},
+		Automation: []auto.RawConfig{
+			{
+				Config: auto.Config{Name: "fooauto", Type: "bar"},
+				Raw:    []byte(`{"name": "fooauto", "type": "bar", "property": "baz"}`),
+			},
+		},
+		Zones: []zone.RawConfig{
+			{
+				Config: zone.Config{Name: "foozone", Type: "bar"},
+				Raw:    []byte(`{"name": "foozone", "type": "bar", "property": "bazmodified"}`),
+			},
+		},
+	}
+
+	if diff := cmp.Diff(expect, store.Active()); diff != "" {
+		t.Fatalf("unexpected active config (-want +got)\n: %s", diff)
+	}
+}
+
+func setupStoreServiceTest(t *testing.T) *Store {
+	t.Helper()
+	external := Config{
+		Drivers: []driver.RawConfig{
+			{
+				BaseConfig: driver.BaseConfig{Name: "foodriver", Type: "bar"},
+				Raw:        []byte(`{"name": "foodriver", "type": "bar", "property": "baz"}`),
+			},
+		},
+		Automation: []auto.RawConfig{
+			{
+				Config: auto.Config{Name: "fooauto", Type: "bar"},
+				Raw:    []byte(`{"name": "fooauto", "type": "bar", "property": "baz"}`),
+			},
+		},
+		Zones: []zone.RawConfig{
+			{
+				Config: zone.Config{Name: "foozone", Type: "bar"},
+				Raw:    []byte(`{"name": "foozone", "type": "bar", "property": "baz"}`),
+			},
+		},
+	}
+	dir := t.TempDir()
+	store, err := LoadStore(external, Schema{}, dir, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}


### PR DESCRIPTION
Fixes bug SC-628.

Trivial fix with tests to confirm.