### PR TITLE
driver/bacnet: add tries as a configurable field for update poll tests

### DIFF
--- a/pkg/driver/bacnet/config/traits.go
+++ b/pkg/driver/bacnet/config/traits.go
@@ -30,6 +30,9 @@ type Trait struct {
 	PollPeriod *Duration `json:"pollPeriod,omitempty"`
 	// how long to wait when running a poll for it to respond. Defaults to PollPeriod.
 	PollTimeout *Duration `json:"pollTimeout,omitempty"`
+	// after a write update, how long to wait by default before giving up on reads becoming consistent with the written value.
+	// defaults to 1m
+	DefaultRWConsistencyTimeout *Duration `json:"defaultRWConsistencyTimeout,omitempty"`
 	// When reading multiple properties, split the properties into chunks of this size and execute in parallel.
 	// 0 means do not chunk.
 	ChunkSize int `json:"chunkSize,omitempty"`
@@ -47,6 +50,13 @@ func (t *Trait) PollTimeoutDuration() time.Duration {
 		return t.PollTimeout.Duration
 	}
 	return t.PollPeriodDuration()
+}
+
+func (t *Trait) DefaultRWConsistencyTimeoutDuration() time.Duration {
+	if t.DefaultRWConsistencyTimeout != nil && t.DefaultRWConsistencyTimeout.Duration != 0 {
+		return t.DefaultRWConsistencyTimeout.Duration
+	}
+	return time.Minute
 }
 
 type RawTrait struct {

--- a/pkg/driver/bacnet/merge/air_temperature.go
+++ b/pkg/driver/bacnet/merge/air_temperature.go
@@ -116,9 +116,8 @@ func (t *airTemperature) UpdateAirTemperature(ctx context.Context, request *trai
 	if err != nil {
 		return nil, err
 	}
-
 	// todo: not strictly correct as we're not paying attention to the require customisation properties that ModelServer would give us
-	return pollUntil(ctx, 5, t.pollPeer, func(temperature *traits.AirTemperature) bool {
+	return pollUntil(ctx, t.config.DefaultRWConsistencyTimeoutDuration(), t.pollPeer, func(temperature *traits.AirTemperature) bool {
 		return temperature.GetTemperatureSetPoint().ValueCelsius == float64(newSetPoint)
 	})
 }

--- a/pkg/driver/bacnet/merge/fan_speed.go
+++ b/pkg/driver/bacnet/merge/fan_speed.go
@@ -98,7 +98,7 @@ func (t *fanSpeed) UpdateFanSpeed(ctx context.Context, request *traits.UpdateFan
 	}
 
 	// todo: not strictly correct as we're not paying attention to the require customisation properties that ModelServer would give us
-	return pollUntil(ctx, 5, t.pollPeer, func(data *traits.FanSpeed) bool {
+	return pollUntil(ctx, t.config.DefaultRWConsistencyTimeoutDuration(), t.pollPeer, func(data *traits.FanSpeed) bool {
 		return data.GetPercentage() == newFanSpeed
 	})
 }

--- a/pkg/driver/bacnet/merge/mode.go
+++ b/pkg/driver/bacnet/merge/mode.go
@@ -156,7 +156,7 @@ func (t *mode) UpdateModeValues(ctx context.Context, request *traits.UpdateModeV
 		return nil, status.Errorf(codes.Internal, "failed to write mode values: %v", multierr.Combine(errs...))
 	}
 
-	return pollUntil(ctx, 5, t.pollPeer, func(values *traits.ModeValues) bool {
+	return pollUntil(ctx, t.config.DefaultRWConsistencyTimeoutDuration(), t.pollPeer, func(values *traits.ModeValues) bool {
 		for _, e := range allExpected {
 			if values.Values[e.name] != e.value {
 				return false

--- a/pkg/driver/bacnet/merge/poll.go
+++ b/pkg/driver/bacnet/merge/poll.go
@@ -38,17 +38,17 @@ func startPoll(init context.Context, name string, pollDelay, pollTimeout time.Du
 //
 //  1. ctx is done
 //  2. pollPeer returns an error
-//  3. defaultDelay has passed if the ctx doesn't have a non-zero ctx.Deadline assigned
-//     or time.Now() + defaultDelay is earlier than the deadline assigned to ctx
+//  3. timeout has passed if the ctx doesn't have a non-zero ctx.Deadline assigned
+//     or time.Now() + timeout is earlier than the deadline assigned to ctx
 //
 // An backoff delay will be added between each call to pollPeer
-func pollUntil[T any](ctx context.Context, defaultDelay time.Duration, poll func(context.Context) (T, error), test func(T) bool) (T, error) {
+func pollUntil[T any](ctx context.Context, timeout time.Duration, poll func(context.Context) (T, error), test func(T) bool) (T, error) {
 	fail := func(err error) (T, error) {
 		var zero T
 		return zero, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, defaultDelay)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	var delay time.Duration

--- a/pkg/driver/bacnet/merge/poll.go
+++ b/pkg/driver/bacnet/merge/poll.go
@@ -3,7 +3,6 @@ package merge
 import (
 	"context"
 	"fmt"
-	"math"
 	"time"
 
 	"go.uber.org/zap"
@@ -38,18 +37,19 @@ func startPoll(init context.Context, name string, pollDelay, pollTimeout time.Du
 // Returns early with error if
 //
 //  1. ctx is done
-//  2. the number of polls is tries
-//  3. pollPeer returns an error
+//  2. pollPeer returns an error
+//  3. defaultDelay has passed if the ctx doesn't have a non-zero ctx.Deadline assigned
+//     or time.Now() + defaultDelay is earlier than the deadline assigned to ctx
 //
 // An backoff delay will be added between each call to pollPeer
-func pollUntil[T any](ctx context.Context, tries int, poll func(context.Context) (T, error), test func(T) bool) (T, error) {
+func pollUntil[T any](ctx context.Context, defaultDelay time.Duration, poll func(context.Context) (T, error), test func(T) bool) (T, error) {
 	fail := func(err error) (T, error) {
 		var zero T
 		return zero, err
 	}
-	if tries == 0 {
-		tries = math.MaxInt
-	}
+
+	ctx, cancel := context.WithTimeout(ctx, defaultDelay)
+	defer cancel()
 
 	var delay time.Duration
 	delayMulti := 1.2
@@ -72,15 +72,10 @@ func pollUntil[T any](ctx context.Context, tries int, poll func(context.Context)
 			delay = time.Duration(float64(delay) * delayMulti)
 		}
 
-		if attempt >= tries {
-			break
-		}
-
 		select {
 		case <-ctx.Done():
-			return fail(ctx.Err())
+			return fail(fmt.Errorf("attempt %d: %w", attempt, ctx.Err()))
 		case <-time.After(delay):
 		}
 	}
-	return fail(fmt.Errorf("ran out of tries: %d", tries))
 }

--- a/pkg/driver/bacnet/merge/poll_test.go
+++ b/pkg/driver/bacnet/merge/poll_test.go
@@ -1,0 +1,163 @@
+package merge
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_pollUntil(t *testing.T) {
+	type B bool
+	type args struct {
+		ctx          func() context.Context
+		defaultDelay time.Duration
+		test         func() func(B) bool
+	}
+
+	poll := func(_ context.Context) (B, error) {
+		return true, nil
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    B
+		wantErr error
+	}{
+		{
+			name: "no deadline - test succeeds after default deadline",
+			args: args{
+				ctx: func() context.Context {
+					return context.Background()
+				},
+				defaultDelay: 10 * time.Millisecond,
+				test: func() func(t B) bool {
+					count := 0
+					return func(t B) bool {
+						count++
+
+						// fail until at least 10 ms has passed
+						if count > 2 {
+							return true
+						}
+
+						return false
+					}
+				},
+			},
+			wantErr: context.DeadlineExceeded,
+		},
+		{
+			name: "no deadline - test succeeds before default deadline",
+			args: args{
+				ctx: func() context.Context {
+					return context.Background()
+				},
+				defaultDelay: 10 * time.Millisecond,
+				test: func() func(t B) bool {
+					return func(t B) bool {
+						// succeed straight away
+						return true
+					}
+				},
+			},
+			wantErr: nil,
+			want:    true,
+		},
+		{
+			name: "deadline before defaultDelay - test succeeds after deadline",
+			args: args{
+				ctx: func() context.Context {
+					ctx, _ := context.WithTimeout(context.Background(), 5*time.Millisecond)
+					return ctx
+				},
+				defaultDelay: 10 * time.Millisecond,
+				test: func() func(t B) bool {
+					count := 0
+					return func(t B) bool {
+						count++
+						if count > 2 {
+							return true
+						}
+						return false
+					}
+				},
+			},
+			wantErr: context.DeadlineExceeded,
+			want:    false,
+		},
+		{
+			name: "deadline before defaultDelay - test succeeds before deadline",
+			args: args{
+				ctx: func() context.Context {
+					ctx, _ := context.WithTimeout(context.Background(), 5*time.Millisecond)
+					return ctx
+				},
+				defaultDelay: 10 * time.Millisecond,
+				test: func() func(t B) bool {
+					return func(t B) bool {
+						return true
+					}
+				},
+			},
+			wantErr: nil,
+			want:    true,
+		},
+		{
+			name: "deadline after defaultDelay - test succeeds after deadline",
+			args: args{
+				ctx: func() context.Context {
+					ctx, _ := context.WithTimeout(context.Background(), 50*time.Millisecond)
+					return ctx
+				},
+				defaultDelay: 10 * time.Millisecond,
+				test: func() func(t B) bool {
+					count := 0
+					return func(t B) bool {
+						count++
+						if count > 2 {
+							return true
+						}
+						return false
+					}
+				},
+			},
+			wantErr: context.DeadlineExceeded,
+			want:    false,
+		},
+		{
+			name: "deadline after defaultDelay - test succeeds before deadline",
+			args: args{
+				ctx: func() context.Context {
+					ctx, _ := context.WithTimeout(context.Background(), 50*time.Millisecond)
+					return ctx
+				},
+				defaultDelay: 10 * time.Millisecond,
+				test: func() func(t B) bool {
+					return func(t B) bool {
+						return true
+					}
+				},
+			},
+			wantErr: nil,
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := pollUntil[B](tt.args.ctx(), tt.args.defaultDelay, poll, tt.args.test())
+
+			if diff := cmp.Diff(res, tt.want); diff != "" {
+				t.Errorf("pollUntil(): (-got +want)\n%s", diff)
+			}
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("pollUntil() error = %v - wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/driver/bacnet/merge/poll_test.go
+++ b/pkg/driver/bacnet/merge/poll_test.go
@@ -12,9 +12,9 @@ import (
 func Test_pollUntil(t *testing.T) {
 	type B bool
 	type args struct {
-		ctx          func() context.Context
-		defaultDelay time.Duration
-		test         func() func(B) bool
+		ctx     func() context.Context
+		timeout time.Duration
+		test    func() func(B) bool
 	}
 
 	poll := func(_ context.Context) (B, error) {
@@ -33,7 +33,7 @@ func Test_pollUntil(t *testing.T) {
 				ctx: func() context.Context {
 					return context.Background()
 				},
-				defaultDelay: 10 * time.Millisecond,
+				timeout: 10 * time.Millisecond,
 				test: func() func(t B) bool {
 					count := 0
 					return func(t B) bool {
@@ -56,7 +56,7 @@ func Test_pollUntil(t *testing.T) {
 				ctx: func() context.Context {
 					return context.Background()
 				},
-				defaultDelay: 10 * time.Millisecond,
+				timeout: 10 * time.Millisecond,
 				test: func() func(t B) bool {
 					return func(t B) bool {
 						// succeed straight away
@@ -68,13 +68,13 @@ func Test_pollUntil(t *testing.T) {
 			want:    true,
 		},
 		{
-			name: "deadline before defaultDelay - test succeeds after deadline",
+			name: "deadline before timeout - test succeeds after deadline",
 			args: args{
 				ctx: func() context.Context {
 					ctx, _ := context.WithTimeout(context.Background(), 5*time.Millisecond)
 					return ctx
 				},
-				defaultDelay: 10 * time.Millisecond,
+				timeout: 10 * time.Millisecond,
 				test: func() func(t B) bool {
 					count := 0
 					return func(t B) bool {
@@ -90,13 +90,13 @@ func Test_pollUntil(t *testing.T) {
 			want:    false,
 		},
 		{
-			name: "deadline before defaultDelay - test succeeds before deadline",
+			name: "deadline before timeout - test succeeds before deadline",
 			args: args{
 				ctx: func() context.Context {
 					ctx, _ := context.WithTimeout(context.Background(), 5*time.Millisecond)
 					return ctx
 				},
-				defaultDelay: 10 * time.Millisecond,
+				timeout: 10 * time.Millisecond,
 				test: func() func(t B) bool {
 					return func(t B) bool {
 						return true
@@ -107,13 +107,13 @@ func Test_pollUntil(t *testing.T) {
 			want:    true,
 		},
 		{
-			name: "deadline after defaultDelay - test succeeds after deadline",
+			name: "deadline after timeout - test succeeds after deadline",
 			args: args{
 				ctx: func() context.Context {
 					ctx, _ := context.WithTimeout(context.Background(), 50*time.Millisecond)
 					return ctx
 				},
-				defaultDelay: 10 * time.Millisecond,
+				timeout: 10 * time.Millisecond,
 				test: func() func(t B) bool {
 					count := 0
 					return func(t B) bool {
@@ -129,13 +129,13 @@ func Test_pollUntil(t *testing.T) {
 			want:    false,
 		},
 		{
-			name: "deadline after defaultDelay - test succeeds before deadline",
+			name: "deadline after timeout - test succeeds before deadline",
 			args: args{
 				ctx: func() context.Context {
 					ctx, _ := context.WithTimeout(context.Background(), 50*time.Millisecond)
 					return ctx
 				},
-				defaultDelay: 10 * time.Millisecond,
+				timeout: 10 * time.Millisecond,
 				test: func() func(t B) bool {
 					return func(t B) bool {
 						return true
@@ -149,7 +149,7 @@ func Test_pollUntil(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := pollUntil[B](tt.args.ctx(), tt.args.defaultDelay, poll, tt.args.test())
+			res, err := pollUntil[B](tt.args.ctx(), tt.args.timeout, poll, tt.args.test())
 
 			if diff := cmp.Diff(res, tt.want); diff != "" {
 				t.Errorf("pollUntil(): (-got +want)\n%s", diff)

--- a/pkg/driver/bacnet/merge/poll_test.go
+++ b/pkg/driver/bacnet/merge/poll_test.go
@@ -151,8 +151,8 @@ func Test_pollUntil(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := pollUntil[B](tt.args.ctx(), tt.args.timeout, poll, tt.args.test())
 
-			if diff := cmp.Diff(res, tt.want); diff != "" {
-				t.Errorf("pollUntil(): (-got +want)\n%s", diff)
+			if diff := cmp.Diff(tt.want, res); diff != "" {
+				t.Errorf("pollUntil(): (-want +got)\n%s", diff)
 			}
 
 			if !errors.Is(err, tt.wantErr) {


### PR DESCRIPTION
> It seems updating the set point leads to errors being thrown in the frontend.. even when the temperature does actually get updated... eventually. I am looking at the BacNet driver, it seems the number of tries in the poll + test functionality is set to 5. Does this need changing to pull the tries from the config? Or was it hardcoded for a reason and 5 tries should be enough pointing a deeper issue with BacNet?