### PR TITLE
node,gateway: improved logging

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -276,7 +276,11 @@ func registerProxyRoute(r *router.Router, name string, conn grpc.ClientConnInter
 func ensureServiceSupported(r *router.Router, s service) error {
 	serviceName := string(s.desc.FullName())
 	if existing := r.GetService(serviceName); existing != nil {
-		if s.nameRouting && !existing.KeyRoutable() {
+		switch {
+		case serviceName == traits.MetadataApi_ServiceDesc.ServiceName:
+		case serviceName == traits.MetadataInfo_ServiceDesc.ServiceName:
+			// skip, we support metadata specially
+		case s.nameRouting && !existing.KeyRoutable():
 			// existing service does not support name routing!
 			return fmt.Errorf("service %q already exists but does not support name routing", serviceName)
 		}

--- a/pkg/system/gateway/announce.go
+++ b/pkg/system/gateway/announce.go
@@ -284,35 +284,35 @@ func (a *announcer) announceRemoteServiceApis(rs protoreflect.ServiceDescriptor)
 	switch {
 	case srv.NameRoutable():
 		// routes will be added by device announcements as this service is routable by name
-		a.logger.Debug("remote supports routable service",
-			zap.String("service", string(rs.FullName())),
-			zap.String("remote", a.node.addr),
-		)
 		err := a.self.SupportService(srv)
 		if err != nil {
-			a.logger.Warn("cannot support service, will not be available",
+			a.logger.Warn("failed to announce routable service",
 				zap.String("service", string(rs.FullName())),
 				zap.Error(err),
 			)
+			break
 		}
+		a.logger.Debug("routable service announced",
+			zap.String("service", string(rs.FullName())),
+		)
 	case a.node.isHub:
 		// route everything to the hub
-		a.logger.Debug("remote is a hub supporting non-routable service",
-			zap.String("service", string(rs.FullName())),
-			zap.String("remote", a.node.addr),
-		)
 		undo, err := a.self.AnnounceService(srv)
-		undos = append(undos, undo)
 		if err != nil {
-			a.logger.Warn("cannot announce service, will not be available",
+			a.logger.Warn("failed to announce non-routable hub service",
 				zap.String("service", string(rs.FullName())),
 				zap.Error(err),
 			)
+			break
 		}
+		a.logger.Debug("non-routable hub service announced",
+			zap.String("service", string(rs.FullName())),
+		)
+		undos = append(undos, undo)
 	default:
 		// Found a non-routable service on a non-hub node.
 		// We didn't think we had any of these so log it to remind us.
-		a.logger.Warn("non-routable service on non-hub node", zap.String("service", string(rs.FullName())))
+		a.logger.Warn("unable to announce non-routable service on non-hub node", zap.String("service", string(rs.FullName())))
 		return nil
 	}
 

--- a/pkg/system/gateway/factory.go
+++ b/pkg/system/gateway/factory.go
@@ -170,7 +170,8 @@ func (s *System) poll(ctx context.Context, t func(context.Context) error, logFie
 		task.WithPollAttemptCallback(func(state task.PollState, err error) bool {
 			defer func() { lastState = state }()
 			if err == nil {
-				if lastState.NextDelay == 0 && state.SuccessesSinceError == 1 {
+				// only print success if the last attempt succeeded after an error
+				if lastState.NextDelay == 0 && state.SuccessesSinceError == 1 && lastState.ErrorsSinceSuccess > 0 {
 					logger.Debug("poll task is now succeeding", zap.Int("attempts", lastState.ErrorsSinceSuccess))
 				}
 				return false

--- a/pkg/system/gateway/scan.go
+++ b/pkg/system/gateway/scan.go
@@ -24,7 +24,11 @@ import (
 // This blocks until ctx is done.
 func (s *System) scanRemoteHub(ctx context.Context, c *cohort, hubConn *grpc.ClientConn) {
 	hubClient := gen.NewHubApiClient(hubConn)
-	hubNode := newRemoteNode(hubConn.Target(), hubConn)
+	hubAddr := hubConn.Target()
+	if hubAddr == "dialchan:ignored" {
+		hubAddr = s.hub.Target()
+	}
+	hubNode := newRemoteNode(hubAddr, hubConn)
 	hubNode.isHub = true
 	c.Nodes.Set(hubNode)
 


### PR DESCRIPTION
Make logging for the gateway and node a little less 'false negative'-y, less stuttery, and more consistent.

This should help to identify actual issues with the boot process and general node/gateway/hub issues.