### PR TITLE
ui/ops: allow the device table to be included in dashboard pages

### DIFF
--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -98,6 +98,12 @@
                   "props": {
                     "forceQuery": {"floor": "Basement"}
                   }
+                },
+                {
+                  "component": "builtin:devices/DeviceTable",
+                  "props": {
+                    "forceQuery": {"metadata.location.floor": "Basement"}
+                  }
                 }
               ],
               "after": [
@@ -127,6 +133,15 @@
                         "forceQuery": {
                           "floor": "Basement",
                           "zone": "Copper Room"
+                        }
+                      }
+                    },
+                    {
+                      "component": "builtin:devices/DeviceTable",
+                      "props": {
+                        "forceQuery": {
+                          "metadata.location.floor": "Basement",
+                          "metadata.location.zone": "Copper Room"
                         }
                       }
                     }
@@ -160,6 +175,15 @@
                           "zone": "Cotswold Room"
                         }
                       }
+                    },
+                    {
+                      "component": "builtin:devices/DeviceTable",
+                      "props": {
+                        "forceQuery": {
+                          "metadata.location.floor": "Basement",
+                          "metadata.location.zone": "Cotswold Room"
+                        }
+                      }
                     }
                   ],
                   "after": [
@@ -189,6 +213,15 @@
                         "forceQuery": {
                           "floor": "Basement",
                           "zone": "Kaolin Room"
+                        }
+                      }
+                    },
+                    {
+                      "component": "builtin:devices/DeviceTable",
+                      "props": {
+                        "forceQuery": {
+                          "metadata.location.floor": "Basement",
+                          "metadata.location.zone": "Kaolin Room"
                         }
                       }
                     }
@@ -258,6 +291,14 @@
                   "props": {
                     "forceQuery": {"floor": "Ground Floor"}
                   }
+                },
+                {
+                  "component": "builtin:devices/DeviceTable",
+                  "props": {
+                    "forceQuery": {
+                      "metadata.location.floor": "Ground Floor"
+                    }
+                  }
                 }
               ],
               "after": [
@@ -289,6 +330,15 @@
                           "zone": "Reception"
                         }
                       }
+                    },
+                    {
+                      "component": "builtin:devices/DeviceTable",
+                      "props": {
+                        "forceQuery": {
+                          "metadata.location.floor": "Ground Floor",
+                          "metadata.location.zone": "Reception"
+                        }
+                      }
                     }
                   ],
                   "after": [
@@ -318,6 +368,15 @@
                         "forceQuery": {
                           "floor": "Ground Floor",
                           "zone": "Teal Room"
+                        }
+                      }
+                    },
+                    {
+                      "component": "builtin:devices/DeviceTable",
+                      "props": {
+                        "forceQuery": {
+                          "metadata.location.floor": "Ground Floor",
+                          "metadata.location.zone": "Teal Room"
                         }
                       }
                     }
@@ -364,6 +423,15 @@
                           "zone": "Green Room"
                         }
                       }
+                    },
+                    {
+                      "component": "builtin:devices/DeviceTable",
+                      "props": {
+                        "forceQuery": {
+                          "metadata.location.floor": "Ground Floor",
+                          "metadata.location.zone": "Green Room"
+                        }
+                      }
                     }
                   ],
                   "after": [
@@ -393,6 +461,15 @@
                         "forceQuery": {
                           "floor": "Ground Floor",
                           "zone": "Yellow Room"
+                        }
+                      }
+                    },
+                    {
+                      "component": "builtin:devices/DeviceTable",
+                      "props": {
+                        "forceQuery": {
+                          "metadata.location.floor": "Ground Floor",
+                          "metadata.location.zone": "Yellow Room"
                         }
                       }
                     }
@@ -450,6 +527,14 @@
                   "props": {
                     "forceQuery": {"floor": "First Floor"}
                   }
+                },
+                {
+                  "component": "builtin:devices/DeviceTable",
+                  "props": {
+                    "forceQuery": {
+                      "metadata.location.floor": "First Floor"
+                    }
+                  }
                 }
               ],
               "after": [
@@ -479,6 +564,15 @@
                         "forceQuery": {
                           "floor": "First Floor",
                           "zone": "The Bank"
+                        }
+                      }
+                    },
+                    {
+                      "component": "builtin:devices/DeviceTable",
+                      "props": {
+                        "forceQuery": {
+                          "metadata.location.floor": "First Floor",
+                          "metadata.location.zone": "The Bank"
                         }
                       }
                     }

