### PR TITLE
driver/mock,zone/openclose: add support for open close presets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/cors v1.8.3
 	github.com/sirupsen/logrus v1.9.3
-	github.com/smart-core-os/sc-api/go v1.0.0-beta.46
-	github.com/smart-core-os/sc-golang v0.0.0-20241002082259-488309e0a69b
+	github.com/smart-core-os/sc-api/go v1.0.0-beta.48
+	github.com/smart-core-os/sc-golang v0.0.0-20241111170323-196841380f4c
 	github.com/stretchr/testify v1.9.0
 	github.com/timshannon/bolthold v0.0.0-20210913165410-232392fc8a6a
 	github.com/vanti-dev/gobacnet v0.0.0-20231102122752-32b0b38bcc53

--- a/go.sum
+++ b/go.sum
@@ -483,10 +483,10 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/smart-core-os/sc-api/go v1.0.0-beta.46 h1:RgQn+FHnEYpAY1+oL+ILHVXix19yX/BLykA86ovhH7I=
-github.com/smart-core-os/sc-api/go v1.0.0-beta.46/go.mod h1:HpHbz0skS27690VbVGBFA+tiNyEkNlZP5p68MUREIJY=
-github.com/smart-core-os/sc-golang v0.0.0-20241002082259-488309e0a69b h1:RfPSanqR14byqENtjV0poZfk6gx9ulfAv9BQN5+2ZmI=
-github.com/smart-core-os/sc-golang v0.0.0-20241002082259-488309e0a69b/go.mod h1:EJjLFL5hIVmFsPil51W0xfl61dBXGEJ+Va3cim0Mlls=
+github.com/smart-core-os/sc-api/go v1.0.0-beta.48 h1:d8BmKJIBFNi5t/poBSQYeRKt7n7GOqe7POvKmohkB+s=
+github.com/smart-core-os/sc-api/go v1.0.0-beta.48/go.mod h1:HpHbz0skS27690VbVGBFA+tiNyEkNlZP5p68MUREIJY=
+github.com/smart-core-os/sc-golang v0.0.0-20241111170323-196841380f4c h1:bDQmqvmzjlvjLJg4ArxEA0LkuwNgJQifAKasXPEIl5A=
+github.com/smart-core-os/sc-golang v0.0.0-20241111170323-196841380f4c/go.mod h1:/0j/MYjdqB2VSOr2u2/X22zRTevncdkeu2OuqfB22FE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/pkg/driver/mock/driver.go
+++ b/pkg/driver/mock/driver.go
@@ -22,7 +22,6 @@ import (
 	"github.com/smart-core-os/sc-golang/pkg/trait/mode"
 	"github.com/smart-core-os/sc-golang/pkg/trait/occupancysensor"
 	"github.com/smart-core-os/sc-golang/pkg/trait/onoff"
-	"github.com/smart-core-os/sc-golang/pkg/trait/openclose"
 	"github.com/smart-core-os/sc-golang/pkg/trait/parent"
 	"github.com/smart-core-os/sc-golang/pkg/trait/publication"
 	"github.com/smart-core-os/sc-golang/pkg/trait/vending"
@@ -238,8 +237,7 @@ func newMockClient(traitMd *traits.TraitMetadata, deviceName string, logger *zap
 	case trait.OnOff:
 		return []wrap.ServiceUnwrapper{onoff.WrapApi(onoff.NewModelServer(onoff.NewModel()))}, nil
 	case trait.OpenClose:
-		model := openclose.NewModel()
-		return []wrap.ServiceUnwrapper{openclose.WrapApi(openclose.NewModelServer(model))}, auto.OpenClose(model)
+		return mockOpenClose(traitMd, deviceName, logger)
 	case trait.Parent:
 		return []wrap.ServiceUnwrapper{parent.WrapApi(parent.NewModelServer(parent.NewModel()))}, nil
 	case trait.Publication:

--- a/pkg/driver/mock/openclose.go
+++ b/pkg/driver/mock/openclose.go
@@ -1,0 +1,98 @@
+package mock
+
+import (
+	"encoding/json"
+
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+	"github.com/smart-core-os/sc-golang/pkg/trait/openclose"
+	"github.com/smart-core-os/sc-golang/pkg/wrap"
+	"github.com/vanti-dev/sc-bos/pkg/driver/mock/auto"
+	"github.com/vanti-dev/sc-bos/pkg/task/service"
+)
+
+// mockOpenClose returns a mock OpenClose device and automation.
+//
+// Configuration of the mock device is done via the trait metadata more map.
+// You can specify a "presets" key which has the JSON format of `[{name, title?, positions}, ...]`,
+// where `positions` is the protojson representation of either a single or array of traits.OpenClosePosition.
+func mockOpenClose(traitMd *traits.TraitMetadata, deviceName string, logger *zap.Logger) ([]wrap.ServiceUnwrapper, service.Lifecycle) {
+	var opts []resource.Option
+
+	opts = append(opts, parseOpenClosePresets(traitMd, deviceName, logger)...)
+
+	model := openclose.NewModel(opts...)
+	server := openclose.NewModelServer(model)
+	return []wrap.ServiceUnwrapper{openclose.WrapApi(server), openclose.WrapInfo(server)}, auto.OpenClose(model)
+}
+
+func parseOpenClosePresets(traitMd *traits.TraitMetadata, deviceName string, logger *zap.Logger) []resource.Option {
+	presets, ok := traitMd.GetMore()["presets"]
+	if !ok {
+		return nil
+	}
+	type presetJson struct {
+		Name      string          `json:"name,omitempty"`
+		Title     string          `json:"title,omitempty"`
+		Positions json.RawMessage `json:"positions,omitempty"`
+	}
+	var cfg []presetJson
+	if err := json.Unmarshal([]byte(presets), &cfg); err != nil {
+		logger.Sugar().Warnf("Unable to unmarshal presets for mock device %q: %v. %v", deviceName, err, presets)
+		return nil
+	}
+
+	var opts []resource.Option
+	for _, presetCfg := range cfg {
+		if presetCfg.Name == "" {
+			logger.Sugar().Warnf("No name provided for mock device preset for %q", deviceName)
+			continue
+		}
+		if len(presetCfg.Positions) == 0 {
+			logger.Sugar().Warnf("No positions provided for mock device preset %s for %q", presetCfg.Name, deviceName)
+			continue
+		}
+
+		// support both "positions": [{...}] and "positions": {...}
+		var positionsJson []json.RawMessage
+		switch presetCfg.Positions[0] {
+		case '[':
+			if err := json.Unmarshal(presetCfg.Positions, &positionsJson); err != nil {
+				logger.Sugar().Warnf("Unable to unmarshal positions for mock device %q: %v. %v", deviceName, err, presetCfg.Positions)
+				continue
+			}
+			if len(positionsJson) == 0 {
+				logger.Sugar().Warnf("No positions provided for mock device preset %s for %q", presetCfg.Name, deviceName)
+				continue
+			}
+		case '{':
+			positionsJson = []json.RawMessage{presetCfg.Positions}
+		default:
+			logger.Sugar().Warnf("Invalid positions format for mock device preset %s for %q: %v", presetCfg.Name, deviceName, presetCfg.Positions)
+			continue
+		}
+
+		positions := make([]*traits.OpenClosePosition, len(positionsJson))
+		for i, posJson := range positionsJson {
+			pos := &traits.OpenClosePosition{}
+			if err := protojson.Unmarshal(posJson, pos); err != nil {
+				logger.Sugar().Warnf("Unable to unmarshal position %s.%d for mock device %q: %v. %v", presetCfg.Name, i, deviceName, err, posJson)
+				continue
+			}
+			positions[i] = pos
+		}
+		if len(positions) == 0 {
+			continue // errors will already have been logged
+		}
+
+		desc := &traits.OpenClosePositions_Preset{
+			Name:  presetCfg.Name,
+			Title: presetCfg.Title,
+		}
+		opts = append(opts, openclose.WithPreset(desc, positions...))
+	}
+	return opts
+}

--- a/pkg/zone/feature/openclose/group_test.go
+++ b/pkg/zone/feature/openclose/group_test.go
@@ -57,8 +57,8 @@ func Test_mergeOpenClosePositions(t *testing.T) {
 		// preset tests
 		{"[{open}]", []value{valPres("open")}, ocpPres("open"), false},
 		{"[{nil },{open},{nil }]", []value{valPres(""), valPres("open"), valPres("")}, ocpPres("open"), false},
-		{"[{open},{open},{open}]", []value{valPres(""), valPres("open"), valPres("")}, ocpPres("open"), false},
-		{"[{shut},{open},{nil }]", []value{valPres("closed"), valPres("open"), valPres("")}, ocpPres(""), false},
+		{"[{open},{open},{open}]", []value{valPres("open"), valPres("open"), valPres("open")}, ocpPres("open"), false},
+		{"[{shut},{open},{nil }]", []value{valPres("shut"), valPres("open"), valPres("")}, ocpPres(""), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/zone/feature/openclose/group_test.go
+++ b/pkg/zone/feature/openclose/group_test.go
@@ -54,6 +54,11 @@ func Test_mergeOpenClosePositions(t *testing.T) {
 		{"[{10% held},{10% held}]", []value{val(pos(10).Held()), val(pos(10).Held())}, ocp(pos(10).Held()), false},
 		// combine it all together
 		{"[{10% up slow,90% down},{30% up,70% down held}]", []value{val(up(10).Slow(), down(90)), val(up(30), down(70).Held())}, ocp(up(20).Slow(), down(80).Held()), false},
+		// preset tests
+		{"[{open}]", []value{valPres("open")}, ocpPres("open"), false},
+		{"[{nil },{open},{nil }]", []value{valPres(""), valPres("open"), valPres("")}, ocpPres("open"), false},
+		{"[{open},{open},{open}]", []value{valPres(""), valPres("open"), valPres("")}, ocpPres("open"), false},
+		{"[{shut},{open},{nil }]", []value{valPres("closed"), valPres("open"), valPres("")}, ocpPres(""), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -91,6 +96,18 @@ func ocp(p ...*position) *traits.OpenClosePositions {
 
 func val(p ...*position) value {
 	return value{val: ocp(p...)}
+}
+
+func valPres(name string) value {
+	return value{val: ocpPres(name)}
+}
+
+func ocpPres(name string) *traits.OpenClosePositions {
+	var preset *traits.OpenClosePositions_Preset
+	if name != "" {
+		preset = &traits.OpenClosePositions_Preset{Name: name}
+	}
+	return &traits.OpenClosePositions{Preset: preset}
 }
 
 type position struct {


### PR DESCRIPTION
We now support configuring presets for the mock driver and as part of a zone.

Fixes SC-920