### PR TITLE
node: don't log errors for services without methods

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -319,12 +319,19 @@ func traitServices(name trait.Name) ([]service, error) {
 
 	var services []service
 	for _, serviceDesc := range serviceDescs {
+		if len(serviceDesc.Methods) == 0 {
+			continue // avoid ERROR logs for services without methods, which would act as non-routable
+		}
 		desc, err := registryDescriptor(serviceDesc.ServiceName)
 		if err != nil {
 			return nil, err
 		}
 
 		services = append(services, service{desc: desc, nameRouting: true})
+	}
+
+	if len(services) == 0 {
+		return nil, fmt.Errorf("trait %s apis have no rpc methods", name)
 	}
 
 	return services, nil


### PR DESCRIPTION
If one of the aspects of a trait was defined without any rpc methods then this service would be treated by node.Node and router.Router as non-routable. During announcement Node would attempt to register that service against the new name, causing ERROR in the logs like:

> cannot register service smartcore.traits.ElectricInfo for "my-device": service "smartcore.traits.ElectricInfo" already exists but does not support name routing

This change filters out these useless services which also can cause issues with type checking, an empty interface matches against all types so everything implements ElectricInfoClient (for example)!