### PR TITLE
fix: add SecurityEvent support to allnodes serviceRegistry

### DIFF
--- a/pkg/node/alltraits/services.go
+++ b/pkg/node/alltraits/services.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vanti-dev/sc-bos/pkg/gentrait/emergencylight"
 	"github.com/vanti-dev/sc-bos/pkg/gentrait/meter"
 	"github.com/vanti-dev/sc-bos/pkg/gentrait/mqttpb"
+	"github.com/vanti-dev/sc-bos/pkg/gentrait/securityevent"
 	"github.com/vanti-dev/sc-bos/pkg/gentrait/udmipb"
 )
 
@@ -55,6 +56,7 @@ var serviceRegistry = map[trait.Name][]grpc.ServiceDesc{
 	meter.TraitName:          {gen.MeterApi_ServiceDesc, gen.MeterInfo_ServiceDesc, gen.MeterHistory_ServiceDesc},
 	mqttpb.TraitName:         {gen.MqttService_ServiceDesc},
 	statusTraitName:          {gen.StatusApi_ServiceDesc, gen.StatusHistory_ServiceDesc},
+	securityevent.TraitName:  {gen.SecurityEventApi_ServiceDesc},
 	udmipb.TraitName:         {gen.UdmiService_ServiceDesc},
 }
 


### PR DESCRIPTION
@dloveen-v while reviewing the hbd Island PR I noticed the warning `cannot determine services to support for trait`, this PR fixes that as security event support was not added in allnodes