### PR TITLE
ui: pathfinder for shared vue components

### DIFF
--- a/ui/ops/package.json
+++ b/ui/ops/package.json
@@ -15,6 +15,7 @@
     "@smart-core-os/sc-api-grpc-web": "^1.0.0-beta.48",
     "@vanti-dev/sc-bos-panzoom-package": "1.0.1-vanti.0",
     "@vanti-dev/sc-bos-ui-gen": "1.0.0-beta.19",
+    "@vanti-dev/sc-bos-ui-lib": "1.0.0-beta.1",
     "binary-search": "^1.3.6",
     "change-case": "^5.4.4",
     "chart.js": "^4.4.2",

--- a/ui/ops/src/components/default/AppBar.vue
+++ b/ui/ops/src/components/default/AppBar.vue
@@ -3,6 +3,7 @@
     <app-menu v-if="accountStore.isLoggedIn"/>
     <brand-logo :theme="config.theme" outline="white" style="height: 35px" class="ml-4 mr-2"/>
     <span class="heading">{{ appBarHeadingWithBrand }}</span>
+    <sc-btn>SC Button</sc-btn>
 
     <v-divider vertical v-if="hasSections" class="mx-8 section-divider" inset/>
 
@@ -27,6 +28,7 @@ import {usePage} from '@/components/page';
 import SmartCoreStatusCard from '@/components/smartCoreStatus/SmartCoreStatusCard.vue';
 import {useAccountStore} from '@/stores/account';
 import {useUiConfigStore} from '@/stores/uiConfig.js';
+import {ScBtn} from '@vanti-dev/sc-bos-ui-lib';
 import {storeToRefs} from 'pinia';
 
 import {computed} from 'vue';

--- a/ui/ops/vite.config.js
+++ b/ui/ops/vite.config.js
@@ -56,11 +56,16 @@ export default defineConfig(({mode}) => {
           configFile: 'src/sass/settings.scss'
         }
       }),
-      eslintPlugin()
+      eslintPlugin({
+        exclude: ['**/node_modules/**', '**/ui-lib/**']
+      })
     ],
     resolve: {
       alias: {
-        '@': fileURLToPath(new URL('./src', import.meta.url))
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+        '@vanti-dev/sc-bos-ui-lib': process.env.NODE_ENV === 'production' ?
+            '@vanti-dev/sc-bos-ui-lib' :
+            '@vanti-dev/sc-bos-ui-lib/index.js'
       }
     }
   };

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,6 +4,7 @@
     "keycloak-login-prototype",
     "ops",
     "panzoom-package",
-    "ui-gen"
+    "ui-gen",
+    "ui-lib"
   ]
 }

--- a/ui/ui-lib/.eslintrc.cjs
+++ b/ui/ui-lib/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  parserOptions: {
+    parser: null,
+    sourceType: 'module',
+    ecmaVersion: 'latest'
+  },
+  extends: [
+    'plugin:vue/recommended',
+    'plugin:jsdoc/recommended'
+  ],
+  ignorePatterns: ['dist/**/*'],
+  env: {
+    browser: true
+  }
+};

--- a/ui/ui-lib/index.js
+++ b/ui/ui-lib/index.js
@@ -1,0 +1,10 @@
+import * as components from './src/components';
+
+export * from './src/components';
+
+/** @type {import('Vue').FunctionPlugin} */
+export function install(app) {
+  for (const component in components) {
+    app.component(component, components[component]);
+  }
+}

--- a/ui/ui-lib/package.json
+++ b/ui/ui-lib/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@vanti-dev/sc-bos-ui-lib",
+  "version": "1.0.0-beta.1",
+  "type": "module",
+  "main": "dist/sc-bos-ui-lib.umd.cjs",
+  "module": "dist/sc-bos-ui-lib.js",
+  "exports": {
+    ".": {
+      "import": "./dist/sc-bos-ui-lib.js",
+      "require": "./dist/sc-bos-ui-lib.umd.cjs"
+    },
+    "./*": "./*"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "build:watch": "vite build --watch",
+    "preview": "vite preview",
+    "lint": "eslint . --ext .vue,.js --fix",
+    "lint:nofix": "eslint . --ext .vue,.js",
+    "lint:nibble": "eslint-nibble . --ext .vue,.js"
+  },
+  "dependencies": {
+    "@smart-core-os/sc-api-grpc-web": "^1.0.0-beta.48",
+    "@vanti-dev/sc-bos-ui-gen": "^1.0.0-beta.19",
+    "google-protobuf": "^3.21.2",
+    "grpc-web": "^1.4.2",
+    "vue": "^3.5.13"
+  },
+  "peerDependencies": {
+    "vue": "^3.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-plugin-jsdoc": "^50.2.1",
+    "eslint-plugin-vue": "^9.28.0",
+    "replace-in-file": "^8.1.0",
+    "vite": "^6.0.7",
+    "vite-plugin-eslint": "^1.8.1"
+  },
+  "repository": "https://github.com/vanti-dev/sc-bos",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/ui/ui-lib/src/components/ScBtn.vue
+++ b/ui/ui-lib/src/components/ScBtn.vue
@@ -1,0 +1,14 @@
+<script setup>
+import ScIcon from './ScIcon.vue';
+</script>
+
+<template>
+  <button class="sc-btn">
+    <ScIcon />
+    <slot />
+  </button>
+</template>
+
+<style scoped>
+
+</style>

--- a/ui/ui-lib/src/components/ScIcon.vue
+++ b/ui/ui-lib/src/components/ScIcon.vue
@@ -1,0 +1,11 @@
+<script setup>
+
+</script>
+
+<template>
+  <span>ICON</span>
+</template>
+
+<style scoped>
+
+</style>

--- a/ui/ui-lib/src/components/index.js
+++ b/ui/ui-lib/src/components/index.js
@@ -1,0 +1,3 @@
+import ScBtn from './ScBtn.vue';
+import ScIcon from './ScIcon.vue';
+export {ScBtn, ScIcon};

--- a/ui/ui-lib/vite.config.js
+++ b/ui/ui-lib/vite.config.js
@@ -1,0 +1,32 @@
+import vue from '@vitejs/plugin-vue';
+import {fileURLToPath, URL} from 'url';
+import {defineConfig} from 'vite';
+import eslintPlugin from 'vite-plugin-eslint';
+
+// https://vitejs.dev/config/
+export default defineConfig(({mode}) => {
+  return {
+    build: {
+      lib: {
+        entry: fileURLToPath(new URL('./index.js', import.meta.url)),
+        name:
+            'sc-bos-ui-lib'
+      },
+      rollupOptions: {
+        external: ['vue'],
+        output:
+            {
+              exports: 'named',
+              globals:
+                  {
+                    vue: 'Vue'
+                  }
+            }
+      }
+    },
+    plugins: [
+      vue(),
+      eslintPlugin()
+    ]
+  };
+})


### PR DESCRIPTION
This PR acts as documentation for the changes needed to have a Vue + Vite application import and use shared project local components and packages.

*Features*

- Hot reload of shared lib code from the app without any special setup
- Can build and publish the shared lib code for others outside this project to use
- Components can be used add hoc (via imports) or via a Vue plugin

*Issues*

- Need to maintain the `index.js` files manually - probably scriptable but can't think of a way to make it automatic (no scripts to run periodically)
- Can't use aliases in the library. Not sure why but the build fails if you do.
- The published lib will include `./*` as an export which is not ideal, but is required for the vite alias to the src `index.js` file to work.