### PR TITLE
driver/steinel: allow older TLS ciphers

### DIFF
--- a/pkg/driver/steinel/hpd/client.go
+++ b/pkg/driver/steinel/hpd/client.go
@@ -17,6 +17,38 @@ type Client struct {
 	Password string `default:""`
 }
 
+func getAllowedCiphers() []uint16 {
+	return []uint16{
+		// TLS 1.0 - 1.2 cipher suites.
+		tls.TLS_RSA_WITH_RC4_128_SHA,
+		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+		tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		// TLS 1.3 cipher suites.
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+	}
+}
+
 // NewInsecureClient creates a Client that connects over HTTPS but does not verify the server certificate.
 func NewInsecureClient(host string, password string) *Client {
 	client := &Client{
@@ -29,6 +61,7 @@ func NewInsecureClient(host string, password string) *Client {
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: true,
+					CipherSuites:       getAllowedCiphers(),
 				},
 			},
 		},


### PR DESCRIPTION
Fixes [SC-635](https://vanti.youtrack.cloud/issue/SC-635/Fix-breaking-change-when-communicating-with-Steinel-sensors)

Allow all the ciphers to maintain backwards and forwards compatability for our Steinel sensors
