### PR TITLE
auto/lights: better logging

### DIFF
--- a/pkg/auto/lights/action.go
+++ b/pkg/auto/lights/action.go
@@ -46,7 +46,7 @@ func (a *clientActions) UpdateBrightness(ctx context.Context, now time.Time, req
 
 // updateBrightnessLevelIfNeeded sets all the names devices brightness levels to level and stores successful responses in state.
 // This does not send requests if state already has a named brightness level equal to level.
-func updateBrightnessLevelIfNeeded(ctx context.Context, now time.Time, state *WriteState, actions actions, level float32, logger *zap.Logger, names ...string) error {
+func updateBrightnessLevelIfNeeded(ctx context.Context, now time.Time, state *WriteState, actions actions, level float32, logger *zap.Logger, names ...deviceName) error {
 	for _, name := range names {
 		if val, ok := state.Brightness[name]; ok && val.V != nil {
 			expired := now.After(val.At.Add(brightnessCacheValidity))
@@ -70,7 +70,7 @@ func updateBrightnessLevelIfNeeded(ctx context.Context, now time.Time, state *Wr
 	return nil
 }
 
-func refreshBrightnessLevel(ctx context.Context, now time.Time, state *WriteState, actions actions, logger *zap.Logger, names ...string) error {
+func refreshBrightnessLevel(ctx context.Context, now time.Time, state *WriteState, actions actions, logger *zap.Logger, names ...deviceName) error {
 	for _, name := range names {
 		val, ok := state.Brightness[name]
 		if !ok || val.V == nil {

--- a/pkg/auto/lights/action.go
+++ b/pkg/auto/lights/action.go
@@ -44,9 +44,83 @@ func (a *clientActions) UpdateBrightness(ctx context.Context, now time.Time, req
 	return err
 }
 
+type actionCounts struct {
+	TotalWrites int
+
+	BrightnessUpdates map[float32][]deviceName // [brightness]names
+	BrightnessWrites  []deviceName             // which devices have been written to
+}
+
+// Changes returns a summary of the changes made by the actions.
+func (a actionCounts) Changes() []string {
+	var res []string
+	for brightness, names := range a.BrightnessUpdates {
+		if l := len(names); l > 1 {
+			res = append(res, fmt.Sprintf("%dx brightness=%.1f%%", l, brightness))
+		} else {
+			res = append(res, fmt.Sprintf("brightness=%.1f%%", brightness))
+		}
+	}
+	return res
+}
+
+// newCountActions counts all invocations of a and stores them in actionCounts.
+func newCountActions(a actions) (actions, *actionCounts) {
+	impl := &countActions{actions: a, actionCounts: &actionCounts{}}
+	return impl, impl.actionCounts
+}
+
+type countActions struct {
+	actions
+	*actionCounts
+}
+
+func (a *countActions) UpdateBrightness(ctx context.Context, now time.Time, req *traits.UpdateBrightnessRequest, state *WriteState) error {
+	a.TotalWrites++
+	a.BrightnessWrites = append(a.BrightnessWrites, req.Name)
+	if a.BrightnessUpdates == nil {
+		a.BrightnessUpdates = make(map[float32][]deviceName)
+	}
+	a.BrightnessUpdates[req.Brightness.LevelPercent] = append(a.BrightnessUpdates[req.Brightness.LevelPercent], req.Name)
+
+	return a.actions.UpdateBrightness(ctx, now, req, state)
+}
+
+// nilActions is an actions that has no side effects.
+// Actions are still recorded in the WriteState.
+type nilActions struct{}
+
+func (nilActions) UpdateBrightness(ctx context.Context, now time.Time, req *traits.UpdateBrightnessRequest, state *WriteState) error {
+	state.Brightness[req.Name] = Value[*traits.Brightness]{
+		V:  req.Brightness,
+		At: now,
+	}
+	return nil
+}
+
+// newLogActions logs to logger each time an action is invoked.
+func newLogActions(a actions, logger *zap.Logger) actions {
+	return &logActions{actions: a, logger: logger}
+}
+
+type logActions struct {
+	actions
+	logger *zap.Logger
+}
+
+func (a *logActions) UpdateBrightness(ctx context.Context, now time.Time, req *traits.UpdateBrightnessRequest, state *WriteState) error {
+	err := a.actions.UpdateBrightness(ctx, now, req, state)
+	a.logger.Debug("actions.UpdateBrightness",
+		zap.String("name", req.Name),
+		zap.Float32("level", req.Brightness.LevelPercent),
+		zap.Error(err),
+	)
+	return err
+}
+
 // updateBrightnessLevelIfNeeded sets all the names devices brightness levels to level and stores successful responses in state.
 // This does not send requests if state already has a named brightness level equal to level.
-func updateBrightnessLevelIfNeeded(ctx context.Context, now time.Time, state *WriteState, actions actions, level float32, logger *zap.Logger, names ...deviceName) error {
+func updateBrightnessLevelIfNeeded(ctx context.Context, now time.Time, state *WriteState, actions actions, level float32, names ...deviceName) error {
 	for _, name := range names {
 		if val, ok := state.Brightness[name]; ok && val.V != nil {
 			expired := now.After(val.At.Add(brightnessCacheValidity))
@@ -56,7 +130,6 @@ func updateBrightnessLevelIfNeeded(ctx context.Context, now time.Time, state *Wr
 			}
 		}
 
-		logger.Debug("Setting brightness for light fitting", zap.String("fitting name", name), zap.Float32("level", level))
 		err := actions.UpdateBrightness(ctx, now, &traits.UpdateBrightnessRequest{
 			Name: name,
 			Brightness: &traits.Brightness{
@@ -70,7 +143,7 @@ func updateBrightnessLevelIfNeeded(ctx context.Context, now time.Time, state *Wr
 	return nil
 }
 
-func refreshBrightnessLevel(ctx context.Context, now time.Time, state *WriteState, actions actions, logger *zap.Logger, names ...deviceName) error {
+func refreshBrightnessLevel(ctx context.Context, now time.Time, state *WriteState, actions actions, names ...deviceName) error {
 	for _, name := range names {
 		val, ok := state.Brightness[name]
 		if !ok || val.V == nil {
@@ -82,10 +155,6 @@ func refreshBrightnessLevel(ctx context.Context, now time.Time, state *WriteStat
 			continue
 		}
 
-		logger.Debug("refreshing brightness for light fitting",
-			zap.String("fitting name", name),
-			zap.Float32("level", val.V.LevelPercent),
-		)
 		err := actions.UpdateBrightness(ctx, now, &traits.UpdateBrightnessRequest{
 			Name:       name,
 			Brightness: val.V,

--- a/pkg/auto/lights/action.go
+++ b/pkg/auto/lights/action.go
@@ -21,8 +21,8 @@ type actions interface {
 	UpdateBrightness(ctx context.Context, now time.Time, req *traits.UpdateBrightnessRequest, state *WriteState) error
 }
 
-// newActions creates an actions backed by node.Clienter clients.
-func newActions(clients node.Clienter) (actions, error) {
+// newClientActions creates an actions backed by node.Clienter clients.
+func newClientActions(clients node.Clienter) (actions, error) {
 	res := &clientActions{}
 	if err := clients.Client(&res.lightClient); err != nil {
 		return nil, fmt.Errorf("%w traits.LightApiClient", err)

--- a/pkg/auto/lights/auto.go
+++ b/pkg/auto/lights/auto.go
@@ -33,7 +33,7 @@ func PirsTurnLightsOn(clients node.Clienter, logger *zap.Logger) *BrightnessAuto
 	return &BrightnessAutomation{
 		logger:      logger,
 		clients:     clients,
-		makeActions: newActions,
+		makeActions: newClientActions,
 		newTimer: func(duration time.Duration) (<-chan time.Time, func() bool) {
 			t := time.NewTimer(duration)
 			return t.C, t.Stop

--- a/pkg/auto/lights/auto_test.go
+++ b/pkg/auto/lights/auto_test.go
@@ -59,8 +59,8 @@ func TestPirsTurnLightsOn(t *testing.T) {
 
 	cfg := config.Default()
 	cfg.Now = func() time.Time { return now }
-	cfg.OccupancySensors = []string{"pir01", "pir02"}
-	cfg.Lights = []string{"light01", "light02"}
+	cfg.OccupancySensors = []deviceName{"pir01", "pir02"}
+	cfg.Lights = []deviceName{"light01", "light02"}
 	cfg.UnoccupiedOffDelay = jsontypes.Duration{Duration: 10 * time.Minute}
 	cfg.RefreshEvery = jsontypes.Duration{Duration: 8 * time.Minute}
 

--- a/pkg/auto/lights/buttons.go
+++ b/pkg/auto/lights/buttons.go
@@ -61,7 +61,7 @@ func captureButtonActions(readState *ReadState, writeState *WriteState, logger *
 }
 
 // getButtonType returns the type of button based on where it appeared in the config
-func getButtonType(state *ReadState, buttonName string) ButtonType {
+func getButtonType(state *ReadState, buttonName deviceName) ButtonType {
 	nFound := 0
 	buttonType := UndefinedButton
 	for _, name := range state.Config.OnButtons {
@@ -86,7 +86,7 @@ func getButtonType(state *ReadState, buttonName string) ButtonType {
 	return buttonType
 }
 
-func getMostRecentButtonPress(readState *ReadState) (name string, state *gen.ButtonState, ok bool) {
+func getMostRecentButtonPress(readState *ReadState) (name deviceName, state *gen.ButtonState, ok bool) {
 	mostRecentTime := time.Time{}
 	for n, button := range readState.Buttons {
 		if button.StateChangeTime.AsTime().After(mostRecentTime) {

--- a/pkg/auto/lights/config/root.go
+++ b/pkg/auto/lights/config/root.go
@@ -22,6 +22,13 @@ const (
 type Root struct {
 	auto.Config
 
+	// Debug and troubleshooting
+	DryRun          bool `json:"dryRun,omitempty"`          // Don't actually write to devices
+	LogWrites       bool `json:"logWrites,omitempty"`       // Log each write to a device as they happen
+	LogEmptyChanges bool `json:"logEmptyChanges,omitempty"` // Log even when no change has been made
+	LogTTLDelays    bool `json:"logTTLDelays,omitempty"`    // Log the TTL when no writes were performed, less chatty than LogEmptyChanges
+	LogTriggers     bool `json:"logTriggers,omitempty"`     // Log what triggered the auto (refresh, ttl, etc), can be chatty and expensive
+
 	OccupancySensors  []string `json:"occupancySensors,omitempty"`
 	Lights            []string `json:"lights,omitempty"`
 	BrightnessSensors []string `json:"brightnessSensors,omitempty"`

--- a/pkg/auto/lights/log.go
+++ b/pkg/auto/lights/log.go
@@ -1,0 +1,93 @@
+package lights
+
+import (
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// logProcessStart logs the start of a processState; the reason it is running.
+func logProcessStart(logger *zap.Logger, oldState, newState *ReadState, reasons ...string) {
+	merge := func(items ...string) []string {
+		if len(reasons) == 0 {
+			return items
+		}
+		if len(items) == 0 {
+			return reasons
+		}
+		return append(reasons, items...)
+	}
+	if oldState == nil {
+		logger.Debug("processState starting", zap.Strings("reasons", merge("initial state")))
+		return
+	}
+	changes := newState.ChangesSince(oldState)
+	if len(changes) == 0 {
+		logger.Debug("processState starting", zap.Strings("reasons", merge("no changes")))
+		return
+	}
+	logger.Debug("processState starting", zap.Strings("reasons", merge(changes...)))
+}
+
+// logProcessComplete logs the completion of a processState; the changes made and why those changes.
+func logProcessComplete(logger *zap.Logger, state *ReadState, writeState *WriteState, counts *actionCounts, duration, ttl time.Duration, err error) {
+	switch {
+	case err != nil:
+	// the caller will already have logged the error
+	case counts.TotalWrites > 0:
+		logger.Debug("processState completed",
+			zap.Strings("changes", counts.Changes()),
+			zap.Strings("reasons", writeState.Reasons),
+			zap.Stringer("duration", formattedDuration(duration)),
+			zap.Stringer("ttl", formattedDuration(ttl)),
+		)
+	case ttl > 0 && state.Config.LogTTLDelays:
+		logger.Debug("processState completed",
+			zap.Strings("reasons", writeState.Reasons),
+			zap.Stringer("duration", formattedDuration(duration)),
+			zap.Stringer("ttl", formattedDuration(ttl)),
+		)
+	case state.Config.LogEmptyChanges:
+		logger.Debug("processState completed",
+			zap.Strings("reasons", writeState.Reasons),
+			zap.Stringer("duration", formattedDuration(duration)),
+			zap.Stringer("ttl", formattedDuration(ttl)),
+		)
+	}
+}
+
+// formatDuration returns a more human and log compatible duration where exact values aren't required.
+func formatDuration(d time.Duration) string {
+	d2 := d
+	switch {
+	case d > time.Hour:
+		d2 = d.Round(time.Hour)
+	case d > time.Minute:
+		d2 = d.Round(time.Minute)
+	case d > time.Second:
+		d2 = d.Round(time.Second)
+	case d > time.Millisecond:
+		d2 = d.Round(time.Millisecond)
+	case d > time.Microsecond:
+		d2 = d.Round(time.Microsecond)
+	}
+
+	s := d2.String()
+	if d2 != d {
+		s = "~" + s
+	}
+	if strings.HasSuffix(s, "m0s") {
+		s = s[:len(s)-2]
+	}
+	if strings.HasSuffix(s, "h0m") {
+		s = s[:len(s)-2]
+	}
+	return s
+}
+
+type formattedDuration time.Duration
+
+func (f formattedDuration) String() string {
+	return formatDuration(time.Duration(f))
+}

--- a/pkg/auto/lights/logic.go
+++ b/pkg/auto/lights/logic.go
@@ -220,7 +220,7 @@ func readStateMode(state *ReadState) (config.ModeOption, bool) {
 // Note is len(brightness) == 0, this will return true.
 func brightnessAllOff(state *WriteState) bool {
 	for _, brightness := range state.Brightness {
-		if brightness.Brightness.LevelPercent > 0 {
+		if brightness.V.GetLevelPercent() > 0 {
 			return false
 		}
 	}
@@ -320,7 +320,10 @@ func getAverageLevel(state *WriteState) (float32, error) {
 	sum := float32(0)
 	n := 0
 	for _, brightness := range state.Brightness {
-		sum += brightness.Brightness.LevelPercent
+		if brightness.V == nil {
+			continue
+		}
+		sum += brightness.V.LevelPercent
 		n++
 	}
 	if n == 0 {

--- a/pkg/auto/lights/logic.go
+++ b/pkg/auto/lights/logic.go
@@ -228,7 +228,7 @@ func brightnessAllOff(state *WriteState) bool {
 }
 
 // areAnyOccupied returns true if any occupancy sensors in the list are occupied
-func areAnyOccupied(sensorsPresent []string, occupancyStates map[string]*traits.Occupancy) bool {
+func areAnyOccupied(sensorsPresent []deviceName, occupancyStates map[deviceName]*traits.Occupancy) bool {
 	var ret = false
 	for _, name := range sensorsPresent {
 		if o, ok := occupancyStates[name]; ok {
@@ -332,7 +332,7 @@ func getAverageLevel(state *WriteState) (float32, error) {
 	return sum / float32(n), nil
 }
 
-func combinedLuxLevel(brightness map[string]*traits.AmbientBrightness) float32 {
+func combinedLuxLevel(brightness map[deviceName]*traits.AmbientBrightness) float32 {
 	var n, v float32
 	n, v = float32(len(brightness)), 0
 	for _, ambientBrightness := range brightness {

--- a/pkg/auto/lights/logic_test.go
+++ b/pkg/auto/lights/logic_test.go
@@ -202,9 +202,9 @@ func Test_processState(t *testing.T) {
 			MostRecentGesture: &gen.ButtonState_Gesture{Kind: gen.ButtonState_Gesture_CLICK},
 		}
 
-		writeState.Brightness["light01"] = BrightnessWriteState{
-			WriteTime:  now,
-			Brightness: &traits.Brightness{LevelPercent: 100},
+		writeState.Brightness["light01"] = Value[*traits.Brightness]{
+			At: now,
+			V:  &traits.Brightness{LevelPercent: 100},
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
@@ -243,13 +243,13 @@ func Test_processState(t *testing.T) {
 			MostRecentGesture: &gen.ButtonState_Gesture{Kind: gen.ButtonState_Gesture_CLICK},
 		}
 
-		writeState.Brightness["light01"] = BrightnessWriteState{
-			WriteTime:  now,
-			Brightness: &traits.Brightness{LevelPercent: 0},
+		writeState.Brightness["light01"] = Value[*traits.Brightness]{
+			At: now,
+			V:  &traits.Brightness{LevelPercent: 0},
 		}
-		writeState.Brightness["light02"] = BrightnessWriteState{
-			WriteTime:  now,
-			Brightness: &traits.Brightness{LevelPercent: 50},
+		writeState.Brightness["light02"] = Value[*traits.Brightness]{
+			At: now,
+			V:  &traits.Brightness{LevelPercent: 50},
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
@@ -288,9 +288,9 @@ func Test_processState(t *testing.T) {
 			MostRecentGesture: &gen.ButtonState_Gesture{Kind: gen.ButtonState_Gesture_CLICK},
 		}
 
-		writeState.Brightness["light01"] = BrightnessWriteState{
-			WriteTime:  now,
-			Brightness: &traits.Brightness{LevelPercent: 0},
+		writeState.Brightness["light01"] = Value[*traits.Brightness]{
+			At: now,
+			V:  &traits.Brightness{LevelPercent: 0},
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
@@ -328,9 +328,9 @@ func Test_processState(t *testing.T) {
 			MostRecentGesture: &gen.ButtonState_Gesture{Kind: gen.ButtonState_Gesture_CLICK},
 		}
 
-		writeState.Brightness["light01"] = BrightnessWriteState{
-			WriteTime:  now,
-			Brightness: &traits.Brightness{LevelPercent: 0},
+		writeState.Brightness["light01"] = Value[*traits.Brightness]{
+			At: now,
+			V:  &traits.Brightness{LevelPercent: 0},
 		}
 		writeState.LastButtonAction = now.Add(-time.Minute)
 
@@ -357,9 +357,9 @@ func Test_processState(t *testing.T) {
 			MostRecentGesture: &gen.ButtonState_Gesture{Kind: gen.ButtonState_Gesture_CLICK},
 		}
 
-		writeState.Brightness["light01"] = BrightnessWriteState{
-			WriteTime:  now,
-			Brightness: &traits.Brightness{LevelPercent: 0},
+		writeState.Brightness["light01"] = Value[*traits.Brightness]{
+			At: now,
+			V:  &traits.Brightness{LevelPercent: 0},
 		}
 		writeState.LastButtonAction = now
 
@@ -386,9 +386,9 @@ func Test_processState(t *testing.T) {
 			MostRecentGesture: &gen.ButtonState_Gesture{Kind: gen.ButtonState_Gesture_CLICK},
 		}
 
-		writeState.Brightness["light01"] = BrightnessWriteState{
-			WriteTime:  now,
-			Brightness: &traits.Brightness{LevelPercent: 0},
+		writeState.Brightness["light01"] = Value[*traits.Brightness]{
+			At: now,
+			V:  &traits.Brightness{LevelPercent: 0},
 		}
 		writeState.LastButtonAction = now
 
@@ -416,9 +416,9 @@ func Test_processState(t *testing.T) {
 			MostRecentGesture: &gen.ButtonState_Gesture{Kind: gen.ButtonState_Gesture_CLICK},
 		}
 
-		writeState.Brightness["light01"] = BrightnessWriteState{
-			WriteTime:  now,
-			Brightness: &traits.Brightness{LevelPercent: 0},
+		writeState.Brightness["light01"] = Value[*traits.Brightness]{
+			At: now,
+			V:  &traits.Brightness{LevelPercent: 0},
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
@@ -457,9 +457,9 @@ func Test_processState(t *testing.T) {
 			MostRecentGesture: &gen.ButtonState_Gesture{Kind: gen.ButtonState_Gesture_CLICK},
 		}
 
-		writeState.Brightness["light01"] = BrightnessWriteState{
-			WriteTime:  now,
-			Brightness: &traits.Brightness{LevelPercent: 0},
+		writeState.Brightness["light01"] = Value[*traits.Brightness]{
+			At: now,
+			V:  &traits.Brightness{LevelPercent: 0},
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
@@ -498,9 +498,9 @@ func Test_processState(t *testing.T) {
 			MostRecentGesture: &gen.ButtonState_Gesture{Kind: gen.ButtonState_Gesture_CLICK},
 		}
 
-		writeState.Brightness["light01"] = BrightnessWriteState{
-			WriteTime:  now,
-			Brightness: &traits.Brightness{LevelPercent: 100},
+		writeState.Brightness["light01"] = Value[*traits.Brightness]{
+			At: now,
+			V:  &traits.Brightness{LevelPercent: 100},
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
@@ -533,9 +533,9 @@ func Test_processState(t *testing.T) {
 			MostRecentGesture: &gen.ButtonState_Gesture{Kind: gen.ButtonState_Gesture_CLICK},
 		}
 
-		writeState.Brightness["light01"] = BrightnessWriteState{
-			WriteTime:  now,
-			Brightness: &traits.Brightness{LevelPercent: 100},
+		writeState.Brightness["light01"] = Value[*traits.Brightness]{
+			At: now,
+			V:  &traits.Brightness{LevelPercent: 100},
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
@@ -568,9 +568,9 @@ func Test_processState(t *testing.T) {
 			MostRecentGesture: &gen.ButtonState_Gesture{Kind: gen.ButtonState_Gesture_CLICK},
 		}
 
-		writeState.Brightness["light01"] = BrightnessWriteState{
-			WriteTime:  now,
-			Brightness: &traits.Brightness{LevelPercent: 0},
+		writeState.Brightness["light01"] = Value[*traits.Brightness]{
+			At: now,
+			V:  &traits.Brightness{LevelPercent: 0},
 		}
 
 		logger, _ := zap.NewDevelopment()
@@ -1045,9 +1045,9 @@ func (ta *testActions) UpdateBrightness(ctx context.Context, now time.Time, req 
 		return err
 	}
 
-	state.Brightness[req.Name] = BrightnessWriteState{
-		WriteTime:  now,
-		Brightness: req.Brightness,
+	state.Brightness[req.Name] = Value[*traits.Brightness]{
+		At: now,
+		V:  req.Brightness,
 	}
 
 	return nil

--- a/pkg/auto/lights/logic_test.go
+++ b/pkg/auto/lights/logic_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -28,8 +27,7 @@ func Test_processState(t *testing.T) {
 		readState := NewReadState(autoStartTime)
 		writeState := NewWriteState(time.Now())
 		actions := newTestActions(t)
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		assertNoErrAndTtl(t, ttl, err, 0)
 		actions.assertNoMoreCalls()
 	})
@@ -43,8 +41,7 @@ func Test_processState(t *testing.T) {
 		readState.Config.Lights = []string{"light01"}
 		readState.Occupancy["pir01"] = &traits.Occupancy{State: traits.Occupancy_OCCUPIED}
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		assertNoErrAndTtl(t, ttl, err, 0)
 		actions.assertNextCall(&traits.UpdateBrightnessRequest{
 			Name: "light01",
@@ -66,8 +63,7 @@ func Test_processState(t *testing.T) {
 		readState.Config.Lights = []string{"light01"}
 		readState.Occupancy["pir01"] = &traits.Occupancy{State: traits.Occupancy_OCCUPIED}
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		// automation start time should expire after one hour
 		assertNoErrAndTtl(t, ttl, err, time.Hour)
 		actions.assertNoMoreCalls()
@@ -87,8 +83,7 @@ func Test_processState(t *testing.T) {
 			StateChangeTime: timestamppb.New(now.Add(-20 * time.Minute)),
 		}
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 
 		assertNoErrAndTtl(t, ttl, err, 0)
 		actions.assertNextCall(&traits.UpdateBrightnessRequest{
@@ -114,8 +109,7 @@ func Test_processState(t *testing.T) {
 			StateChangeTime: timestamppb.New(now.Add(-5 * time.Minute)),
 		}
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		if err != nil {
 			t.Fatalf("Got error %v", err)
 		}
@@ -170,8 +164,7 @@ func Test_processState(t *testing.T) {
 					readState.AmbientBrightness[name] = &traits.AmbientBrightness{BrightnessLux: lux}
 				}
 
-				logger, _ := zap.NewDevelopment()
-				ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+				ttl, err := processState(context.Background(), readState, writeState, actions)
 				assertNoErrAndTtl(t, ttl, err, 0)
 				actions.assertNextCall(&traits.UpdateBrightnessRequest{
 					Name: "light01",
@@ -208,8 +201,7 @@ func Test_processState(t *testing.T) {
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		if ttl != 0 {
 			t.Fatalf("Error, ttl not equal 0 minutes, got %s", ttl.String())
 		}
@@ -253,8 +245,7 @@ func Test_processState(t *testing.T) {
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		if ttl != 0 {
 			t.Fatalf("Error, ttl not equal 0 minutes, got %s", ttl.String())
 		}
@@ -294,8 +285,7 @@ func Test_processState(t *testing.T) {
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		if ttl != 10*time.Minute {
 			t.Fatalf("Error, ttl not equal 10 minutes, got %s", ttl.String())
 		}
@@ -334,8 +324,7 @@ func Test_processState(t *testing.T) {
 		}
 		writeState.LastButtonAction = now.Add(-time.Minute)
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		assertNoErrAndTtl(t, ttl, err, 0)
 
 		actions.assertNoMoreCalls()
@@ -363,8 +352,7 @@ func Test_processState(t *testing.T) {
 		}
 		writeState.LastButtonAction = now
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		assertNoErrAndTtl(t, ttl, err, 0)
 
 		actions.assertNoMoreCalls()
@@ -392,8 +380,7 @@ func Test_processState(t *testing.T) {
 		}
 		writeState.LastButtonAction = now
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		assertNoErrAndTtl(t, ttl, err, 0)
 
 		actions.assertNoMoreCalls()
@@ -422,8 +409,7 @@ func Test_processState(t *testing.T) {
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		if ttl != 10*time.Minute {
 			t.Fatalf("Error, ttl not equal 10 minutes, got %s", ttl.String())
 		}
@@ -463,8 +449,7 @@ func Test_processState(t *testing.T) {
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		if ttl != 9*time.Minute {
 			t.Fatalf("Error, ttl not equal 9 minutes, got %s", ttl.String())
 		}
@@ -504,8 +489,7 @@ func Test_processState(t *testing.T) {
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		if ttl != 10*time.Minute {
 			t.Fatalf("Error, ttl not equal 10 minutes, got %s", ttl.String())
 		}
@@ -539,8 +523,7 @@ func Test_processState(t *testing.T) {
 		}
 		writeState.LastButtonAction = now.Add(-5 * time.Minute)
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		assertNoErrAndTtl(t, ttl, err, 0)
 
 		actions.assertNextCall(&traits.UpdateBrightnessRequest{
@@ -573,8 +556,7 @@ func Test_processState(t *testing.T) {
 			V:  &traits.Brightness{LevelPercent: 0},
 		}
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		assertNoErrAndTtl(t, ttl, err, 0)
 
 		actions.assertNoMoreCalls()
@@ -592,8 +574,7 @@ func Test_processState(t *testing.T) {
 
 		writeState.LastButtonOnTime = now.Add(-time.Minute)
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		if ttl != 9*time.Minute {
 			t.Fatalf("Error, ttl not equal 9 minutes, got %s", ttl.String())
 		}
@@ -620,8 +601,7 @@ func Test_processState(t *testing.T) {
 		}
 		writeState.LastButtonOnTime = now.Add(-time.Minute)
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		if ttl != 9*time.Minute {
 			t.Fatalf("Error, ttl not equal 5 minutes, got %s", ttl.String())
 		}
@@ -648,8 +628,7 @@ func Test_processState(t *testing.T) {
 		}
 		writeState.LastButtonOnTime = now.Add(-15 * time.Minute)
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		if ttl != 5*time.Minute {
 			t.Fatalf("Error, ttl not equal 5 minutes, got %s", ttl.String())
 		}
@@ -676,8 +655,7 @@ func Test_processState(t *testing.T) {
 		}
 		writeState.LastButtonOnTime = now.Add(-15 * time.Minute)
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		assertNoErrAndTtl(t, ttl, err, 0)
 		actions.assertNextCall(&traits.UpdateBrightnessRequest{
 			Name: "light01",
@@ -702,8 +680,7 @@ func Test_processState(t *testing.T) {
 			OnLevelPercent: &onLevel,
 		}
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		assertNoErrAndTtl(t, ttl, err, 0)
 		actions.assertNextCall(&traits.UpdateBrightnessRequest{
 			Name: "light01",
@@ -733,8 +710,7 @@ func Test_processState(t *testing.T) {
 			OffLevelPercent: &offLevel,
 		}
 
-		logger, _ := zap.NewDevelopment()
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 
 		assertNoErrAndTtl(t, ttl, err, 0)
 		actions.assertNextCall(&traits.UpdateBrightnessRequest{
@@ -772,9 +748,7 @@ func Test_processState(t *testing.T) {
 		}
 		readState.Config.Now = func() time.Time { return now }
 
-		logger, _ := zap.NewDevelopment()
-
-		ttl, err := processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err := processState(context.Background(), readState, writeState, actions)
 		if ttl != 10*time.Minute {
 			t.Fatalf("Error, ttl not equal 10 minutes, got %s", ttl.String())
 		}
@@ -789,7 +763,7 @@ func Test_processState(t *testing.T) {
 		})
 
 		now = now.Add(10 * time.Minute)
-		ttl, err = processState(context.Background(), readState, writeState, actions, logger)
+		ttl, err = processState(context.Background(), readState, writeState, actions)
 		if ttl != 8*time.Minute {
 			t.Fatalf("Error, ttl not equal 8 minutes, got %s", ttl.String())
 		}
@@ -806,7 +780,6 @@ func Test_processState(t *testing.T) {
 	})
 
 	t.Run("reassert level on mode change", func(t *testing.T) {
-		logger, _ := zap.NewDevelopment()
 		startTime := time.Unix(0, 0).In(time.UTC)
 		readState := NewReadState(now)
 
@@ -852,7 +825,7 @@ func Test_processState(t *testing.T) {
 		actions := newTestActions(t)
 
 		// check that we use mode a
-		_, err := processState(context.Background(), readState, writeState, actions, logger)
+		_, err := processState(context.Background(), readState, writeState, actions)
 		if err != nil {
 			t.Fatalf("unexpected error %v", err)
 		}
@@ -866,7 +839,7 @@ func Test_processState(t *testing.T) {
 		// switch to mode b
 		readState.Modes.Values[ModeValueKey] = "b"
 		// check that we use mode b
-		_, err = processState(context.Background(), readState, writeState, actions, logger)
+		_, err = processState(context.Background(), readState, writeState, actions)
 		if err != nil {
 			t.Fatalf("unexpected error %v", err)
 		}
@@ -879,7 +852,6 @@ func Test_processState(t *testing.T) {
 		actions.assertNoMoreCalls()
 	})
 	t.Run("do nothing when mode disables auto", func(t *testing.T) {
-		logger, _ := zap.NewDevelopment()
 		startTime := time.Unix(0, 0).In(time.UTC)
 		readState := NewReadState(now)
 
@@ -926,7 +898,7 @@ func Test_processState(t *testing.T) {
 		actions := newTestActions(t)
 
 		// check that we use mode a
-		_, err := processState(context.Background(), readState, writeState, actions, logger)
+		_, err := processState(context.Background(), readState, writeState, actions)
 		if err != nil {
 			t.Fatalf("unexpected error %v", err)
 		}
@@ -941,7 +913,7 @@ func Test_processState(t *testing.T) {
 		now = now.Add(time.Minute)
 		readState.Modes.Values[ModeValueKey] = "b"
 		// check that we use mode b
-		_, err = processState(context.Background(), readState, writeState, actions, logger)
+		_, err = processState(context.Background(), readState, writeState, actions)
 		if err != nil {
 			t.Fatalf("unexpected error %v", err)
 		}
@@ -950,7 +922,7 @@ func Test_processState(t *testing.T) {
 		// switch back to mode a
 		now = now.Add(time.Minute)
 		readState.Modes.Values[ModeValueKey] = "a"
-		_, err = processState(context.Background(), readState, writeState, actions, logger)
+		_, err = processState(context.Background(), readState, writeState, actions)
 		if err != nil {
 			t.Fatalf("unexpected error %v", err)
 		}

--- a/pkg/auto/lights/patch.go
+++ b/pkg/auto/lights/patch.go
@@ -156,8 +156,6 @@ type source struct {
 }
 
 func (b *BrightnessAutomation) processConfig(ctx context.Context, cfg config.Root, sources []*source, changes chan<- Patcher) (sourceCount int) {
-	logger := b.logger.With(zap.String("auto", cfg.Name))
-
 	if cfg.OnProcessError.BackOffMultiplier.Duration.Nanoseconds() <= 0 {
 		cfg.OnProcessError.BackOffMultiplier.Duration = config.DefaultBackOffMultiplier
 	}
@@ -176,7 +174,7 @@ func (b *BrightnessAutomation) processConfig(ctx context.Context, cfg config.Roo
 		sourcesToStop := shallowCopyMap(source.runningSources)
 		for _, name := range names {
 			sourceCount++
-			logger := logger.With(zap.String("source", name))
+			logger := b.logger.With(zap.String("source", name))
 
 			// are we already watching this name?
 			if _, ok := sourcesToStop[name]; ok {

--- a/pkg/auto/lights/patch_brightness_sensor.go
+++ b/pkg/auto/lights/patch_brightness_sensor.go
@@ -11,7 +11,7 @@ import (
 
 // BrightnessSensorPatches contributes patches for changing the state based on brightness sensor readings.
 type BrightnessSensorPatches struct {
-	name   string
+	name   deviceName
 	client traits.BrightnessSensorApiClient
 	logger *zap.Logger
 }
@@ -67,7 +67,7 @@ func (o *pullAmbientBrightnessTransition) Patch(s *ReadState) {
 }
 
 type getAmbientBrightnessPatcher struct {
-	name string
+	name deviceName
 	res  *traits.AmbientBrightness
 }
 

--- a/pkg/auto/lights/patch_button.go
+++ b/pkg/auto/lights/patch_button.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ButtonPatches struct {
-	name   string
+	name   deviceName
 	client gen.ButtonApiClient
 	logger *zap.Logger
 }
@@ -72,7 +72,7 @@ func (p pullButtonStatePatcher) Patch(state *ReadState) {
 }
 
 type getButtonStatePatcher struct {
-	name        string
+	name        deviceName
 	buttonState *gen.ButtonState
 }
 

--- a/pkg/auto/lights/patch_modes.go
+++ b/pkg/auto/lights/patch_modes.go
@@ -11,7 +11,7 @@ import (
 
 // ModePatches contributes patches for changing the state based on mode changes.
 type ModePatches struct {
-	name   string
+	name   deviceName
 	client traits.ModeApiClient
 	logger *zap.Logger
 }
@@ -67,7 +67,7 @@ func (o *pullModeValuesTransition) Patch(s *ReadState) {
 }
 
 type getModeValuesPatcher struct {
-	name string
+	name deviceName
 	res  *traits.ModeValues
 }
 

--- a/pkg/auto/lights/patch_occupancy_sensor.go
+++ b/pkg/auto/lights/patch_occupancy_sensor.go
@@ -11,7 +11,7 @@ import (
 
 // OccupancySensorPatches contributes patches for changing the state based on occupancy sensor readings.
 type OccupancySensorPatches struct {
-	name   string
+	name   deviceName
 	client traits.OccupancySensorApiClient
 	logger *zap.Logger
 }
@@ -67,7 +67,7 @@ func (o *pullOccupancyTransition) Patch(s *ReadState) {
 }
 
 type getOccupancyPatcher struct {
-	name string
+	name deviceName
 	res  *traits.Occupancy
 }
 

--- a/pkg/auto/lights/state.go
+++ b/pkg/auto/lights/state.go
@@ -10,16 +10,20 @@ import (
 	"github.com/vanti-dev/sc-bos/pkg/gen"
 )
 
+// deviceName is a smart core name for a device.
+// Use deviceName instead of string to help with documenting the intent behind the string.
+type deviceName = string
+
 // ReadState models everything we have read from the system.
 // For example if we PullBrightness, then the responses will be recoded here.
 type ReadState struct {
 	Config config.Root
 
 	AutoStartTime time.Time // time that the automation started up
-	Occupancy     map[string]*traits.Occupancy
+	Occupancy     map[deviceName]*traits.Occupancy
 	// used for daylight dimming
-	AmbientBrightness map[string]*traits.AmbientBrightness
-	Buttons           map[string]*gen.ButtonState
+	AmbientBrightness map[deviceName]*traits.AmbientBrightness
+	Buttons           map[deviceName]*gen.ButtonState
 	// used for selecting the run modes, aka "modes" config property
 	Modes *traits.ModeValues
 }
@@ -27,9 +31,9 @@ type ReadState struct {
 func NewReadState(t time.Time) *ReadState {
 	return &ReadState{
 		AutoStartTime:     t,
-		Occupancy:         make(map[string]*traits.Occupancy),
-		AmbientBrightness: make(map[string]*traits.AmbientBrightness),
-		Buttons:           make(map[string]*gen.ButtonState),
+		Occupancy:         make(map[deviceName]*traits.Occupancy),
+		AmbientBrightness: make(map[deviceName]*traits.AmbientBrightness),
+		Buttons:           make(map[deviceName]*gen.ButtonState),
 	}
 }
 
@@ -60,7 +64,7 @@ func (s *ReadState) Now() time.Time {
 // WriteState models the state of the system based on the changes we've made to it.
 // For example if we UpdateBrightness, then the response to that call is recorded in this state.
 type WriteState struct {
-	Brightness       map[string]Value[*traits.Brightness]
+	Brightness       map[deviceName]Value[*traits.Brightness]
 	LastButtonAction time.Time // used for button press deduplication, the last time we did anything due to a button press
 	LastButtonOnTime time.Time // used for occupancy related darkness, the last time lights were turned on due to button press
 	ActiveMode       string
@@ -80,7 +84,7 @@ func (v *Value[V]) set(at time.Time, value V) {
 
 func NewWriteState(startTime time.Time) *WriteState {
 	return &WriteState{
-		Brightness: make(map[string]Value[*traits.Brightness]),
+		Brightness: make(map[deviceName]Value[*traits.Brightness]),
 		// This causes all button presses before we boot to be ignored for action purposes - i.e. they don't directly turn lights on or off.
 		// This doesn't affect occupancy timeouts, so if a button was pressed 2 mins ago it still counts towards unoccupied darkness.
 		LastButtonAction: startTime,

--- a/pkg/auto/lights/state.go
+++ b/pkg/auto/lights/state.go
@@ -2,6 +2,10 @@ package lights
 
 import (
 	"context"
+	"fmt"
+	"maps"
+	"math"
+	"slices"
 	"time"
 
 	"github.com/smart-core-os/sc-api/go/traits"
@@ -61,15 +65,81 @@ func (s *ReadState) Now() time.Time {
 	return s.Config.Now()
 }
 
+// ChangesSince returns a human/log compatible list of changes between other and s.
+func (s *ReadState) ChangesSince(other *ReadState) []string {
+	var changes []string
+	changes = append(changes, mapChanges("occupancy", other.Occupancy, s.Occupancy, func(a, b *traits.Occupancy) string {
+		if a.State != b.State {
+			return fmt.Sprintf("%s->%s", a.State, b.State)
+		}
+		// we could report on state change time, but that could get noisy
+		return ""
+	})...)
+	changes = append(changes, mapChanges("ambient brightness", other.AmbientBrightness, s.AmbientBrightness, func(a, b *traits.AmbientBrightness) string {
+		if math.Abs(float64(a.BrightnessLux-b.BrightnessLux)) > 0.01 {
+			return fmt.Sprintf("%.2f->%.2f", a.BrightnessLux, b.BrightnessLux)
+		}
+		return ""
+	})...)
+	changes = append(changes, mapChanges("buttons", other.Buttons, s.Buttons, func(a, b *gen.ButtonState) string {
+		var changes []string
+		if a.State != b.State {
+			changes = append(changes, fmt.Sprintf("%s->%s", a.State, b.State))
+		}
+		if a.MostRecentGesture != b.MostRecentGesture {
+			changes = append(changes, fmt.Sprintf("%s->%s", a.MostRecentGesture, b.MostRecentGesture))
+		}
+		return ""
+	})...)
+	return changes
+}
+
+func mapChanges[V any](prefix string, a, b map[deviceName]V, cmp func(a, b V) string) []string {
+	aNotB := map[deviceName]struct{}{}
+	bNotA := map[deviceName]struct{}{}
+	aAndB := map[deviceName]struct{}{}
+	for k := range a {
+		aNotB[k] = struct{}{}
+	}
+	for k := range b {
+		if _, ok := a[k]; ok {
+			aAndB[k] = struct{}{}
+			delete(aNotB, k)
+		} else {
+			bNotA[k] = struct{}{}
+		}
+	}
+
+	changes := make([]string, 0, len(aNotB)+len(bNotA)) // at least this many
+
+	for _, k := range slices.Sorted(maps.Keys(aNotB)) {
+		changes = append(changes, fmt.Sprintf("%s %s: removed", prefix, k))
+	}
+	for _, k := range slices.Sorted(maps.Keys(bNotA)) {
+		changes = append(changes, fmt.Sprintf("%s %s: added", prefix, k))
+	}
+	for _, k := range slices.Sorted(maps.Keys(aAndB)) {
+		diff := cmp(a[k], b[k])
+		if diff != "" {
+			changes = append(changes, fmt.Sprintf("%s %s: %s", prefix, k, diff))
+		}
+	}
+
+	return changes
+}
+
 // WriteState models the state of the system based on the changes we've made to it.
 // For example if we UpdateBrightness, then the response to that call is recorded in this state.
 type WriteState struct {
+	Reasons []string
+
 	Brightness       map[deviceName]Value[*traits.Brightness]
 	LastButtonAction time.Time // used for button press deduplication, the last time we did anything due to a button press
 	LastButtonOnTime time.Time // used for occupancy related darkness, the last time lights were turned on due to button press
 	ActiveMode       string
 }
 
+// Value is a nuget of data we know about.
 type Value[V any] struct {
 	V   V
 	At  time.Time
@@ -100,6 +170,26 @@ func (s *WriteState) MergeFrom(other *WriteState) {
 		}
 	}
 	s.LastButtonAction = other.LastButtonAction
+}
+
+// Before sets up the write state ready for processing.
+func (s *WriteState) Before() {
+	s.Reasons = s.Reasons[:0] // save some allocations
+}
+
+// After should be called immediately after processing has completed.
+func (s *WriteState) After() {
+	// nothing to do here yet
+}
+
+func (s *WriteState) AddReason(reason string) {
+	if reason != "" {
+		s.Reasons = append(s.Reasons, reason)
+	}
+}
+
+func (s *WriteState) AddReasonf(format string, args ...any) {
+	s.AddReason(fmt.Sprintf(format, args...))
 }
 
 // readStateChanges collates changes and emits *ReadState.

--- a/pkg/util/pull/pull.go
+++ b/pkg/util/pull/pull.go
@@ -149,7 +149,7 @@ func runBlocking(ctx context.Context, name string, task Getter, conf changeOpts,
 	// The task method itself blocks until error so we have to track separately for success,
 	// mostly for peace of mind and logging.
 	var taskDuration time.Duration
-	const successfulMultiplier = 4
+	const successfulMultiplier = 10
 	successTimer := conf.clock.AfterFunc(math.MaxInt64, func() {
 		attempts := resetErr()
 		if attempts > 5 { // we only log failure after 5 attempts
@@ -172,7 +172,7 @@ func runBlocking(ctx context.Context, name string, task Getter, conf changeOpts,
 			errCount := incErr()
 			successTimer.Reset(taskDuration * successfulMultiplier)
 			if errCount == 5 {
-				conf.logger.Warn(name+" are failing, will keep retrying", zap.Error(err))
+				conf.logger.Warn(name+" are failing, will keep retrying", zap.Error(err), zap.Duration("duration", taskDuration))
 			}
 		} else {
 			// A nil error means the task stopped successfully, this is unusual as it should block forever, but not technically an error.


### PR DESCRIPTION
A collection of changes that improve the logging for the lighting automation.

Most of the changes are minor: remove duplicate fields, rename a type, etc. The big one is the rewriting of the logging system for the auto that's in 29cd077ad1c5f51443a2834d4505109225cbae9f which is the part that really needs a review.

I've attempted to keep the logic the same throughout, only changing logging lines and related bits (func args, etc). But there are a few minor changes that might cause issue later (assuming the tests missed them). The biggest one I can see is that the WriteState used to only record successful changes, now it also records failed changes. This happened in c3598c2c4be5a8bd17157be7c952dd285bf4f779 (I think).

I've deleted/refactored a couple of bits I noticed to make them more Go:

- replacing `if foo { do something important }` with `if !foo { return }`
- removing unused timers in the main logic loop

I have deployed this to site (on one floor) to see if it works and tells me more information than I had before.

Example default log output from auto_test now:

```
processState completed	{"changes": ["2x brightness=100.0%"], "reasons": ["mode:default", "occupied", "refreshEvery:0"], "time": "0s", "ttl": "8m"}
processState completed	{"changes": ["2x brightness=0.0%"], "reasons": ["ttl", "mode:default", "unoccupied for 10m", "refreshEvery:0"], "time": "0s", "ttl": "8m"}
processState failed; scheduling retry	{"error": "failed to update brightness this time", "retryAfter": "540.548913ms"}
processState completed	{"changes": ["2x brightness=100.0%"], "reasons": ["error retry", "mode:default", "occupied", "refreshEvery:0"], "time": "0s", "ttl": "8m"}
processState completed	{"changes": ["2x brightness=0.0%"], "reasons": ["mode:default", "unoccupied for ~10m", "refreshEvery:0"], "time": "0s", "ttl": "8m"}
processState failed; scheduling retry	{"error": "failed to update brightness this time", "retryAfter": "424.421497ms"}
processState failed; scheduling retry	{"error": "failed to update brightness this time", "retryAfter": "1.199535042s"}
processState failed; too many failures, aborting retires	{"error": "failed to update brightness this time", "retryCounter": 3}
```

Example log output with LogTriggers and LogEmptyChanges enabled:

```
processState starting	{"reasons": ["initial state"]}
processState completed	{"reasons": ["mode:default", "no occupancy signals, using auto start time", "unoccupied 0s<10m ago", "refreshing", "refreshEvery:10m->8m"], "time": "0s", "ttl": "8m"}
processState starting	{"reasons": ["occupancy pir01: added", "occupancy pir02: added"]}
processState completed	{"changes": ["2x brightness=100.0%"], "reasons": ["mode:default", "occupied", "refreshEvery:0"], "time": "0s", "ttl": "8m"}
processState starting	{"reasons": ["occupancy pir02: STATE_UNSPECIFIED->OCCUPIED"]}
processState completed	{"reasons": ["mode:default", "occupied", "refreshEvery:0"], "time": "0s", "ttl": "8m"}
processState starting	{"reasons": ["occupancy pir01: OCCUPIED->UNOCCUPIED"]}
processState completed	{"reasons": ["mode:default", "occupied", "refreshEvery:0"], "time": "0s", "ttl": "8m"}
processState starting	{"reasons": ["occupancy pir02: OCCUPIED->UNOCCUPIED"]}
processState completed	{"reasons": ["mode:default", "unoccupied 3m<10m ago", "refreshing"], "time": "0s", "ttl": "7m"}
processState starting	{"reasons": ["ttl", "no changes"]}
processState completed	{"changes": ["2x brightness=0.0%"], "reasons": ["ttl", "mode:default", "unoccupied for 10m", "refreshEvery:0"], "time": "0s", "ttl": "8m"}
processState starting	{"reasons": ["occupancy pir01: UNOCCUPIED->OCCUPIED"]}
processState failed; scheduling retry	{"error": "failed to update brightness this time", "retryAfter": "538.618819ms"}
processState starting	{"reasons": ["error retry", "no changes"]}
processState completed	{"changes": ["2x brightness=100.0%"], "reasons": ["error retry", "mode:default", "occupied", "refreshEvery:0"], "time": "0s", "ttl": "8m"}
processState starting	{"reasons": ["refresh", "no changes"]}
processState completed	{"reasons": ["refresh", "mode:default", "occupied", "refreshEvery:0"], "time": "0s", "ttl": "8m"}
processState starting	{"reasons": ["occupancy pir01: OCCUPIED->UNOCCUPIED"]}
processState completed	{"changes": ["2x brightness=0.0%"], "reasons": ["mode:default", "unoccupied for ~10m", "refreshEvery:0"], "time": "0s", "ttl": "8m"}
processState starting	{"reasons": ["occupancy pir01: UNOCCUPIED->OCCUPIED"]}
processState failed; scheduling retry	{"error": "failed to update brightness this time", "retryAfter": "478.271092ms"}
processState starting	{"reasons": ["error retry", "no changes"]}
processState failed; scheduling retry	{"error": "failed to update brightness this time", "retryAfter": "1.161716394s"}
processState starting	{"reasons": ["error retry", "no changes"]}
processState failed; too many failures, aborting retires	{"error": "failed to update brightness this time", "retryCounter": 3}
```

Fixes SC-40