### PR TITLE
Add bacnet emergency lowerthan

### DIFF
--- a/pkg/driver/bacnet/merge/emergency.go
+++ b/pkg/driver/bacnet/merge/emergency.go
@@ -21,8 +21,9 @@ import (
 	"github.com/vanti-dev/sc-bos/pkg/task"
 )
 
-// AlarmConfig allows configuring a specific bacnet point to raise an Emergency if the
-// value read from that point is anything other than OkValue
+// AlarmConfig allows configuring a specific bacnet point to raise an Emergency if either:
+// - value read from that point is anything other than OkValue
+// - value read from that point is less than GreaterThanOkValue
 type AlarmConfig struct {
 	config.ValueSource
 	OkValue            int    `json:"okValue"`            // what we expect to read from the point when it is ok, any other value is an emergency

--- a/pkg/driver/bacnet/merge/emergency.go
+++ b/pkg/driver/bacnet/merge/emergency.go
@@ -25,8 +25,9 @@ import (
 // value read from that point is anything other than OkValue
 type AlarmConfig struct {
 	config.ValueSource
-	OkValue     int    `json:"okValue"`     // what we expect to read from the point when it is ok, any other value is an emergency
-	AlarmReason string `json:"alarmReason"` // the reason of the alarm
+	OkValue            int    `json:"okValue"`            // what we expect to read from the point when it is ok, any other value is an emergency
+	GreaterThanOkValue int    `json:"greaterThanOkValue"` // we expect the point to be greater than this value, if it isn't we have an emergency
+	AlarmReason        string `json:"alarmReason"`        // the reason of the alarm
 }
 
 type emergencyConfig struct {
@@ -146,7 +147,8 @@ func (t *emergencyImpl) pollPeer(ctx context.Context) (*traits.Emergency, error)
 				return comm.ErrReadProperty{Prop: "alarmConfig", Cause: err}
 			}
 
-			if int64(t.config.AlarmConfig.OkValue) != value {
+			if value != int64(t.config.AlarmConfig.OkValue) ||
+				value < int64(t.config.AlarmConfig.GreaterThanOkValue) {
 				data.Reason = t.config.AlarmConfig.AlarmReason
 				data.Level = traits.Emergency_EMERGENCY
 			} else {

--- a/pkg/driver/bacnet/merge/emergency_test.go
+++ b/pkg/driver/bacnet/merge/emergency_test.go
@@ -1,0 +1,176 @@
+package merge
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+)
+
+// test the emergencyImpl alarmConfig for int values
+//   - ok value good
+//   - ok value bad
+//   - okAbove good
+//   - okAbove bad
+func Test_emergency_int(t *testing.T) {
+	impl := &emergencyImpl{}
+	okValue := int64(234)
+
+	tests := []struct {
+		name       string
+		alarmConf  AlarmConfig
+		checkFunc  func(any) (*traits.Emergency, error)
+		pointValue any
+		wantLevel  traits.Emergency_Level
+		wantReason string
+		wantErr    bool
+	}{
+		{
+			name: "ok value good",
+			alarmConf: AlarmConfig{
+				OkValue: &okValue,
+			},
+			checkFunc:  impl.checkIntValueForEmergency,
+			pointValue: int32(234),
+			wantLevel:  traits.Emergency_OK,
+			wantReason: "",
+			wantErr:    false,
+		},
+		{
+			name: "ok value bad",
+			alarmConf: AlarmConfig{
+				OkValue:     &okValue,
+				AlarmReason: "Sensor is not reading the expected value",
+			},
+			checkFunc:  impl.checkIntValueForEmergency,
+			pointValue: int32(777),
+			wantLevel:  traits.Emergency_EMERGENCY,
+			wantReason: "Sensor is not reading the expected value",
+			wantErr:    false,
+		},
+		{
+			name: "okAbove good",
+			alarmConf: AlarmConfig{
+				OkAbove: &okValue,
+			},
+			checkFunc:  impl.checkIntValueForEmergency,
+			pointValue: int32(235),
+			wantLevel:  traits.Emergency_OK,
+			wantReason: "",
+			wantErr:    false,
+		},
+		{
+			name: "okAbove bad",
+			alarmConf: AlarmConfig{
+				OkAbove:     &okValue,
+				AlarmReason: "Sensor is not reading the expected value",
+			},
+			checkFunc:  impl.checkIntValueForEmergency,
+			pointValue: int32(233),
+			wantLevel:  traits.Emergency_EMERGENCY,
+			wantReason: "Sensor is not reading the expected value",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl.config.AlarmConfig = &tt.alarmConf
+			emergency, err := tt.checkFunc(tt.pointValue)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("%s: error = %v, wantErr %v", tt.name, err, tt.wantErr)
+				return
+			}
+			if emergency.Level != tt.wantLevel {
+				t.Errorf("%s: got = %v, want %v", tt.name, emergency.Level, tt.wantLevel)
+			}
+			if emergency.Reason != tt.wantReason {
+				t.Errorf("%s: got = %v, want %v", tt.name, emergency.Reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+// test the emergencyImpl alarmConfig for float values
+//   - okAbove good
+//   - okAbove bad
+func Test_emergency_float(t *testing.T) {
+	impl := &emergencyImpl{}
+	okValue := int64(234)
+
+	tests := []struct {
+		name       string
+		alarmConf  AlarmConfig
+		checkFunc  func(any) (*traits.Emergency, error)
+		pointValue any
+		wantLevel  traits.Emergency_Level
+		wantReason string
+		wantErr    bool
+	}{
+		{
+			name: "okAbove good",
+			alarmConf: AlarmConfig{
+				OkAbove: &okValue,
+			},
+			checkFunc:  impl.checkFloatValueForEmergency,
+			pointValue: float32(235),
+			wantLevel:  traits.Emergency_OK,
+			wantReason: "",
+			wantErr:    false,
+		},
+		{
+			name: "okAbove bad",
+			alarmConf: AlarmConfig{
+				OkAbove:     &okValue,
+				AlarmReason: "Sensor is not reading the expected value",
+			},
+			checkFunc:  impl.checkFloatValueForEmergency,
+			pointValue: float32(233),
+			wantLevel:  traits.Emergency_EMERGENCY,
+			wantReason: "Sensor is not reading the expected value",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl.config.AlarmConfig = &tt.alarmConf
+			emergency, err := tt.checkFunc(tt.pointValue)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("%s: error = %v, wantErr %v", tt.name, err, tt.wantErr)
+				return
+			}
+			if emergency.Level != tt.wantLevel {
+				t.Errorf("%s: got = %v, want %v", tt.name, emergency.Level, tt.wantLevel)
+			}
+			if emergency.Reason != tt.wantReason {
+				t.Errorf("%s: got = %v, want %v", tt.name, emergency.Reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+// test create a new emergencyImpl with both okValue and okAbove set
+func Test_emergency_both(t *testing.T) {
+	okValue := int64(234)
+	okAbove := int64(235)
+
+	emergencyCfg := emergencyConfig{
+		AlarmConfig: &AlarmConfig{
+			OkValue: &okValue,
+			OkAbove: &okAbove,
+		},
+	}
+
+	bytes, err := json.Marshal(emergencyCfg)
+	if err != nil {
+		t.Errorf("error marshalling emergencyCfg: %v", err)
+	}
+
+	_, err = readEmergencyConfig(bytes)
+	if err != nil {
+		if err.Error() != "cannot set both okValue and okAbove" {
+			t.Errorf("cannot set both okValue and okAbove: %v", err)
+		}
+	}
+}

--- a/pkg/driver/bacnet/merge/emergency_test.go
+++ b/pkg/driver/bacnet/merge/emergency_test.go
@@ -10,8 +10,9 @@ import (
 // test the emergencyImpl alarmConfig for int values
 //   - ok value good
 //   - ok value bad
-//   - okAbove good
-//   - okAbove bad
+//   - okAtOrAbove good
+//   - okAtOrAbove equal to value
+//   - okAtOrAbove bad
 func Test_emergency_int(t *testing.T) {
 	impl := &emergencyImpl{}
 	okValue := int64(234)
@@ -49,9 +50,9 @@ func Test_emergency_int(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name: "okAbove good",
+			name: "okAtOrAbove good",
 			alarmConf: AlarmConfig{
-				OkAbove: &okValue,
+				OkAtOrAbove: &okValue,
 			},
 			checkFunc:  impl.checkIntValueForEmergency,
 			pointValue: int32(235),
@@ -60,9 +61,20 @@ func Test_emergency_int(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name: "okAbove bad",
+			name: "okAtOrAbove equal to",
 			alarmConf: AlarmConfig{
-				OkAbove:     &okValue,
+				OkAtOrAbove: &okValue,
+			},
+			checkFunc:  impl.checkIntValueForEmergency,
+			pointValue: int32(234),
+			wantLevel:  traits.Emergency_OK,
+			wantReason: "",
+			wantErr:    false,
+		},
+		{
+			name: "okAtOrAbove bad",
+			alarmConf: AlarmConfig{
+				OkAtOrAbove: &okValue,
 				AlarmReason: "Sensor is not reading the expected value",
 			},
 			checkFunc:  impl.checkIntValueForEmergency,
@@ -92,8 +104,9 @@ func Test_emergency_int(t *testing.T) {
 }
 
 // test the emergencyImpl alarmConfig for float values
-//   - okAbove good
-//   - okAbove bad
+//   - okAtOrAbove good
+//   - okAtOrAbove equal to value
+//   - okAtOrAbove bad
 func Test_emergency_float(t *testing.T) {
 	impl := &emergencyImpl{}
 	okValue := int64(234)
@@ -108,9 +121,9 @@ func Test_emergency_float(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name: "okAbove good",
+			name: "okAtOrAbove good",
 			alarmConf: AlarmConfig{
-				OkAbove: &okValue,
+				OkAtOrAbove: &okValue,
 			},
 			checkFunc:  impl.checkFloatValueForEmergency,
 			pointValue: float32(235),
@@ -119,9 +132,20 @@ func Test_emergency_float(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name: "okAbove bad",
+			name: "okAtOrAbove equal to",
 			alarmConf: AlarmConfig{
-				OkAbove:     &okValue,
+				OkAtOrAbove: &okValue,
+			},
+			checkFunc:  impl.checkFloatValueForEmergency,
+			pointValue: float32(235),
+			wantLevel:  traits.Emergency_OK,
+			wantReason: "",
+			wantErr:    false,
+		},
+		{
+			name: "okAtOrAbove bad",
+			alarmConf: AlarmConfig{
+				OkAtOrAbove: &okValue,
 				AlarmReason: "Sensor is not reading the expected value",
 			},
 			checkFunc:  impl.checkFloatValueForEmergency,
@@ -150,15 +174,15 @@ func Test_emergency_float(t *testing.T) {
 	}
 }
 
-// test create a new emergencyImpl with both okValue and okAbove set
+// test create a new emergencyImpl with both okValue and okAtOrAbove set
 func Test_emergency_both(t *testing.T) {
 	okValue := int64(234)
-	okAbove := int64(235)
+	okAtOrAbove := int64(235)
 
 	emergencyCfg := emergencyConfig{
 		AlarmConfig: &AlarmConfig{
-			OkValue: &okValue,
-			OkAbove: &okAbove,
+			OkValue:     &okValue,
+			OkAtOrAbove: &okAtOrAbove,
 		},
 	}
 
@@ -169,8 +193,8 @@ func Test_emergency_both(t *testing.T) {
 
 	_, err = readEmergencyConfig(bytes)
 	if err != nil {
-		if err.Error() != "cannot set both okValue and okAbove" {
-			t.Errorf("cannot set both okValue and okAbove: %v", err)
+		if err.Error() != "cannot set both okValue and okAtOrAbove" {
+			t.Errorf("cannot set both okValue and okAtOrAbove: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
Add an option on the bacnet alarm config to trigger an emergency if a value drops below a good ok value.
We already supported an equality comparison, this adds support for an equality comparison.
Also adds support for float values