### PR TITLE
SC-970: add HTTP middleware to authorize access

### DIFF
--- a/pkg/auth/policy/default/http.rego
+++ b/pkg/auth/policy/default/http.rego
@@ -1,0 +1,16 @@
+package http
+
+import data.scutil.token.token_has_role
+
+allow {
+  log_level_permission
+  input.path == "/__/log/level"
+}
+
+allow {
+  # everyone can get the service version
+  input.path == "/__/version"
+}
+
+log_level_permission { token_has_role("admin") }
+log_level_permission { token_has_role("super-admin") }

--- a/pkg/auth/policy/policy_test.go
+++ b/pkg/auth/policy/policy_test.go
@@ -40,7 +40,10 @@ func TestValidate(t *testing.T) {
 
 	cases := map[string]testCase{
 		"Hierarchy": {
-			attr:      Attributes{Service: "foo.bar.baz"},
+			attr: Attributes{
+				Protocol: ProtocolGRPC,
+				Service:  "foo.bar.baz",
+			},
 			expectErr: ErrPermissionDenied,
 			expectQueries: []string{
 				"data.foo.bar.baz.allow",
@@ -50,7 +53,10 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"ShortCircuit_Positive": {
-			attr: Attributes{Service: "foo.bar.baz"},
+			attr: Attributes{
+				Protocol: ProtocolGRPC,
+				Service:  "foo.bar.baz",
+			},
 			responses: map[string]rego.ResultSet{
 				"data.foo.bar.baz.allow": empty,
 				"data.foo.bar.allow":     allow,
@@ -63,7 +69,10 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"ShortCircuit_Negative": {
-			attr: Attributes{Service: "foo.bar.baz"},
+			attr: Attributes{
+				Protocol: ProtocolGRPC,
+				Service:  "foo.bar.baz",
+			},
 			responses: map[string]rego.ResultSet{
 				"data.foo.bar.baz.allow": empty,
 				"data.foo.bar.allow":     deny,
@@ -116,11 +125,17 @@ func TestValidate_Integration(t *testing.T) {
 	}
 	cases := map[string]testCase{
 		"foo.bar": {
-			attr:      Attributes{Service: "foo.bar"},
+			attr: Attributes{
+				Protocol: ProtocolGRPC,
+				Service:  "foo.bar",
+			},
 			expectErr: ErrPermissionDenied,
 		},
 		"foo.baz": {
-			attr:      Attributes{Service: "foo.baz"},
+			attr: Attributes{
+				Protocol: ProtocolGRPC,
+				Service:  "foo.baz",
+			},
 			expectErr: nil,
 		},
 	}


### PR DESCRIPTION
We have an endpoint `/__/log/level` which is not auth-protected but should be.

Add HTTP support to policy.Interceptor.

Add Protocol and Path to Attributes to allow policies to access HTTP details.

Only hook up HTTP auth for the log level handler for now.
Other endpoints should have it applied, but we need to
do a comprehensive inventory of endpoints first and work out what to do with the dynamically registered endpoints.