### PR TITLE
node: add AnnounceScope and ReplaceAnnouncer, deprecate AnnounceContext

### DIFF
--- a/pkg/auto/history/occupancysensor_test.go
+++ b/pkg/auto/history/occupancysensor_test.go
@@ -28,9 +28,9 @@ func Test_automation_collectOccupancyChanges(t *testing.T) {
 	)
 
 	collector := &automation{
-		clients:  n,
-		announce: n,
-		logger:   zap.NewNop(),
+		clients:   n,
+		announcer: node.NewReplaceAnnouncer(n),
+		logger:    zap.NewNop(),
 	}
 
 	payloads := make(chan []byte, 5)

--- a/pkg/driver/pestsense/driver.go
+++ b/pkg/driver/pestsense/driver.go
@@ -22,7 +22,7 @@ type factory struct{}
 
 func (f factory) New(services driver.Services) service.Lifecycle {
 	d := &Driver{
-		announcer: services.Node,
+		announcer: node.NewReplaceAnnouncer(services.Node),
 	}
 	d.Service = service.New(service.MonoApply(d.applyConfig))
 	d.logger = services.Logger.Named(DriverName)
@@ -32,7 +32,7 @@ func (f factory) New(services driver.Services) service.Lifecycle {
 type Driver struct {
 	*service.Service[config.Root]
 	logger    *zap.Logger
-	announcer node.Announcer
+	announcer *node.ReplaceAnnouncer
 
 	devices map[string]*PestSensor
 
@@ -40,7 +40,7 @@ type Driver struct {
 }
 
 func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
-	announcer := node.AnnounceContext(ctx, d.announcer)
+	announcer := d.announcer.Replace(ctx)
 
 	d.devices = make(map[string]*PestSensor)
 	// Add devices and apis

--- a/pkg/driver/shelly/trv/driver.go
+++ b/pkg/driver/shelly/trv/driver.go
@@ -21,7 +21,7 @@ type factory struct{}
 
 func (f factory) New(services driver.Services) service.Lifecycle {
 	d := &Driver{
-		announcer: services.Node,
+		announcer: node.NewReplaceAnnouncer(services.Node),
 	}
 	d.Service = service.New(service.MonoApply(d.applyConfig))
 	d.logger = services.Logger.Named(DriverName)
@@ -31,13 +31,13 @@ func (f factory) New(services driver.Services) service.Lifecycle {
 type Driver struct {
 	*service.Service[config.Root]
 	logger    *zap.Logger
-	announcer node.Announcer
+	announcer *node.ReplaceAnnouncer
 
 	devices []*TRV
 }
 
 func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
-	announcer := node.AnnounceContext(ctx, d.announcer)
+	announcer := d.announcer.Replace(ctx)
 
 	for _, device := range cfg.Devices {
 		logger := d.logger.Named(device.Name)

--- a/pkg/driver/steinel/hpd/driver.go
+++ b/pkg/driver/steinel/hpd/driver.go
@@ -27,7 +27,7 @@ type factory struct{}
 
 func (f factory) New(services driver.Services) service.Lifecycle {
 	d := &Driver{
-		announcer: services.Node,
+		announcer: node.NewReplaceAnnouncer(services.Node),
 	}
 	d.Service = service.New(service.MonoApply(d.applyConfig))
 	d.logger = services.Logger.Named(DriverName)
@@ -37,7 +37,7 @@ func (f factory) New(services driver.Services) service.Lifecycle {
 type Driver struct {
 	*service.Service[config.Root]
 	logger    *zap.Logger
-	announcer node.Announcer
+	announcer *node.ReplaceAnnouncer
 
 	client *Client
 
@@ -49,7 +49,7 @@ type Driver struct {
 }
 
 func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
-	announcer := node.AnnounceContext(ctx, d.announcer)
+	announcer := d.announcer.Replace(ctx)
 	if cfg.Metadata != nil {
 		announcer.Announce(cfg.Name, node.HasMetadata(cfg.Metadata))
 	}

--- a/pkg/system/alerts/factory.go
+++ b/pkg/system/alerts/factory.go
@@ -27,7 +27,7 @@ func NewSystem(services system.Services) *System {
 	logger := services.Logger.Named("alerts")
 	s := &System{
 		name:      services.Node.Name(),
-		announcer: services.Node,
+		announcer: node.NewReplaceAnnouncer(services.Node),
 
 		cohortManagerName: "", // use the default
 		cohortManager:     services.CohortManager,
@@ -45,7 +45,7 @@ type System struct {
 	*service.Service[config.Root]
 
 	name      string
-	announcer node.Announcer
+	announcer *node.ReplaceAnnouncer
 
 	cohortManagerName string
 	cohortManager     node.Remote
@@ -53,7 +53,7 @@ type System struct {
 
 func (s *System) applyConfig(ctx context.Context, cfg config.Root) error {
 	// using AnnounceContext only makes when using MonoApply, which we are in NewSystem
-	announcer := node.AnnounceContext(ctx, s.announcer)
+	announcer := s.announcer.Replace(ctx)
 
 	if cfg.Storage == nil {
 		return errors.New("no storage")

--- a/pkg/system/history/factory.go
+++ b/pkg/system/history/factory.go
@@ -33,7 +33,7 @@ func NewSystem(services system.Services) *System {
 	logger := services.Logger.Named("history")
 	s := &System{
 		name:      services.Node.Name(),
-		announcer: services.Node,
+		announcer: node.NewReplaceAnnouncer(services.Node),
 		db:        services.Database,
 		logger:    logger,
 	}
@@ -49,7 +49,7 @@ func NewSystem(services system.Services) *System {
 type System struct {
 	*service.Service[config.Root]
 	name      string
-	announcer node.Announcer
+	announcer *node.ReplaceAnnouncer
 	db        *bolthold.Store
 
 	logger *zap.Logger
@@ -57,7 +57,7 @@ type System struct {
 
 func (s *System) applyConfig(ctx context.Context, cfg config.Root) error {
 	// using AnnounceContext only makes when using MonoApply, which we are in NewSystem
-	announcer := node.AnnounceContext(ctx, s.announcer)
+	announcer := s.announcer.Replace(ctx)
 
 	if cfg.Storage == nil {
 		return errors.New("no storage")

--- a/pkg/zone/area/area.go
+++ b/pkg/zone/area/area.go
@@ -57,9 +57,9 @@ type factory struct {
 func (f factory) New(services zone.Services) service.Lifecycle {
 	services.Logger = services.Logger.Named("area")
 	a := &Area{
-		services:      services,
-		features:      f.features,
-		announcements: node.NewReplaceAnnouncer(services.Node),
+		services:  services,
+		features:  f.features,
+		announcer: node.NewReplaceAnnouncer(services.Node),
 	}
 	a.Service = service.New(service.MonoApply(a.applyConfig))
 	return a
@@ -97,13 +97,13 @@ func (f factory) ConfigBlocks(cfg *sysconf.Config) []block.Block {
 
 type Area struct {
 	*service.Service[config.Root]
-	services      zone.Services
-	features      []zone.Factory
-	announcements *node.ReplaceAnnouncer
+	services  zone.Services
+	features  []zone.Factory
+	announcer *node.ReplaceAnnouncer
 }
 
 func (a *Area) applyConfig(ctx context.Context, cfg config.Root) error {
-	announce := a.announcements.Replace(ctx)
+	announce := a.announcer.Replace(ctx)
 	if cfg.Metadata != nil {
 		announce.Announce(cfg.Name, node.HasMetadata(cfg.Metadata))
 	}

--- a/pkg/zone/feature/access/access.go
+++ b/pkg/zone/feature/access/access.go
@@ -16,10 +16,10 @@ import (
 var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 	services.Logger = services.Logger.Named("access")
 	f := &feature{
-		announce: services.Node,
-		devices:  services.Devices,
-		clients:  services.Node,
-		logger:   services.Logger,
+		announcer: node.NewReplaceAnnouncer(services.Node),
+		devices:   services.Devices,
+		clients:   services.Node,
+		logger:    services.Logger,
 	}
 	f.Service = service.New(service.MonoApply(f.applyConfig))
 	return f
@@ -27,14 +27,14 @@ var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 
 type feature struct {
 	*service.Service[config.Root]
-	announce node.Announcer
-	devices  *zone.Devices
-	clients  node.Clienter
-	logger   *zap.Logger
+	announcer *node.ReplaceAnnouncer
+	devices   *zone.Devices
+	clients   node.Clienter
+	logger    *zap.Logger
 }
 
 func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
-	announce := node.AnnounceContext(ctx, f.announce)
+	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 
 	if len(cfg.AccessPoints) > 0 {

--- a/pkg/zone/feature/airquality/airquality.go
+++ b/pkg/zone/feature/airquality/airquality.go
@@ -17,10 +17,10 @@ import (
 var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 	services.Logger = services.Logger.Named("airquality")
 	f := &feature{
-		announce: services.Node,
-		devices:  services.Devices,
-		clients:  services.Node,
-		logger:   services.Logger,
+		announcer: node.NewReplaceAnnouncer(services.Node),
+		devices:   services.Devices,
+		clients:   services.Node,
+		logger:    services.Logger,
 	}
 	f.Service = service.New(service.MonoApply(f.applyConfig))
 	return f
@@ -28,14 +28,14 @@ var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 
 type feature struct {
 	*service.Service[config.Root]
-	announce node.Announcer
-	devices  *zone.Devices
-	clients  node.Clienter
-	logger   *zap.Logger
+	announcer *node.ReplaceAnnouncer
+	devices   *zone.Devices
+	clients   node.Clienter
+	logger    *zap.Logger
 }
 
 func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
-	announce := node.AnnounceContext(ctx, f.announce)
+	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 
 	if len(cfg.AirQualitySensors) > 0 {

--- a/pkg/zone/feature/electric/electric.go
+++ b/pkg/zone/feature/electric/electric.go
@@ -18,10 +18,10 @@ import (
 var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 	services.Logger = services.Logger.Named("electric")
 	f := &feature{
-		announce: services.Node,
-		devices:  services.Devices,
-		clients:  services.Node,
-		logger:   services.Logger,
+		announcer: node.NewReplaceAnnouncer(services.Node),
+		devices:   services.Devices,
+		clients:   services.Node,
+		logger:    services.Logger,
 	}
 	f.Service = service.New(service.MonoApply(f.applyConfig))
 	return f
@@ -29,10 +29,10 @@ var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 
 type feature struct {
 	*service.Service[config.Root]
-	announce node.Announcer
-	devices  *zone.Devices
-	clients  node.Clienter
-	logger   *zap.Logger
+	announcer *node.ReplaceAnnouncer
+	devices   *zone.Devices
+	clients   node.Clienter
+	logger    *zap.Logger
 }
 
 func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
@@ -44,7 +44,7 @@ func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
 		return err
 	}
 
-	announce := node.AnnounceContext(ctx, f.announce)
+	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 
 	announceGroup := func(name string, devices []string) {

--- a/pkg/zone/feature/enterleave/enterleave.go
+++ b/pkg/zone/feature/enterleave/enterleave.go
@@ -23,7 +23,7 @@ type enterLeave struct {
 }
 
 func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
-	announce := node.AnnounceContext(ctx, f.announce)
+	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 
 	if len(cfg.EnterLeaveSensors) > 0 {

--- a/pkg/zone/feature/enterleave/group.go
+++ b/pkg/zone/feature/enterleave/group.go
@@ -31,19 +31,19 @@ type Group struct {
 
 type feature struct {
 	*service.Service[config.Root]
-	announce node.Announcer
-	devices  *zone.Devices
-	clients  node.Clienter
-	logger   *zap.Logger
+	announcer *node.ReplaceAnnouncer
+	devices   *zone.Devices
+	clients   node.Clienter
+	logger    *zap.Logger
 }
 
 var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 	services.Logger = services.Logger.Named("enterleave")
 	f := &feature{
-		announce: services.Node,
-		devices:  services.Devices,
-		clients:  services.Node,
-		logger:   services.Logger,
+		announcer: node.NewReplaceAnnouncer(services.Node),
+		devices:   services.Devices,
+		clients:   services.Node,
+		logger:    services.Logger,
 	}
 	f.Service = service.New(service.MonoApply(f.applyConfig))
 	return f

--- a/pkg/zone/feature/hvac/hvac.go
+++ b/pkg/zone/feature/hvac/hvac.go
@@ -18,10 +18,10 @@ import (
 var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 	services.Logger = services.Logger.Named("hvac")
 	f := &feature{
-		announce: services.Node,
-		devices:  services.Devices,
-		clients:  services.Node,
-		logger:   services.Logger,
+		announcer: node.NewReplaceAnnouncer(services.Node),
+		devices:   services.Devices,
+		clients:   services.Node,
+		logger:    services.Logger,
 	}
 	f.Service = service.New(service.MonoApply(f.applyConfig))
 	return f
@@ -29,14 +29,14 @@ var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 
 type feature struct {
 	*service.Service[config.Root]
-	announce node.Announcer
-	devices  *zone.Devices
-	clients  node.Clienter
-	logger   *zap.Logger
+	announcer *node.ReplaceAnnouncer
+	devices   *zone.Devices
+	clients   node.Clienter
+	logger    *zap.Logger
 }
 
 func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
-	announce := node.AnnounceContext(ctx, f.announce)
+	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 	publish := func(name string, t config.Thermostat) error {
 		var client traits.AirTemperatureApiClient

--- a/pkg/zone/feature/lighting/lighting.go
+++ b/pkg/zone/feature/lighting/lighting.go
@@ -20,10 +20,10 @@ import (
 var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 	services.Logger = services.Logger.Named("lighting")
 	f := &feature{
-		announce: services.Node,
-		devices:  services.Devices,
-		clients:  services.Node,
-		logger:   services.Logger,
+		announcer: node.NewReplaceAnnouncer(services.Node),
+		devices:   services.Devices,
+		clients:   services.Node,
+		logger:    services.Logger,
 	}
 	f.Service = service.New(service.MonoApply(f.applyConfig))
 	return f
@@ -31,14 +31,14 @@ var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 
 type feature struct {
 	*service.Service[config.Root]
-	announce node.Announcer
-	devices  *zone.Devices
-	clients  node.Clienter
-	logger   *zap.Logger
+	announcer *node.ReplaceAnnouncer
+	devices   *zone.Devices
+	clients   node.Clienter
+	logger    *zap.Logger
 }
 
 func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
-	announce := node.AnnounceContext(ctx, f.announce)
+	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 
 	announceGroup := func(name string, lights []string, logger *zap.Logger) error {

--- a/pkg/zone/feature/meter/meter.go
+++ b/pkg/zone/feature/meter/meter.go
@@ -17,10 +17,10 @@ import (
 var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 	services.Logger = services.Logger.Named("meter")
 	f := &feature{
-		announce: services.Node,
-		devices:  services.Devices,
-		clients:  services.Node,
-		logger:   services.Logger,
+		announcer: node.NewReplaceAnnouncer(services.Node),
+		devices:   services.Devices,
+		clients:   services.Node,
+		logger:    services.Logger,
 	}
 	f.Service = service.New(service.MonoApply(f.applyConfig))
 	return f
@@ -28,14 +28,14 @@ var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 
 type feature struct {
 	*service.Service[config.Root]
-	announce node.Announcer
-	devices  *zone.Devices
-	clients  node.Clienter
-	logger   *zap.Logger
+	announcer *node.ReplaceAnnouncer
+	devices   *zone.Devices
+	clients   node.Clienter
+	logger    *zap.Logger
 }
 
 func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
-	announce := node.AnnounceContext(ctx, f.announce)
+	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 
 	var apiClient gen.MeterApiClient

--- a/pkg/zone/feature/mode/mode.go
+++ b/pkg/zone/feature/mode/mode.go
@@ -17,10 +17,10 @@ import (
 var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 	services.Logger = services.Logger.Named("mode")
 	f := &feature{
-		announce: services.Node,
-		devices:  services.Devices,
-		clients:  services.Node,
-		logger:   services.Logger,
+		announcer: node.NewReplaceAnnouncer(services.Node),
+		devices:   services.Devices,
+		clients:   services.Node,
+		logger:    services.Logger,
 	}
 	f.Service = service.New(service.MonoApply(f.applyConfig), service.WithParser(config.ReadConfigBytes))
 	return f
@@ -28,17 +28,17 @@ var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 
 type feature struct {
 	*service.Service[config.Root]
-	announce node.Announcer
-	devices  *zone.Devices
-	clients  node.Clienter
-	logger   *zap.Logger
+	announcer *node.ReplaceAnnouncer
+	devices   *zone.Devices
+	clients   node.Clienter
+	logger    *zap.Logger
 }
 
 func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
 	if len(cfg.Modes) == 0 {
 		return nil
 	}
-	announce := node.AnnounceContext(ctx, f.announce)
+	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 
 	var api traits.ModeApiClient

--- a/pkg/zone/feature/occupancy/occupancy.go
+++ b/pkg/zone/feature/occupancy/occupancy.go
@@ -16,10 +16,10 @@ import (
 var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 	services.Logger = services.Logger.Named("occupancy")
 	f := &feature{
-		announce: services.Node,
-		devices:  services.Devices,
-		clients:  services.Node,
-		logger:   services.Logger,
+		announcer: node.NewReplaceAnnouncer(services.Node),
+		devices:   services.Devices,
+		clients:   services.Node,
+		logger:    services.Logger,
 	}
 	f.Service = service.New(service.MonoApply(f.applyConfig))
 	return f
@@ -27,14 +27,14 @@ var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 
 type feature struct {
 	*service.Service[config.Root]
-	announce node.Announcer
-	devices  *zone.Devices
-	clients  node.Clienter
-	logger   *zap.Logger
+	announcer *node.ReplaceAnnouncer
+	devices   *zone.Devices
+	clients   node.Clienter
+	logger    *zap.Logger
 }
 
 func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
-	announce := node.AnnounceContext(ctx, f.announce)
+	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 
 	if len(cfg.OccupancySensors) > 0 || len(cfg.EnterLeaveOccupancySensors) > 0 {

--- a/pkg/zone/feature/openclose/openclose.go
+++ b/pkg/zone/feature/openclose/openclose.go
@@ -22,10 +22,10 @@ import (
 var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 	services.Logger = services.Logger.Named("openclose")
 	f := &feature{
-		announce: services.Node,
-		devices:  services.Devices,
-		clients:  services.Node,
-		logger:   services.Logger,
+		announcer: node.NewReplaceAnnouncer(services.Node),
+		devices:   services.Devices,
+		clients:   services.Node,
+		logger:    services.Logger,
 	}
 	f.Service = service.New(service.MonoApply(f.applyConfig))
 	return f
@@ -33,14 +33,14 @@ var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 
 type feature struct {
 	*service.Service[config.Root]
-	announce node.Announcer
-	devices  *zone.Devices
-	clients  node.Clienter
-	logger   *zap.Logger
+	announcer *node.ReplaceAnnouncer
+	devices   *zone.Devices
+	clients   node.Clienter
+	logger    *zap.Logger
 }
 
 func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
-	announce := node.AnnounceContext(ctx, f.announce)
+	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 
 	var apiClient traits.OpenCloseApiClient

--- a/pkg/zone/feature/status/status.go
+++ b/pkg/zone/feature/status/status.go
@@ -16,10 +16,10 @@ import (
 var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 	services.Logger = services.Logger.Named("status")
 	f := &feature{
-		announce: services.Node,
-		devices:  services.Devices,
-		clients:  services.Node,
-		logger:   services.Logger,
+		announcer: node.NewReplaceAnnouncer(services.Node),
+		devices:   services.Devices,
+		clients:   services.Node,
+		logger:    services.Logger,
 	}
 	f.Service = service.New(service.MonoApply(f.applyConfig))
 	return f
@@ -27,14 +27,14 @@ var Feature = zone.FactoryFunc(func(services zone.Services) service.Lifecycle {
 
 type feature struct {
 	*service.Service[config.Root]
-	announce node.Announcer
-	devices  *zone.Devices
-	clients  node.Clienter
-	logger   *zap.Logger
+	announcer *node.ReplaceAnnouncer
+	devices   *zone.Devices
+	clients   node.Clienter
+	logger    *zap.Logger
 }
 
 func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
-	announce := node.AnnounceContext(ctx, f.announce)
+	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 
 	if len(cfg.StatusLogs) > 0 || cfg.StatusLogAll {


### PR DESCRIPTION
The existing AnnounceContext is insufficient for services, because there's no way to wait for previous announcements to be undone before announcing the devices again.
Announcements are then interleaved incorrectly with undos which produces missing metadata etc.

These new types provide a way for a driver to wait for its previous announcements to be undone before it makes new ones. 