### PR TITLE
auto/lights: fix intermittent test failures by being stricter with stateChangeTime field

### DIFF
--- a/pkg/auto/lights/auto_test.go
+++ b/pkg/auto/lights/auto_test.go
@@ -217,8 +217,8 @@ func TestPirsTurnLightsOn(t *testing.T) {
 	})
 
 	// testing retries getting cancelled after max attempts
-	_, _ = pir01.SetOccupancy(&traits.Occupancy{State: traits.Occupancy_UNOCCUPIED})
-	_, _ = pir02.SetOccupancy(&traits.Occupancy{State: traits.Occupancy_UNOCCUPIED})
+	_, _ = pir01.SetOccupancy(&traits.Occupancy{State: traits.Occupancy_UNOCCUPIED, StateChangeTime: timestamppb.New(time.Unix(0, 0).Add(-3 * time.Minute))})
+	_, _ = pir02.SetOccupancy(&traits.Occupancy{State: traits.Occupancy_UNOCCUPIED, StateChangeTime: timestamppb.New(time.Unix(0, 0).Add(-3 * time.Minute))})
 	tickChan <- now
 	ttl, err = waitForState(time.Millisecond*500, func(state *ReadState) bool {
 		o01, ok01 := state.Occupancy["pir01"]


### PR DESCRIPTION
lights/auto_test: as the model server is still running, we want lastUnoccupiedTime to resolve to -3 minutes from the start of the test existence
	if we don't set StateChangeTime to this, the PIR automation logic *sometimes* resolves lastUnoccupiedTime to Unix zero.
	which means the logic defaults back to the readState.AutoStartTime
	since the unoccupiedOffDelay is set to 10 minutes
	and now.Sub(unix 0) is 7 minutes, we get a ttl of ~3minutes whenever the test fails which we don't want.