### PR TITLE
util/pull: retry pull even when Unimplemented

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgx/v4 v4.18.2
+	github.com/jonboulle/clockwork v0.5.0
 	github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9
 	github.com/olebedev/emitter v0.0.0-20190110104742-e8d1457e6aee
 	github.com/open-policy-agent/opa v0.68.0

--- a/go.sum
+++ b/go.sum
@@ -302,7 +302,10 @@ github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/pkg/util/pull/pull.go
+++ b/pkg/util/pull/pull.go
@@ -15,14 +15,113 @@ import (
 
 type Getter = func(context.Context) error
 
-// OrPoll will attempt to call pull, falling back to poll if it's not supported.
-// pull subscribe to changes, blocking until the subscription fails, if possible failures will be retried.
-// poll should query for the current state, this function manages delays between calls.
-func OrPoll(ctx context.Context, pull, poll Getter, opts ...Option) error {
+// OrPoll calls pull, falling back to repeated calls to get if pull returns a codes.Unimplemented error.
+// Argument pull should subscribe to changes, blocking until the subscription fails.
+// Argument get should get the current state, blocking until the state is got or an error occurs.
+// OrPoll blocks until the context is cancelled, retrying either pull or get on error.
+func OrPoll(ctx context.Context, pull, get Getter, opts ...Option) error {
 	conf := calcOpts(opts...)
 
-	shouldPoll := false
+	return runBlocking(ctx, "blocking tasks", func(ctx context.Context) error {
+		err := runPull(ctx, pull, conf)
+		if shouldReturn(err) {
+			return err
+		}
+		// the runPull err is never nil, so if we're here then we need to try polling
+		err = get(ctx) // get one to see if this is unimplemented too
+		if shouldReturn(err) {
+			return err
+		}
+		if !isUnimplemented(err) {
+			// pull is unimplemented but get is not, there's a chance things have changed (i.e. during boot)
+			// so try pull again just to be sure.
+			pullErr := runPull(ctx, pull, conf)
+			if shouldReturn(pullErr) {
+				return pullErr
+			}
+			// pull is still unimplemented, let's start the poll loop for real
+			err = runPoll(ctx, err, get, conf)
+			if shouldReturn(err) {
+				return err
+			}
+			// else get is unimplemented
+		}
 
+		// if we're here both pull and get returned unimplemented, so retry everything after a delay
+		return err
+	}, conf, func(error) bool { return false })
+}
+
+// Changes calls Pull on poller unless it's not supported, in which case it polls.
+// It will retry on error, backing off exponentially up to a maximum delay.
+// It will return if the context is cancelled or a non-recoverable error occurs.
+func Changes[C any](ctx context.Context, poller Fetcher[C], changes chan<- C, opts ...Option) error {
+	return OrPoll(ctx,
+		func(ctx context.Context) error {
+			return poller.Pull(ctx, changes)
+		},
+		func(ctx context.Context) error {
+			return poller.Poll(ctx, changes)
+		},
+		opts...)
+}
+
+// runPull retries calling pull returning on context cancellation or when pull returns an error that has codes.Unimplemented.
+// runPull will never return a nil error.
+func runPull(ctx context.Context, pull Getter, conf changeOpts) error {
+	return runBlocking(ctx, "pulls", pull, conf, isUnimplemented)
+}
+
+// runPoll blocks repeatedly calling get after some delay until context is cancelled or get returns an error that is not codes.Unimplemented.
+// runPoll never returns a nil error.
+func runPoll(ctx context.Context, err error, get Getter, conf changeOpts) error {
+	pollDelay := conf.pollDelay
+	errCount := 0
+	ticker := conf.clock.NewTicker(conf.pollDelay)
+	defer ticker.Stop()
+
+	incErr := func() {
+		errCount++
+		pollDelay = time.Duration(float64(pollDelay) * 1.2)
+		if pollDelay > conf.fallbackMaxDelay {
+			pollDelay = conf.fallbackMaxDelay
+		}
+		ticker.Reset(pollDelay)
+		if errCount == 5 {
+			conf.logger.Warn("poll is failing, will try keep retrying", zap.Error(err))
+		}
+	}
+
+	if err != nil {
+		incErr()
+	}
+
+	for {
+		// delay before first poll as the caller will have called get for us already.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.Chan():
+		}
+
+		err := get(ctx)
+		if shouldReturn(err) || isUnimplemented(err) {
+			return err
+		}
+		if err != nil {
+			incErr()
+		} else {
+			// get worked, reset the poll delay back to the configured one (if we have to)
+			if pollDelay != conf.pollDelay {
+				pollDelay = conf.pollDelay
+				ticker.Reset(conf.pollDelay)
+			}
+		}
+	}
+}
+
+// runBlocking reties task until ctx is cancelled or fatal returns true for returned errors.
+func runBlocking(ctx context.Context, name string, task Getter, conf changeOpts, fatal func(error) bool) error {
 	var mu sync.Mutex
 	var delay time.Duration
 	var errCount int
@@ -54,113 +153,46 @@ func OrPoll(ctx context.Context, pull, poll Getter, opts ...Option) error {
 	}
 
 	// These are used to track successful pulls.
-	// The Pull method itself blocks until error so we have to track separately for success,
+	// The task method itself blocks until error so we have to track separately for success,
 	// mostly for peace of mind and logging.
-	var pullDuration time.Duration
-	const successfulPullMultiplier = 4
-	pullSuccessTimer := time.AfterFunc(math.MaxInt64, func() {
+	var taskDuration time.Duration
+	const successfulMultiplier = 4
+	successTimer := conf.clock.AfterFunc(math.MaxInt64, func() {
 		attempts := resetErr()
 		if attempts > 5 { // we only log failure after 5 attempts
-			conf.logger.Debug("pulls are now succeeding", zap.Int("attempts", attempts))
+			conf.logger.Debug(name+" are now succeeding", zap.Int("attempts", attempts))
 		}
 	})
-	pullSuccessTimer.Stop() // avoid the timer actually running, the above was just to avoid nil timers
+	successTimer.Stop() // avoid the timer actually running, the above was just to avoid nil timers
+	defer successTimer.Stop()
 
 	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
+		t0 := conf.clock.Now()
+		err := task(ctx) // blocks
+		taskDuration = conf.clock.Since(t0)
+		successTimer.Stop()
+
+		if shouldReturn(err) || fatal(err) {
+			return err
 		}
-
-		if shouldPoll {
-			return runPoll(ctx, poll, conf)
+		if err != nil {
+			errCount := incErr()
+			successTimer.Reset(taskDuration * successfulMultiplier)
+			if errCount == 5 {
+				conf.logger.Warn(name+" are failing, will keep retrying", zap.Error(err))
+			}
 		} else {
-			if errCount > 0 {
-				pullSuccessTimer.Reset(pullDuration * successfulPullMultiplier)
-			}
-
-			t0 := time.Now()
-			err := pull(ctx)
-			pullDuration = time.Since(t0)
-
-			if err != nil {
-				pullSuccessTimer.Stop()
-				if shouldReturn(err) {
-					return err
-				}
-				if fallBackToPolling(err) {
-					conf.logger.Debug("pull not supported, polling instead")
-					shouldPoll = true
-					resetErr()
-					continue // skip the wait
-				}
-				if err != nil {
-					if incErr() == 5 {
-						conf.logger.Warn("updates are failing, will keep retrying", zap.Error(err))
-					}
-				}
-			} else {
-				if errCount > 0 {
-					conf.logger.Debug("updates are now succeeding")
-				}
-				resetErr()
-			}
+			// A nil error means the task stopped successfully, this is unusual as it should block forever, but not technically an error.
+			// Let's make sure we run it again and hope that the next time it stays alive for longer.
+			resetErr()
+			continue // skip the wait
 		}
 
 		incDelay()
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(delay):
-		}
-	}
-}
-
-// Changes calls Pull on poller unless it's not supported, in which case it polls.
-// It will retry on error, backing off exponentially up to a maximum delay.
-// It will return if the context is cancelled or a non-recoverable error occurs.
-func Changes[C any](ctx context.Context, poller Fetcher[C], changes chan<- C, opts ...Option) error {
-	return OrPoll(ctx,
-		func(ctx context.Context) error {
-			return poller.Pull(ctx, changes)
-		},
-		func(ctx context.Context) error {
-			return poller.Poll(ctx, changes)
-		},
-		opts...)
-}
-
-func runPoll(ctx context.Context, get Getter, conf changeOpts) error {
-	pollDelay := conf.pollDelay
-	errCount := 0
-	ticker := time.NewTicker(conf.pollDelay)
-	defer ticker.Stop()
-	for {
-		err := get(ctx)
-		if err != nil {
-			if status.Code(err) == codes.Unimplemented {
-				return err
-			}
-
-			errCount++
-			pollDelay = time.Duration(float64(pollDelay) * 1.2)
-			if pollDelay > conf.fallbackMaxDelay {
-				pollDelay = conf.fallbackMaxDelay
-			}
-			if errCount == 5 {
-				conf.logger.Warn("poll is failing, will try keep retrying", zap.Error(err))
-			}
-		} else {
-			if pollDelay != conf.pollDelay {
-				pollDelay = conf.pollDelay
-				ticker.Reset(conf.pollDelay)
-			}
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
+		case <-conf.clock.After(delay):
 		}
 	}
 }
@@ -169,7 +201,7 @@ func shouldReturn(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
-func fallBackToPolling(err error) bool {
+func isUnimplemented(err error) bool {
 	if grpcError, ok := status.FromError(err); ok {
 		if grpcError.Code() == codes.Unimplemented {
 			return true

--- a/pkg/util/pull/pull.go
+++ b/pkg/util/pull/pull.go
@@ -72,7 +72,7 @@ func runPull(ctx context.Context, pull Getter, conf changeOpts) error {
 	return runBlocking(ctx, "pulls", pull, conf, isUnimplemented)
 }
 
-// runPoll blocks repeatedly calling get after some delay until context is cancelled or get returns an error that is not codes.Unimplemented.
+// runPoll blocks repeatedly calling get after some delay until context is cancelled or get returns an error that has codes.Unimplemented.
 // runPoll never returns a nil error.
 func runPoll(ctx context.Context, err error, get Getter, conf changeOpts) error {
 	pollDelay := conf.pollDelay

--- a/pkg/util/pull/pull_test.go
+++ b/pkg/util/pull/pull_test.go
@@ -36,7 +36,7 @@ func TestOrPoll(t *testing.T) {
 	})
 
 	t.Run("get", func(t *testing.T) {
-		ctx, stop := context.WithTimeout(context.Background(), 10000*time.Second)
+		ctx, stop := context.WithTimeout(context.Background(), 10*time.Second)
 		t.Cleanup(stop)
 
 		clock := clockwork.NewFakeClock()
@@ -44,7 +44,7 @@ func TestOrPoll(t *testing.T) {
 
 		res := make(chan error, 1)
 		go func() {
-			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock))
+			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock), WithPullFallbackJitter(0))
 		}()
 
 		pull.Return(status.Error(codes.Unimplemented, "not implemented"))
@@ -73,7 +73,7 @@ func TestOrPoll(t *testing.T) {
 
 		res := make(chan error, 1)
 		go func() {
-			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock))
+			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock), WithPullFallbackJitter(0))
 		}()
 
 		pull.Return(status.Error(codes.NotFound, "not found"))
@@ -94,7 +94,7 @@ func TestOrPoll(t *testing.T) {
 
 		res := make(chan error, 1)
 		go func() {
-			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock))
+			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock), WithPullFallbackJitter(0))
 		}()
 
 		pull.Return(status.Error(codes.Unimplemented, "not implemented"))
