### PR TITLE
auto/wordpress: ctx timeouts with cancel to test if hanging connectio…

### DIFF
--- a/pkg/auto/wordpress/job/air_quality.go
+++ b/pkg/auto/wordpress/job/air_quality.go
@@ -32,8 +32,11 @@ func (a *AirQualityJob) Do(ctx context.Context, sendFn sender) error {
 	count := 0
 
 	for _, sensor := range a.Sensors {
-		resp, err := a.client.GetAirQuality(ctx, &traits.GetAirQualityRequest{Name: sensor})
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 
+		resp, err := a.client.GetAirQuality(cctx, &traits.GetAirQualityRequest{Name: sensor})
+
+		cancel()
 		if err != nil {
 			a.Logger.Error("getting air quality", zap.String("sensor", sensor), zap.Error(err))
 			continue

--- a/pkg/auto/wordpress/job/occupancy.go
+++ b/pkg/auto/wordpress/job/occupancy.go
@@ -30,7 +30,10 @@ func (o *OccupancyJob) Do(ctx context.Context, sendFn sender) error {
 	sum := int32(0)
 
 	for _, sensor := range o.Sensors {
-		resp, err := o.client.GetOccupancy(ctx, &traits.GetOccupancyRequest{Name: sensor})
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+
+		resp, err := o.client.GetOccupancy(cctx, &traits.GetOccupancyRequest{Name: sensor})
+		cancel()
 
 		if err != nil {
 			o.Logger.Error("getting occupancy", zap.String("sensor", sensor), zap.Error(err))

--- a/pkg/auto/wordpress/job/temperature.go
+++ b/pkg/auto/wordpress/job/temperature.go
@@ -32,7 +32,10 @@ func (t *TemperatureJob) Do(ctx context.Context, sendFn sender) error {
 	count := 0
 
 	for _, sensor := range t.Sensors {
-		resp, err := t.client.GetAirTemperature(ctx, &traits.GetAirTemperatureRequest{Name: sensor})
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+
+		resp, err := t.client.GetAirTemperature(cctx, &traits.GetAirTemperatureRequest{Name: sensor})
+		cancel()
 
 		if err != nil {
 			t.Logger.Error("getting air temperature", zap.String("sensor", sensor), zap.Error(err))


### PR DESCRIPTION
The automation seems to die / hang after a few ticker cycles. This will test whether the issue is related to hanging gRPC calls.

Will deploy and monitor via logs to OCW