### PR TITLE
fix: add hub api client to lookup

### DIFF
--- a/pkg/node/alltraits/clients.go
+++ b/pkg/node/alltraits/clients.go
@@ -156,6 +156,8 @@ func NewClient(ptr any, conn grpc.ClientConnInterface) (ok bool) {
 
 	case *gen.HistoryAdminApiClient:
 		*ptr = gen.NewHistoryAdminApiClient(conn)
+	case *gen.HubApiClient:
+		*ptr = gen.NewHubApiClient(conn)
 
 	default:
 		return false


### PR DESCRIPTION
Missing case in NewClient lookup, fixes https://vanti.youtrack.cloud/issue/INF-280/fix-5hp-building-controller-as-hub