@@ -120,7 +120,7 @@ func TestOrPoll(t *testing.T) {
 
 		res := make(chan error, 1)
 		go func() {
-			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock))
+			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock), WithPullFallbackJitter(0))
 		}()
 
 		pull.Return(status.Error(codes.Unimplemented, "not implemented"))
@@ -144,7 +144,7 @@ func TestOrPoll(t *testing.T) {
 
 		res := make(chan error, 1)
 		go func() {
-			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock))
+			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock), WithPullFallbackJitter(0))
 		}()
 
 		pull.Return(status.Error(codes.Unimplemented, "not implemented"))

--- a/pkg/util/pull/pull_test.go
+++ b/pkg/util/pull/pull_test.go
@@ -1,0 +1,208 @@
+package pull
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/vanti-dev/sc-bos/pkg/util/chans"
+)
+
+func TestOrPoll(t *testing.T) {
+	const delay = 100 * time.Millisecond // used to wait for the blocking go routine
+
+	t.Run("pull", func(t *testing.T) {
+		ctx, stop := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(stop)
+
+		clock := clockwork.NewFakeClock()
+		pull, get := testGetters(t)
+
+		res := make(chan error, 1)
+		go func() {
+			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock))
+		}()
+
+		pull.AssertCalled()
+		get.AssertNotCalled()
+		if err := chans.IsEmptyWithin(res, delay); err != nil {
+			t.Errorf("expected no result, got %v", err)
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		ctx, stop := context.WithTimeout(context.Background(), 10000*time.Second)
+		t.Cleanup(stop)
+
+		clock := clockwork.NewFakeClock()
+		pull, get := testGetters(t)
+
+		res := make(chan error, 1)
+		go func() {
+			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock))
+		}()
+
+		pull.Return(status.Error(codes.Unimplemented, "not implemented"))
+		returns := get.AssertCalled()
+		if err := chans.IsEmptyWithin(res, delay); err != nil {
+			t.Errorf("expected no result, got %v", err)
+		}
+
+		// check the next get is called after poll delay (and not before)
+		returns <- nil
+		pull.Return(status.Error(codes.Unimplemented, "not implemented")) // double check
+		get.AssertNotCalled()
+		if err := clock.BlockUntilContext(ctx, 1); err != nil {
+			t.Errorf("expected wait on clock, but got %v", err)
+		}
+		clock.Advance(DefaultPollDelay)
+		get.AssertCalled()
+	})
+
+	t.Run("pull retry", func(t *testing.T) {
+		ctx, stop := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(stop)
+
+		clock := clockwork.NewFakeClock()
+		pull, get := testGetters(t)
+
+		res := make(chan error, 1)
+		go func() {
+			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock))
+		}()
+
+		pull.Return(status.Error(codes.NotFound, "not found"))
+		if err := clock.BlockUntilContext(ctx, 1); err != nil {
+			t.Errorf("expected wait on clock, but got %v", err)
+		}
+		pull.AssertNotCalled() // should wait for retry delay
+		clock.Advance(DefaultRetryInit)
+		pull.AssertCalled()
+	})
+
+	t.Run("get retry", func(t *testing.T) {
+		ctx, stop := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(stop)
+
+		clock := clockwork.NewFakeClock()
+		pull, get := testGetters(t)
+
+		res := make(chan error, 1)
+		go func() {
+			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock))
+		}()
+
+		pull.Return(status.Error(codes.Unimplemented, "not implemented"))
+		get.Return(status.Error(codes.NotFound, "not found"))
+		pull.Return(status.Error(codes.Unimplemented, "not implemented: retry"))
+		if err := clock.BlockUntilContext(ctx, 1); err != nil {
+			t.Errorf("expected wait on clock, but got %v", err)
+		}
+		get.AssertNotCalled() // should wait for retry delay
+		clock.Advance(DefaultPollDelay)
+		get.AssertNotCalled()               // on error, we increase the poll delay
+		clock.Advance(DefaultPollDelay / 2) // add on the remaining extra time
+		get.AssertCalled()
+	})
+
+	// pull and get report unimplemented until a delay, then pull reports ok
+	t.Run("delayed support", func(t *testing.T) {
+		ctx, stop := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(stop)
+
+		clock := clockwork.NewFakeClock()
+		pull, get := testGetters(t)
+
+		res := make(chan error, 1)
+		go func() {
+			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock))
+		}()
+
+		pull.Return(status.Error(codes.Unimplemented, "not implemented"))
+		get.Return(status.Error(codes.Unimplemented, "not implemented"))
+		if err := clock.BlockUntilContext(ctx, 1); err != nil {
+			t.Errorf("expected wait on clock, but got %v", err)
+		}
+		pull.AssertNotCalled()
+		get.AssertNotCalled()
+		clock.Advance(DefaultRetryInit)
+		pull.AssertCalled()
+	})
+
+	// pull reports unimplemented, get reports ok, pull then reports ok
+	t.Run("racy support", func(t *testing.T) {
+		ctx, stop := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(stop)
+
+		clock := clockwork.NewFakeClock()
+		pull, get := testGetters(t)
+
+		res := make(chan error, 1)
+		go func() {
+			res <- OrPoll(ctx, pull.Getter, get.Getter, withClock(clock))
+		}()
+
+		pull.Return(status.Error(codes.Unimplemented, "not implemented"))
+		get.Return(nil)
+		pull.AssertCalled()
+		get.AssertNotCalled()
+	})
+}
+
+func testGetters(t *testing.T) (pull, get *testGetter) {
+	return newTestGetter(t, "pull"), newTestGetter(t, "get")
+}
+
+func newTestGetter(t *testing.T, name string) *testGetter {
+	return &testGetter{t: t, name: name, calls: make(chan chan error)}
+}
+
+// testGetter is a Getter function with utilities for testing.
+type testGetter struct {
+	t         *testing.T
+	name      string
+	calls     chan chan error
+	closeOnce sync.Once
+}
+
+func (g *testGetter) Getter(ctx context.Context) error {
+	res := make(chan error, 1)
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case g.calls <- res:
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-res:
+			return err
+		}
+	}
+}
+
+func (g *testGetter) Return(err error) {
+	g.AssertCalled() <- err
+}
+
+func (g *testGetter) AssertCalled() chan<- error {
+	g.t.Helper()
+	if res, err := chans.RecvWithin(g.calls, time.Second); err != nil {
+		g.t.Errorf("%s expected called, but was not", g.name)
+		return nil
+	} else {
+		return res
+	}
+}
+
+func (g *testGetter) AssertNotCalled() {
+	g.t.Helper()
+	if err := chans.IsEmptyWithin(g.calls, 10*time.Millisecond); err != nil {
+		g.t.Errorf("%s expected not called, but was", g.name)
+	}
+}


### PR DESCRIPTION
pull.OrPoll (and pull.Changes) used to have an assumption that if pull and get both returned errors with codes.Unimplemented then there was no point continuing to retry the requests as this couldn't change. This assumption was violated when we implemented dynamic gRPC apis as part of the dynamic gateway work.

This change adjusts the pull functions to retry even when Unimplemented is returned.