### PR TITLE
ui/ops: replace a.hasOwnProperty(b) with Object.hasOwn(a, b)

### DIFF
--- a/ui/ops/src/api/convpb.js
+++ b/ui/ops/src/api/convpb.js
@@ -32,7 +32,7 @@ export function setProperties(dst, src, ...props) {
  */
 export function convertProperties(dst, src, conv, ...props) {
   for (const prop of props) {
-    if (src.hasOwnProperty(prop)) {
+    if (Object.hasOwn(src, prop)) {
       dst['set' + prop[0].toUpperCase() + prop.substring(1)](conv(src[prop]));
     }
   }
@@ -61,7 +61,7 @@ export function timestampFromObject(obj) {
 export function timestampToDate(ts) {
   if (!ts) return undefined;
   if (ts instanceof Timestamp) return ts.toDate();
-  if (ts.hasOwnProperty('nanos') && ts.hasOwnProperty('seconds')) {
+  if (Object.hasOwn(ts, 'nanos') && Object.hasOwn(ts, 'seconds')) {
     return timestampToDate(new Timestamp().setSeconds(ts.seconds).setNanos(ts.seconds));
   }
 

--- a/ui/ops/src/api/sc/traits/air-temperature.js
+++ b/ui/ops/src/api/sc/traits/air-temperature.js
@@ -166,7 +166,7 @@ export function airTemperatureModeToString(mode) {
  * @return {string}
  */
 export function temperatureToString(value) {
-  if (value.hasOwnProperty('valueCelsius')) {
+  if (Object.hasOwn(value, 'valueCelsius')) {
     return value.valueCelsius.toFixed(1) + '°C';
   }
   return '-';

--- a/ui/ops/src/components/filter/ListChooser.vue
+++ b/ui/ops/src/components/filter/ListChooser.vue
@@ -33,13 +33,13 @@ const _items = computed(() => props.items.map(item => {
 }));
 const isSelectedItem = (item) => {
   if (item === null || item === undefined) return props.value === null || props.value === undefined;
-  if (item.hasOwnProperty('_src')) return props.value === item._src;
-  if (item.hasOwnProperty('value') && props.value?.hasOwnProperty('value')) return props.value.value === item.value;
+  if (Object.hasOwn(item, '_src')) return props.value === item._src;
+  if (Object.hasOwn(item, 'value') && Object.hasOwn(props.value ?? {}, 'value')) return props.value.value === item.value;
   return props.value === item;
 };
 const onClick = (item) => {
   if (item === null || item === undefined) emit('input', null);
-  else if (item.hasOwnProperty('_src')) emit('input', item._src);
+  else if (Object.hasOwn(item, '_src')) emit('input', item._src);
   else emit('input', item);
 };
 </script>

--- a/ui/ops/src/components/filter/filterCtx.js
+++ b/ui/ops/src/components/filter/filterCtx.js
@@ -128,7 +128,7 @@ export default function useFilterCtx(opts) {
     for (const f of newFilters) {
       toRemove.delete(f.key);
 
-      if (!choices.hasOwnProperty(f.key)) {
+      if (!Object.hasOwn(choices, f.key)) {
         toAdd.push(f);
       } else {
         // check if the option and the existing choice are still compatible
@@ -172,7 +172,7 @@ export default function useFilterCtx(opts) {
    * @return {boolean} - if the value changed
    */
   const choose = (key, value) => {
-    if (!choices.hasOwnProperty(key)) {
+    if (!Object.hasOwn(choices, key)) {
       throw new Error(`No filter with key ${key}`);
     }
     if (value === undefined || value === null) {

--- a/ui/ops/src/components/filter/pageCtx.js
+++ b/ui/ops/src/components/filter/pageCtx.js
@@ -27,11 +27,11 @@ export default function usePageCtx(filterCtx, page) {
     const p = toValue(page);
     if (p === null || p === undefined) return null;
     if (typeof p === 'string') {
-      if (!filterCtx.filtersByKey.value.hasOwnProperty(p)) throw new Error(`No filter with key ${p}`);
+      if (!Object.hasOwn(filterCtx.filtersByKey.value, p)) throw new Error(`No filter with key ${p}`);
       return filterCtx.filtersByKey.value[p];
     }
     if (typeof p === 'object') {
-      if (!p.hasOwnProperty('key')) throw new Error('Filter object must have a key');
+      if (!Object.hasOwn(p, 'key')) throw new Error('Filter object must have a key');
       return p;
     }
 

--- a/ui/ops/src/components/ui-error/error.js
+++ b/ui/ops/src/components/ui-error/error.js
@@ -51,7 +51,7 @@ export const useErrorStore = defineStore('error', () => {
    * @return {WatchStopHandle}
    */
   function registerTracker(actionTracker) {
-    if (actionTracker.hasOwnProperty('error')) {
+    if (Object.hasOwn(actionTracker, 'error')) {
       return watch(() => actionTracker.error, (error) => {
         if (error && error.code !== StatusCode.OK) {
           addError(actionTracker, error);
@@ -86,7 +86,7 @@ export const useErrorStore = defineStore('error', () => {
    * @return {WatchStopHandle}
    */
   function registerCollection(collection) {
-    if (collection.hasOwnProperty('streamError')) {
+    if (Object.hasOwn(collection, 'streamError')) {
       return watch(() => collection.streamError, (error) => {
         if (error && error.code !== StatusCode.OK) {
           addError(collection, error);

--- a/ui/ops/src/routes/ops/notifications/NotificationsTable.vue
+++ b/ui/ops/src/routes/ops/notifications/NotificationsTable.vue
@@ -240,8 +240,9 @@ const filterOpts = computed(() => {
   // we only add filters that can affect the output, i.e. no floor filter if nothing has a floor.
   const filters = [];
   const defaults = [];
+  const forceQuery = props.forceQuery ?? {};
   // Acknowledged
-  if (!props.forceQuery?.hasOwnProperty('acknowledged')) {
+  if (!Object.hasOwn(forceQuery, 'acknowledged')) {
     filters.push({
       key: 'acknowledged',
       icon: 'mdi-checkbox-marked-circle-outline', title: 'Acknowledgement', type: 'boolean',
@@ -258,7 +259,7 @@ const filterOpts = computed(() => {
     });
   }
   // Floor
-  if (!props.forceQuery?.hasOwnProperty('floor')) {
+  if (!Object.hasOwn(forceQuery, 'floor')) {
     const items = floors.value
         // we can't query for empty strings anyway.
         .filter(s => Boolean(s));
@@ -267,8 +268,8 @@ const filterOpts = computed(() => {
     }
   }
   // Severity
-  if (!props.forceQuery?.hasOwnProperty('severityNotAbove') &&
-      !props.forceQuery?.hasOwnProperty('severityNotBelow')) {
+  if (!Object.hasOwn(forceQuery, 'severityNotAbove') &&
+      !Object.hasOwn(forceQuery, 'severityNotBelow')) {
     filters.push({
       key: 'severity', // maps to severityNotBelow and severityNotAbove
       icon: 'mdi-alert-box-outline', title: 'Severity', type: 'range',
@@ -278,7 +279,7 @@ const filterOpts = computed(() => {
     });
   }
   // Subsystem
-  if (!props.forceQuery?.hasOwnProperty('subsystem')) {
+  if (!Object.hasOwn(forceQuery, 'subsystem')) {
     const items = subsystems.value
         // we can't query for empty strings anyway.
         .filter(s => Boolean(s));
@@ -287,7 +288,7 @@ const filterOpts = computed(() => {
     }
   }
   // Zone
-  if (!props.forceQuery?.hasOwnProperty('zone')) {
+  if (!Object.hasOwn(forceQuery, 'zone')) {
     const items = zones.value
         // we can't query for empty strings anyway.
         .filter(s => Boolean(s));
@@ -296,7 +297,7 @@ const filterOpts = computed(() => {
     }
   }
 
-  if (!props.forceQuery?.hasOwnProperty('resolved')) {
+  if (!Object.hasOwn(forceQuery, 'resolved')) {
     filters.push({
       key: 'resolved',
       icon: 'mdi-checkbox-marked-circle-outline', title: 'Resolution', type: 'boolean',

--- a/ui/ops/src/routes/ops/overview/pageConfig.js
+++ b/ui/ops/src/routes/ops/overview/pageConfig.js
@@ -96,7 +96,7 @@ export default function usePageConfig(path) {
   const filterProps = {'layout': true, 'children': true};
   const filteredConfig = computed(() => Object.entries(configObj.value)
       .reduce((acc, [k, v]) => {
-        if (filterProps.hasOwnProperty(k)) return acc;
+        if (Object.hasOwn(filterProps, k)) return acc;
         acc[k] = v;
         return acc;
       }, {}));

--- a/ui/ops/src/stores/uiConfig.js
+++ b/ui/ops/src/stores/uiConfig.js
@@ -88,7 +88,7 @@ export function useSiteMap(config) {
   const enabledPaths = computed(() => {
     let features = [];
     const _config = toValue(config);
-    if (_config.hasOwnProperty('features')) {
+    if (Object.hasOwn(_config, 'features')) {
       // generate paths list, then convert each one to regex
       features = _generatePaths('', _config.features).map(path => {
         return new RegExp(`^${path.replace(/\*/g, '.*')}$`);

--- a/ui/ops/src/thirdparty/panzoom/PanZoom.vue
+++ b/ui/ops/src/thirdparty/panzoom/PanZoom.vue
@@ -50,7 +50,7 @@ export default {
       for (let i = 0; i < names.length; i++) {
         const name = names[i];
         const eName = 'on' + name[0].toUpperCase() + name.slice(1);
-        if (this.$attrs.hasOwnProperty(eName)) {
+        if (Object.hasOwn(this.$attrs, eName)) {
           on[`panzoom${name}`] = (e) => this.$emit(name, e.detail);
         }
       }

--- a/ui/ops/src/traits/airTemperature/airTemperature.js
+++ b/ui/ops/src/traits/airTemperature/airTemperature.js
@@ -86,7 +86,7 @@ export function useUpdateAirTemperature(name) {
         updateMask: {pathsList: ['temperature_set_point']}
       };
     }
-    if (!req.hasOwnProperty('state')) {
+    if (!Object.hasOwn(req, 'state')) {
       req = {state: /** @type {AirTemperature.AsObject} */ req};
     }
     return setRequestName(req, name);

--- a/ui/ops/src/traits/light/light.js
+++ b/ui/ops/src/traits/light/light.js
@@ -96,7 +96,7 @@ export function useUpdateBrightness(name) {
         updateMask: {pathsList: ['level_percent']}
       };
     }
-    if (!req.hasOwnProperty('brightness')) {
+    if (!Object.hasOwn(req, 'brightness')) {
       req = {brightness: req};
     }
     return setRequestName(req, name);

--- a/ui/ops/src/util/traits.js
+++ b/ui/ops/src/util/traits.js
@@ -32,10 +32,10 @@ export const toQueryObject = (input) => {
 export const setRequestName = (req, name) => {
   const nameValue = toValue(name);
   const needsName = nameValue === null || nameValue === undefined;
-  if (needsName && !req.hasOwnProperty('name')) {
+  if (needsName && !Object.hasOwn(req, 'name')) {
     throw new Error('name is required as part of request');
   }
-  if (!req.hasOwnProperty('name')) {
+  if (!Object.hasOwn(req, 'name')) {
     req.name = nameValue;
   }
   return req;


### PR DESCRIPTION
Calling hasOwnProperty on an instance was already discouraged in favour of Object.prototype.hasOwnProperty. As that's a mouth full modern browsers also have Object.hasOwn to replace this.