### PR TITLE
app/server: fix intermittent test failures

### DIFF
--- a/pkg/app/servers_test.go
+++ b/pkg/app/servers_test.go
@@ -53,6 +53,10 @@ func TestServeHTTPS(t *testing.T) {
 		serveErr <- err
 	}()
 
+	// N.B.: in some cases, the client issues a GET request before the server is listening on the port.
+	// without explicit TLS timeout configurations, the TLS handshake hangs forever
+	time.Sleep(10 * time.Millisecond)
+
 	go func() {
 		client := &http.Client{
 			Transport: &http.Transport{TLSClientConfig: &tls.Config{


### PR DESCRIPTION
Insert this in line 49:
```go
	serveErr := make(chan error, 1)
	go func() {
                 time.Sleep(time.Second)
		err := ServeHTTPS(ctx, server, time.Second, zap.NewNop())
		if !errors.Is(err, context.Canceled) {
			t.Error(err)
		}
		serveErr <- err
	}()
```

and the test hangs forever due to TLS not being configured with a timeout.