### PR TITLE
history/apistore: fix panic when reading the length of the remote store

### DIFF
--- a/pkg/history/apistore/store_test.go
+++ b/pkg/history/apistore/store_test.go
@@ -1,0 +1,19 @@
+package apistore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/smart-core-os/sc-golang/pkg/wrap"
+	"github.com/vanti-dev/sc-bos/pkg/gen"
+)
+
+func TestSlice_Len_panicOnFail(t *testing.T) {
+	client := gen.NewHistoryAdminApiClient(wrap.ServerToClient(gen.HistoryAdminApi_ServiceDesc, &testFailingHistoryAdminServer{}))
+	// the below can panic if we aren't handling sync.Once retries correctly.
+	_, _ = New(client, "name", "source").Len(context.Background())
+}
+
+type testFailingHistoryAdminServer struct {
+	gen.UnimplementedHistoryAdminApiServer
+}


### PR DESCRIPTION
Turns out you shouldn't reassign to a sync.Once ever. This issue: https://github.com/golang/go/issues/16762 outlines why

> [paraphrasing] When calling `Do` it takes the address of the `sync.Once`. If you then reassign to the underlying value the mutex that is being unlocked is not the same as the one that was locked, causing the panic.

Fixes SC-942