### PR TITLE
hub/pgxhub: return the error in TestHubNode

### DIFF
--- a/pkg/system/hub/pgxhub/server.go
+++ b/pkg/system/hub/pgxhub/server.go
@@ -294,7 +294,7 @@ func (n *Server) TestHubNode(ctx context.Context, request *gen.TestHubNodeReques
 	_, err = client.GetMetadata(ctx, &traits.GetMetadataRequest{})
 	if err != nil {
 		logger.Debug("failed api request", zap.Error(err))
-		return nil, status.Error(codes.Unavailable, fmt.Errorf("failed api request: %w", err).Error())
+		return nil, status.Errorf(codes.Unavailable, "failed api request: %v", err)
 	}
 
 	return &gen.TestHubNodeResponse{}, nil

--- a/pkg/system/hub/pgxhub/server.go
+++ b/pkg/system/hub/pgxhub/server.go
@@ -294,7 +294,7 @@ func (n *Server) TestHubNode(ctx context.Context, request *gen.TestHubNodeReques
 	_, err = client.GetMetadata(ctx, &traits.GetMetadataRequest{})
 	if err != nil {
 		logger.Debug("failed api request", zap.Error(err))
-		return nil, status.Error(codes.Unavailable, "failed api request")
+		return nil, status.Error(codes.Unavailable, fmt.Errorf("failed api request: %w", err).Error())
 	}
 
 	return &gen.TestHubNodeResponse{}, nil


### PR DESCRIPTION
![Screenshot 2024-12-05 at 15 04 54](https://github.com/user-attachments/assets/5af3fa96-076d-4583-b897-3b55422bf4f2)
