### PR TITLE
node,proxy: fix incorrect 'owner node' when using proxy.skipChild

### DIFF
--- a/pkg/driver/proxy/driver.go
+++ b/pkg/driver/proxy/driver.go
@@ -200,6 +200,8 @@ func (p *proxy) announceTraits(announced announcedTraits, childName string, trai
 		features := []node.Feature{node.HasServices(p.conn, services...)}
 		if !p.skipChild {
 			features = append(features, node.HasTrait(tn))
+		} else {
+			features = append(features, node.HasNoAutoMetadata())
 		}
 
 		undo := p.announcer.Announce(childName, features...)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -161,10 +161,10 @@ func (n *Node) announceLocked(name string, features ...Feature) Undo {
 		}
 		mds = append(mds, md)
 	}
-	// always need to set the name of the device in its metadata
-	mds = append(mds, &traits.Metadata{Name: name})
 
 	for _, md := range mds {
+		// always need to set the name of the device in its metadata
+		md.Name = name
 		undoMd, err := n.mergeMetadata(name, md)
 		if err != nil {
 			if errors.Is(err, MetadataTraitNotSupported) {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -29,8 +29,8 @@ import (
 // Calling Support after Register will not have any effect on the served apis.
 type Node struct {
 	name   string
-	router *router.Router
 	mu     sync.Mutex // protects all fields below, typically Announce, Support, and methods that rely on that data
+	router *router.Router
 
 	// children keeps track of all the names that have been announced to this node.
 	// Lazy, initialised when addChildTrait via Announce(HasTrait) or Register are called.

--- a/pkg/node/service.go
+++ b/pkg/node/service.go
@@ -73,6 +73,8 @@ func (n *Node) AnnounceService(srv *Service) (Undo, error) {
 // No routes are added, so by default all requests will fail.
 func (n *Node) SupportService(srv *Service) error {
 	serviceName := srv.routerService.Name()
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	if n.router.GetService(serviceName) == nil {
 		err := n.router.AddService(srv.routerService)
 		if err != nil {


### PR DESCRIPTION
Fix an issue that had symptoms like 'name not found' when it should exist.

The root cause was the proxy drivers `skipChild` feature not working since the reworking of the node package to support ClientConnInterface (instead of generated service wrappers/routers). The change was that metadata was always added for all names, which resulted in those named being queryable via the DevicesApi. The DevicesApi is used by both gateways and proxies, and having authoritative devices in that list (when we didn't want them) could cause unexpected issues.

In summary, when a device name was discovered in more than one place, the routing could break causing not-found issues for some apis but still have discovery work.

This change makes it possible again to announce a name without it appearing in the DevicesApi. The proxy driver is updated to make use of this feature.

Fixes SC-908
Fixed SC-909