### PR TITLE
app: allow adding to the self-signed SAN list from config

### DIFF
--- a/pkg/app/sysconf/config.go
+++ b/pkg/app/sysconf/config.go
@@ -57,6 +57,8 @@ type Config struct {
 	GRPCAddr string `json:"grpcAddr,omitempty"`
 	HTTPAddr string `json:"httpAddr,omitempty"`
 
+	SANs []string `json:"sans,omitempty"` // Subject Alternative Names for the self-signed cert
+
 	AppConfig []string `json:"appConfig,omitempty"` // defaults to [".conf/app.conf.json"]
 	DataDir   string   `json:"dataDir,omitempty"`   // defaults to .data/
 

--- a/pkg/util/netutil/ip.go
+++ b/pkg/util/netutil/ip.go
@@ -1,0 +1,14 @@
+package netutil
+
+import (
+	"net"
+)
+
+// StripPort removes the port from an address string.
+func StripPort(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	return host
+}


### PR DESCRIPTION
This allows more flexible hosting infrastructure, including containers accessing host systems and inter-container comms via host names