### PR TITLE
auto/lights: add ability to retry if updating brightness fails

### DIFF
--- a/pkg/auto/lights/auto.go
+++ b/pkg/auto/lights/auto.go
@@ -170,7 +170,6 @@ func (b *BrightnessAutomation) processStateChanges(ctx context.Context, readStat
 	writeState := NewWriteState(time.Now())
 
 	processStateFn := func(readState *ReadState) error {
-		cancelTtlTimer()
 		cancelRetryTimer()
 
 		ttl, err := processState(ctx, readState, writeState, actions, b.logger.Named("Process State"))
@@ -190,8 +189,8 @@ func (b *BrightnessAutomation) processStateChanges(ctx context.Context, readStat
 			)
 
 			if retryCounter > readState.Config.OnProcessError.MaxRetries {
-				retryCounter = 0
 				// reset retries to prevent too many repeated attempts
+				retryCounter = 0
 				if !cancelTtlTimer() {
 					<-ttlExpired
 				}

--- a/pkg/auto/lights/auto.go
+++ b/pkg/auto/lights/auto.go
@@ -191,7 +191,7 @@ func (b *BrightnessAutomation) processStateChanges(ctx context.Context, readStat
 
 			if retryCounter > readState.Config.OnProcessError.MaxRetries {
 				retryCounter = 0
-				// reset retries as new valid state received
+				// reset retries to prevent too many repeated attempts
 				if !cancelTtlTimer() {
 					<-ttlExpired
 				}

--- a/pkg/auto/lights/auto.go
+++ b/pkg/auto/lights/auto.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/backoffutils"
 	"github.com/olebedev/emitter"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -183,7 +184,8 @@ func (b *BrightnessAutomation) processStateChanges(ctx context.Context, readStat
 
 			// if the context remains live, schedule another update soon
 			retryCounter++
-			after = time.Duration(retryCounter) * readState.Config.OnProcessError.BackOffMultiplier.Duration
+			after = backoffutils.JitterUp(time.Duration(retryCounter)*readState.Config.OnProcessError.BackOffMultiplier.Duration, 0.2)
+
 			b.logger.Error("processState failed; scheduling retry",
 				zap.Error(err),
 				zap.Duration("retryAfter", after),

--- a/pkg/auto/lights/auto.go
+++ b/pkg/auto/lights/auto.go
@@ -161,10 +161,10 @@ func (b *BrightnessAutomation) processStateChanges(ctx context.Context, readStat
 	retryCounter := 0
 
 	var ttlExpired <-chan time.Time
-	cancelTtlTimer := func() bool { return false }
+	cancelTtlTimer := func() bool { return true }
 
 	var retryFailedProcessing <-chan time.Time
-	cancelRetryTimer := func() bool { return false }
+	cancelRetryTimer := func() bool { return true }
 
 	// writeState is only accessed from this go routine.
 	writeState := NewWriteState(time.Now())

--- a/pkg/auto/lights/auto.go
+++ b/pkg/auto/lights/auto.go
@@ -225,6 +225,7 @@ func (b *BrightnessAutomation) processStateChanges(ctx context.Context, readStat
 		case <-ctx.Done():
 			return ctx.Err()
 		case readState := <-readStates:
+			b.retries = 0 // reset retries as new valid state received
 			lastReadState = readState
 			err := processStateFn(readState)
 			if err != nil {

--- a/pkg/auto/lights/auto_test.go
+++ b/pkg/auto/lights/auto_test.go
@@ -66,7 +66,7 @@ func TestPirsTurnLightsOn(t *testing.T) {
 
 	tickChan := make(chan time.Time, 1)
 	automation.newTimer = func(d time.Duration) (<-chan time.Time, func() bool) {
-		return tickChan, func() bool { return false }
+		return tickChan, func() bool { return true }
 	}
 	if err := automation.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -181,7 +181,7 @@ func TestPirsTurnLightsOn(t *testing.T) {
 		}
 		return o01.State == traits.Occupancy_OCCUPIED
 	})
-	assertErrorAndTtl(t, ttl, err, time.Millisecond*500, errFailedBrightnessUpdate)
+	assertErrorAndTtl(t, ttl, err, cfg.OnProcessError.BackOffMultiplier.Duration*8/10, errFailedBrightnessUpdate)
 	tickChan <- now.Add(time.Millisecond * 500)
 	ttl, err = waitForState(time.Millisecond*500, func(state *ReadState) bool {
 		o01, ok01 := state.Occupancy["pir01"]

--- a/pkg/auto/lights/config/root.go
+++ b/pkg/auto/lights/config/root.go
@@ -11,6 +11,8 @@ import (
 	"github.com/vanti-dev/sc-bos/pkg/util/jsontypes"
 )
 
+const DefaultBackOffMultiplier = time.Millisecond * 500
+
 // Root represent the configuration parameters available for the lighting automation.
 // This should be convertable to/from json.
 type Root struct {
@@ -186,7 +188,7 @@ func Default() Root {
 		},
 		RefreshEvery: jsontypes.Duration{Duration: time.Minute},
 		OnProcessError: OnProcessError{
-			BackOffMultiplier: jsontypes.Duration{Duration: time.Millisecond * 500},
+			BackOffMultiplier: jsontypes.Duration{Duration: DefaultBackOffMultiplier},
 			MaxRetries:        2,
 		},
 	}

--- a/pkg/auto/lights/config/root_test.go
+++ b/pkg/auto/lights/config/root_test.go
@@ -105,7 +105,7 @@ func TestRoot_MarshalJSON(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		want := `{"name":"test","type":"lights","unoccupiedOffDelay":"0s","daylightDimming":{}}`
+		want := `{"name":"test","type":"lights","unoccupiedOffDelay":"0s","daylightDimming":{},"refreshEvery":"0s","onProcessError":{"backOffMultiplier":"0s"}}`
 		if string(bin) != want {
 			t.Fatalf("got %q, want %q", string(bin), want)
 		}

--- a/pkg/auto/lights/logic_test.go
+++ b/pkg/auto/lights/logic_test.go
@@ -976,8 +976,8 @@ func assertNoErrAndTtl(t *testing.T, ttl time.Duration, err error, targetTtl tim
 
 func assertErrorAndTtl(t *testing.T, ttl time.Duration, err error, targetTtl time.Duration, targetErr error) {
 	t.Helper()
-	if ttl != targetTtl {
-		t.Fatalf("TTL want %v, got %v", targetTtl, ttl)
+	if ttl.Nanoseconds() < targetTtl.Nanoseconds() {
+		t.Fatalf("TTL want %v, got %v, got ttl less than target TTL", targetTtl, ttl)
 	}
 
 	if !errors.Is(err, targetErr) {

--- a/pkg/auto/lights/logic_test.go
+++ b/pkg/auto/lights/logic_test.go
@@ -1037,16 +1037,17 @@ func (ta *testActions) UpdateBrightness(ctx context.Context, now time.Time, req 
 	defer ta.m.Unlock()
 	ta.calls = append(ta.calls, req)
 	ta.brightnessCalls = append(ta.brightnessCalls, req)
-	state.Brightness[req.Name] = BrightnessWriteState{
-		WriteTime:  now,
-		Brightness: req.Brightness,
-	}
 	var err error
 	if ta.err != nil {
 		err = ta.err
 		ta.err = nil
 
 		return err
+	}
+
+	state.Brightness[req.Name] = BrightnessWriteState{
+		WriteTime:  now,
+		Brightness: req.Brightness,
 	}
 
 	return nil

--- a/pkg/auto/lights/logic_test.go
+++ b/pkg/auto/lights/logic_test.go
@@ -965,6 +965,7 @@ func Test_processState(t *testing.T) {
 }
 
 func assertNoErrAndTtl(t *testing.T, ttl time.Duration, err error, targetTtl time.Duration) {
+	t.Helper()
 	if ttl != targetTtl {
 		t.Fatalf("TTL want %v, got %v", targetTtl, ttl)
 	}
@@ -974,15 +975,15 @@ func assertNoErrAndTtl(t *testing.T, ttl time.Duration, err error, targetTtl tim
 }
 
 func assertErrorAndTtl(t *testing.T, ttl time.Duration, err error, targetTtl time.Duration, targetErr error) {
-	{
-		if ttl != targetTtl {
-			t.Fatalf("TTL want %v, got %v", targetTtl, ttl)
-		}
-
-		if !errors.Is(err, targetErr) {
-			t.Fatalf("Error want %v, got %v", targetErr, err)
-		}
+	t.Helper()
+	if ttl != targetTtl {
+		t.Fatalf("TTL want %v, got %v", targetTtl, ttl)
 	}
+
+	if !errors.Is(err, targetErr) {
+		t.Fatalf("Error want %v, got %v", targetErr, err)
+	}
+
 }
 
 func newTestActions(t *testing.T) *testActions {

--- a/pkg/auto/lights/patch.go
+++ b/pkg/auto/lights/patch.go
@@ -157,6 +157,11 @@ type source struct {
 
 func (b *BrightnessAutomation) processConfig(ctx context.Context, cfg config.Root, sources []*source, changes chan<- Patcher) (sourceCount int) {
 	logger := b.logger.With(zap.String("auto", cfg.Name))
+
+	b.refreshEvery.Store(cfg.RefreshEvery.Duration)
+	b.maxRetries = cfg.OnProcessError.MaxRetries
+	b.backoffMultiplier = cfg.OnProcessError.BackOffMultiplier.Duration
+
 	for _, source := range sources {
 		names := source.names(cfg)
 		if source.runningSources == nil && len(names) > 0 {

--- a/pkg/auto/lights/patch.go
+++ b/pkg/auto/lights/patch.go
@@ -161,6 +161,12 @@ func (b *BrightnessAutomation) processConfig(ctx context.Context, cfg config.Roo
 	if cfg.OnProcessError.BackOffMultiplier.Duration.Nanoseconds() <= 0 {
 		cfg.OnProcessError.BackOffMultiplier.Duration = config.DefaultBackOffMultiplier
 	}
+	if cfg.OnProcessError.MaxRetries < 0 {
+		cfg.OnProcessError.MaxRetries = config.DefaultMaxRetries
+	}
+	if cfg.RefreshEvery.Duration.Nanoseconds() <= 0 {
+		cfg.RefreshEvery.Duration = config.DefaultRefreshEvery
+	}
 
 	for _, source := range sources {
 		names := source.names(cfg)

--- a/pkg/auto/lights/patch.go
+++ b/pkg/auto/lights/patch.go
@@ -158,6 +158,10 @@ type source struct {
 func (b *BrightnessAutomation) processConfig(ctx context.Context, cfg config.Root, sources []*source, changes chan<- Patcher) (sourceCount int) {
 	logger := b.logger.With(zap.String("auto", cfg.Name))
 
+	if cfg.OnProcessError.BackOffMultiplier.Duration.Nanoseconds() <= 0 {
+		cfg.OnProcessError.BackOffMultiplier.Duration = config.DefaultBackOffMultiplier
+	}
+
 	for _, source := range sources {
 		names := source.names(cfg)
 		if source.runningSources == nil && len(names) > 0 {

--- a/pkg/auto/lights/patch.go
+++ b/pkg/auto/lights/patch.go
@@ -158,10 +158,6 @@ type source struct {
 func (b *BrightnessAutomation) processConfig(ctx context.Context, cfg config.Root, sources []*source, changes chan<- Patcher) (sourceCount int) {
 	logger := b.logger.With(zap.String("auto", cfg.Name))
 
-	b.refreshEvery.Store(cfg.RefreshEvery.Duration)
-	b.maxRetries = cfg.OnProcessError.MaxRetries
-	b.backoffMultiplier = cfg.OnProcessError.BackOffMultiplier.Duration
-
 	for _, source := range sources {
 		names := source.names(cfg)
 		if source.runningSources == nil && len(names) > 0 {


### PR DESCRIPTION
auto/lights: add tests for retrying when updateBrightness fails

I changed the constants to be part of the config.
I also added config options for retry-ability in the auto/lights package. Updated some tests to verify this.