### PR TITLE
driver/bacnet: add configurable emergency based on point value

### DIFF
--- a/pkg/driver/bacnet/comm/value.go
+++ b/pkg/driver/bacnet/comm/value.go
@@ -246,6 +246,27 @@ func BoolValue(data any) (bool, error) {
 	return false, fmt.Errorf("unsupported conversion %T -> bool for val %v", data, data)
 }
 
+func IntValue(data any) (int64, error) {
+	switch v := data.(type) {
+	case error:
+		return 0, v
+	case uint8:
+		return int64(v), nil
+	case uint16:
+		return int64(v), nil
+	case uint32:
+		return int64(v), nil
+	case int8:
+		return int64(v), nil
+	case int16:
+		return int64(v), nil
+	case int32:
+		return int64(v), nil
+	}
+
+	return 0, fmt.Errorf("unsupported conversion %T -> int for val %v", data, data)
+}
+
 func EnumValue(data any) (bactypes.Enumerated, error) {
 	switch v := data.(type) {
 	case error:

--- a/pkg/driver/bacnet/merge/emergency.go
+++ b/pkg/driver/bacnet/merge/emergency.go
@@ -141,12 +141,12 @@ func (t *emergencyImpl) pollPeer(ctx context.Context) (*traits.Emergency, error)
 		requestNames = append(requestNames, "alarmConfig")
 		readValues = append(readValues, t.config.AlarmConfig.ValueSource)
 		resProcessors = append(resProcessors, func(response any) error {
-			enum, err := comm.EnumValue(response)
+			value, err := comm.IntValue(response)
 			if err != nil {
 				return comm.ErrReadProperty{Prop: "alarmConfig", Cause: err}
 			}
 
-			if t.config.AlarmConfig.OkValue != int(enum) {
+			if int64(t.config.AlarmConfig.OkValue) != value {
 				data.Reason = t.config.AlarmConfig.AlarmReason
 				data.Level = traits.Emergency_EMERGENCY
 			} else {

--- a/pkg/driver/bacnet/merge/emergency.go
+++ b/pkg/driver/bacnet/merge/emergency.go
@@ -22,11 +22,11 @@ import (
 )
 
 // AlarmConfig allows configuring a specific bacnet point to become an Emergency if the
-// value read from that point matches the ActivePolarity.
+// value read from that point matches the OkValue.
 type AlarmConfig struct {
 	config.ValueSource
-	ActivePolarity int    `json:"activePolarity"` // e.g. 1 if the alarm is active high, 0 if the alarm is active low
-	AlarmReason    string `json:"alarmReason"`    // the reason of the alarm
+	OkValue     int    `json:"okValue"`     // what we expect to read from the point when it is ok, any other value is an emergency
+	AlarmReason string `json:"alarmReason"` // the reason of the alarm
 }
 
 type emergencyConfig struct {
@@ -146,7 +146,7 @@ func (t *emergencyImpl) pollPeer(ctx context.Context) (*traits.Emergency, error)
 				return comm.ErrReadProperty{Prop: "alarmConfig", Cause: err}
 			}
 
-			if t.config.AlarmConfig.ActivePolarity == int(enum) {
+			if t.config.AlarmConfig.OkValue != int(enum) {
 				data.Reason = t.config.AlarmConfig.AlarmReason
 				data.Level = traits.Emergency_EMERGENCY
 			} else {

--- a/pkg/driver/bacnet/merge/emergency.go
+++ b/pkg/driver/bacnet/merge/emergency.go
@@ -21,8 +21,8 @@ import (
 	"github.com/vanti-dev/sc-bos/pkg/task"
 )
 
-// AlarmConfig allows configuring a specific bacnet point to become an Emergency if the
-// value read from that point matches the OkValue.
+// AlarmConfig allows configuring a specific bacnet point to raise an Emergency if the
+// value read from that point is anything other than OkValue
 type AlarmConfig struct {
 	config.ValueSource
 	OkValue     int    `json:"okValue"`     // what we expect to read from the point when it is ok, any other value is an emergency

--- a/pkg/driver/bacnet/merge/emergency.go
+++ b/pkg/driver/bacnet/merge/emergency.go
@@ -21,9 +21,18 @@ import (
 	"github.com/vanti-dev/sc-bos/pkg/task"
 )
 
+// AlarmConfig allows configuring a specific bacnet point to become an Emergency if the
+// value read from that point matches the ActivePolarity.
+type AlarmConfig struct {
+	config.ValueSource
+	ActivePolarity int    `json:"activePolarity"` // e.g. 1 if the alarm is active high, 0 if the alarm is active low
+	AlarmReason    string `json:"alarmReason"`    // the reason of the alarm
+}
+
 type emergencyConfig struct {
 	config.Trait
-	Level *config.ValueSource `json:"level,omitempty"`
+	Level       *config.ValueSource `json:"level,omitempty"`
+	AlarmConfig *AlarmConfig        `json:"alarmConfig,omitempty"`
 }
 
 func readEmergencyConfig(raw []byte) (cfg emergencyConfig, err error) {
@@ -122,6 +131,26 @@ func (t *emergencyImpl) pollPeer(ctx context.Context) (*traits.Emergency, error)
 				data.Drill = true
 			default:
 				data.Drill = false
+			}
+
+			return nil
+		})
+	}
+
+	if t.config.AlarmConfig != nil {
+		requestNames = append(requestNames, "alarmConfig")
+		readValues = append(readValues, t.config.AlarmConfig.ValueSource)
+		resProcessors = append(resProcessors, func(response any) error {
+			enum, err := comm.EnumValue(response)
+			if err != nil {
+				return comm.ErrReadProperty{Prop: "alarmConfig", Cause: err}
+			}
+
+			if t.config.AlarmConfig.ActivePolarity == int(enum) {
+				data.Reason = t.config.AlarmConfig.AlarmReason
+				data.Level = traits.Emergency_EMERGENCY
+			} else {
+				data.Level = traits.Emergency_OK
 			}
 
 			return nil


### PR DESCRIPTION
Add the ability to set an emergency when a given bacnet point reads the configured value, intended for binary alarm states, fire alarm, water level low etc