--- a/ui/ops/src/composables/devices.js
+++ b/ui/ops/src/composables/devices.js
@@ -100,6 +100,7 @@ export function useDevicesMetadataField(value, field) {
 
 const NO_FLOOR = '< no floor >';
 const NO_ZONE = '< no zone >';
+const NO_SUBSYSTEM = '< no subsystem >';
 
 /**
  * @typedef {Object} UseDevicesOptions
@@ -111,7 +112,7 @@ const NO_ZONE = '< no zone >';
  * @property {string} search
  *   - if present adds a condition for each word {stringContainsFold: word}
  * @property {Device.Query.Condition.AsObject[]} conditions
- * @property {(value: Device.AsObject, index: number, array: Device.AsObject[]) => boolean} filter
+ * @property {(value: Device.AsObject, index?: number, array?: Device.AsObject[]) => boolean} filter
  */
 
 /**
@@ -206,23 +207,25 @@ export function useDeviceFloorList() {
 export function useDeviceFilters(forcedFilters) {
   const {value: md} = usePullDevicesMetadata([
     'metadata.location.floor',
-    'metadata.location.zone'
+    'metadata.location.zone',
+    'metadata.membership.subsystem'
   ]);
   const {keys: floorKeys} = useDevicesMetadataField(md, 'metadata.location.floor');
   const {keys: zoneKeys} = useDevicesMetadataField(md, 'metadata.location.zone');
+  const {keys: subsystemKeys} = useDevicesMetadataField(md, 'metadata.membership.subsystem');
   const filterOpts = computed(() => {
     const filters = [];
     const defaults = [];
 
     const forced = toValue(forcedFilters) ?? {};
 
-    if (!Object.hasOwn(forced, 'floor')) {
+    if (!Object.hasOwn(forced, 'metadata.location.floor')) {
       const floors = [...floorKeys.value]
           .sort((a, b) => a.localeCompare(b, undefined, {numeric: true}))
           .map(f => f === '' ? NO_FLOOR : f);
       if (floors.length > 1) {
         filters.push({
-          key: 'floor',
+          key: 'metadata.location.floor',
           icon: 'mdi-layers-triple-outline',
           title: 'Floor',
           type: 'list',
@@ -231,15 +234,28 @@ export function useDeviceFilters(forcedFilters) {
       }
     }
 
-    if (!Object.hasOwn(forced, 'zone')) {
+    if (!Object.hasOwn(forced, 'metadata.location.zone')) {
       const zones = zoneKeys.value.map(z => z === '' ? NO_ZONE : z);
       if (zones.length > 1) {
         filters.push({
-          key: 'zone',
+          key: 'metadata.location.zone',
           icon: 'mdi-select-all',
           title: 'Zone',
           type: 'list',
           items: zones
+        });
+      }
+    }
+
+    if (!Object.hasOwn(forced, 'metadata.membership.subsystem')) {
+      const subsystems = subsystemKeys.value.map(s => s === '' ? NO_SUBSYSTEM : s);
+      if (subsystems.length > 1) {
+        filters.push({
+          key: 'metadata.membership.subsystem',
+          icon: 'mdi-cube-outline',
+          title: 'Subsystem',
+          type: 'list',
+          items: subsystems
         });
       }
     }
@@ -253,18 +269,22 @@ export function useDeviceFilters(forcedFilters) {
     if (value === undefined || value === null) return null;
     switch (field) {
       case 'floor':
+      case 'metadata.location.floor':
         return {field: 'metadata.location.floor', stringEqualFold: value === NO_FLOOR ? '' : value};
       case 'zone':
+      case 'metadata.location.zone':
         return {field: 'metadata.location.zone', stringEqualFold: value === NO_ZONE ? '' : value};
       case 'subsystem':
-        return {field: 'metadata.membership.subsystem', stringEqualFold: value};
+      case 'metadata.membership.subsystem':
+        return {field: 'metadata.membership.subsystem', stringEqualFold: value === NO_SUBSYSTEM ? '' : value};
+      default:
+        return {field: field, stringEqualFold: value};
     }
-    return null;
   };
 
   const forcedConditions = computed(() => {
     const res = [];
-    for (const [k, v] of Object.entries(forcedFilters.value)) {
+    for (const [k, v] of Object.entries(toValue(forcedFilters) ?? {})) {
       const cond = toCondition(k, v);
       if (cond) res.push(cond);
     }

--- a/ui/ops/src/dynamic/widgets/pallet.js
+++ b/ui/ops/src/dynamic/widgets/pallet.js
@@ -10,5 +10,6 @@ export const builtinWidgets = {
   'notifications/ZoneNotifications': defineAsyncComponent(() => import('@/dynamic/widgets/notifications/ZoneNotifications.vue')),
   // from elsewhere in our codebase
   'lighting/LightIcon': defineAsyncComponent(() => import('@/traits/light/LightIcon.vue')),
-  'environmental/AirTemperatureChip': defineAsyncComponent(() => import('@/traits/airTemperature/AirTemperatureChip.vue'))
+  'environmental/AirTemperatureChip': defineAsyncComponent(() => import('@/traits/airTemperature/AirTemperatureChip.vue')),
+  'devices/DeviceTable': defineAsyncComponent(() => import('@/routes/devices/components/DeviceTable.vue'))
 };


### PR DESCRIPTION
These changes were mostly about relaxing the subsystem filtering assumptions we were using when the device was a full page with sidebar nav. Now you can filter by subsystem if the condition isn't forced.