### PR TITLE
history: fix missing History Admin & alert API client

### DIFF
--- a/pkg/node/alltraits/clients.go
+++ b/pkg/node/alltraits/clients.go
@@ -154,6 +154,9 @@ func NewClient(ptr any, conn grpc.ClientConnInterface) (ok bool) {
 	case *gen.StatusHistoryClient:
 		*ptr = gen.NewStatusHistoryClient(conn)
 
+	case *gen.HistoryAdminApiClient:
+		*ptr = gen.NewHistoryAdminApiClient(conn)
+
 	default:
 		return false
 	}

--- a/pkg/node/alltraits/clients.go
+++ b/pkg/node/alltraits/clients.go
@@ -67,6 +67,8 @@ func NewClient(ptr any, conn grpc.ClientConnInterface) (ok bool) {
 		*ptr = traits.NewSpeakerApiClient(conn)
 	case *traits.VendingApiClient:
 		*ptr = traits.NewVendingApiClient(conn)
+	case *gen.AlertApiClient:
+		*ptr = gen.NewAlertApiClient(conn)
 	case *gen.ButtonApiClient:
 		*ptr = gen.NewButtonApiClient(conn)
 	case *gen.ColorApiClient:


### PR DESCRIPTION
Add missing `*gen.HistoryAdminApiClient` `*gen.AlertApiClient` to switch.
