### PR TITLE
router: fix panic when downloading devices from the gateway

### DIFF
--- a/internal/router/loopback.go
+++ b/internal/router/loopback.go
@@ -2,12 +2,14 @@ package router
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/dynamicpb"
 )
 
 // Loopback implements grpc.ClientConnInterface using a MethodResolver to find the real connection for each request.
@@ -196,6 +198,33 @@ func (c copyRecver) RecvMsg(m any) error {
 	if !ok {
 		return ErrNonProtoMessage
 	}
-	proto.Merge(mProto, c.from)
+	safeProtoMerge(mProto, c.from)
 	return nil
+}
+
+// safeProtoMerge is like proto.Merge but doesn't panic when using dynamicpb messages.
+//
+// proto.Merge will panic if the descriptors of src and dest aren't equal according to ==.
+// This has problems for us because we're mixing dynamic and explicit messages, which have subtly different descriptors in ways that are implementation dependent.
+// To fix this we fall back to marshalling and unmarshalling the messages, which is what proto.Merge is intended to imitate.
+func safeProtoMerge(dst, src proto.Message) {
+	_, srcDynamic := src.(*dynamicpb.Message)
+	_, dstDynamic := dst.(*dynamicpb.Message)
+	if !srcDynamic && !dstDynamic {
+		proto.Merge(dst, src)
+		return
+	}
+
+	// fall back to marshalling and unmarshalling,
+	// we assume that the descriptors are the same if their names are the same
+	if want, got := dst.ProtoReflect().Descriptor().FullName(), src.ProtoReflect().Descriptor().FullName(); want != got {
+		panic(fmt.Sprintf("descriptor mismatch: %v != %v", got, want))
+	}
+	data, err := proto.Marshal(src)
+	if err != nil {
+		panic(fmt.Sprintf("src marshal: %v", err))
+	}
+	if err := proto.Unmarshal(data, dst); err != nil {
+		panic(fmt.Sprintf("dst unmarshal: %v", err))
+	}
 }

--- a/internal/router/loopback.go
+++ b/internal/router/loopback.go
@@ -220,11 +220,12 @@ func safeProtoMerge(dst, src proto.Message) {
 	if want, got := dst.ProtoReflect().Descriptor().FullName(), src.ProtoReflect().Descriptor().FullName(); want != got {
 		panic(fmt.Sprintf("descriptor mismatch: %v != %v", got, want))
 	}
-	data, err := proto.Marshal(src)
+	data, err := proto.MarshalOptions{AllowPartial: true}.Marshal(src)
 	if err != nil {
 		panic(fmt.Sprintf("src marshal: %v", err))
 	}
-	if err := proto.Unmarshal(data, dst); err != nil {
+	err = proto.UnmarshalOptions{AllowPartial: true, Merge: true}.Unmarshal(data, dst)
+	if err != nil {
 		panic(fmt.Sprintf("dst unmarshal: %v", err))
 	}
 }

--- a/internal/router/loopback_test.go
+++ b/internal/router/loopback_test.go
@@ -1,24 +1,33 @@
 package router
 
 import (
+	"bytes"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoregistry"
-	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/dynamicpb"
 
 	"github.com/smart-core-os/sc-api/go/traits"
 )
 
 func TestCopyRecver_RecvMsg(t *testing.T) {
-	msg := func(s string) proto.Message {
-		return &traits.Metadata{Name: s}
+	moreMap := func(more ...string) map[string]string {
+		if len(more) == 0 {
+			return nil
+		}
+		m := make(map[string]string, len(more)/2)
+		for i := 0; i < len(more); i += 2 {
+			m[more[i]] = more[i+1]
+		}
+		return m
 	}
-	msg2 := func(s string) proto.Message {
-		return &traits.TraitMetadata{Name: s}
+	msg := func(s string, more ...string) proto.Message {
+		return &traits.Metadata{Name: s, More: moreMap(more...)}
+	}
+	msg2 := func(s string, more ...string) proto.Message {
+		return &traits.TraitMetadata{Name: s, More: moreMap(more...)}
 	}
 	// simulate descriptors from the reflection package
 	mkDynamic := func(m proto.Message) proto.Message {
@@ -50,10 +59,11 @@ func TestCopyRecver_RecvMsg(t *testing.T) {
 		src, dst, want     proto.Message
 		wantErr, wantPanic bool
 	}{
-		{"msg,msg", msg("a"), msg("b"), msg("a"), false, false},
-		{"msg,dynamic", msg("a"), mkDynamic(msg("b")), msg("a"), false, false},
-		{"dynamic,msg", mkDynamic(msg("a")), msg("b"), msg("a"), false, false},
-		{"dynamic,dynamic", mkDynamic(msg("a")), mkDynamic(msg("b")), msg("a"), false, false},
+		{"msg,msg", msg("a"), msg("b", "k", "v"), msg("a", "k", "v"), false, false},
+		{"msg,dynamic", msg("a"), mkDynamic(msg("b", "k", "v")), msg("a", "k", "v"), false, false},
+		{"dynamic,msg", mkDynamic(msg("a")), msg("b", "k", "v"), msg("a", "k", "v"), false, false},
+		{"dynamic,msg", mkDynamic(msg("a")), msg("b", "k", "v"), msg("a", "k", "v"), false, false},
+		{"dynamic,dynamic", mkDynamic(msg("a")), mkDynamic(msg("b", "k", "v")), msg("a", "k", "v"), false, false},
 		{"msg1,msg2", msg("1"), msg2("2"), msg2("2"), false, true},
 		{"msg2,msg1", msg2("2"), msg("1"), msg("1"), false, true},
 		{"msg1,dynamic2", msg("1"), mkDynamic(msg2("2")), msg2("2"), false, true},
@@ -78,8 +88,10 @@ func TestCopyRecver_RecvMsg(t *testing.T) {
 			}
 
 			// proto.Equal doesn't work for messages with different descriptors
-			if diff := cmp.Diff(tt.want, tt.dst, protocmp.Transform()); diff != "" {
-				t.Errorf("RecvMsg() (-want,+got)\n%s", diff)
+			wantBytes, _ := proto.MarshalOptions{Deterministic: true}.Marshal(tt.want)
+			gotBytes, _ := proto.MarshalOptions{Deterministic: true}.Marshal(tt.dst)
+			if !bytes.Equal(wantBytes, gotBytes) {
+				t.Errorf("RecvMsg() = %v, want %v", tt.dst, tt.want)
 			}
 		})
 	}

--- a/internal/router/loopback_test.go
+++ b/internal/router/loopback_test.go
@@ -1,0 +1,86 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/dynamicpb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+)
+
+func TestCopyRecver_RecvMsg(t *testing.T) {
+	msg := func(s string) proto.Message {
+		return &traits.Metadata{Name: s}
+	}
+	msg2 := func(s string) proto.Message {
+		return &traits.TraitMetadata{Name: s}
+	}
+	// simulate descriptors from the reflection package
+	mkDynamic := func(m proto.Message) proto.Message {
+		// convert the descriptor to an equivalent one via the proto file representation
+		descriptor := m.ProtoReflect().Descriptor()
+		file, err := protodesc.NewFile(protodesc.ToFileDescriptorProto(descriptor.ParentFile()), protoregistry.GlobalFiles)
+		if err != nil {
+			t.Fatalf("NewFile() error = %v", err)
+		}
+		msgDesc := file.Messages().ByName(descriptor.Name())
+		if msgDesc == nil {
+			t.Fatalf("message not found in file: %v", descriptor.Name())
+		}
+		dm := dynamicpb.NewMessage(msgDesc)
+
+		// copy over the data, don't use proto.Merge!
+		data, err := proto.Marshal(m)
+		if err != nil {
+			t.Fatalf("Marshal() error = %v", err)
+		}
+		if err := proto.Unmarshal(data, dm); err != nil {
+			t.Fatalf("Unmarshal() error = %v", err)
+		}
+		return dm
+	}
+
+	tests := []struct {
+		name               string
+		src, dst, want     proto.Message
+		wantErr, wantPanic bool
+	}{
+		{"msg,msg", msg("a"), msg("b"), msg("a"), false, false},
+		{"msg,dynamic", msg("a"), mkDynamic(msg("b")), msg("a"), false, false},
+		{"dynamic,msg", mkDynamic(msg("a")), msg("b"), msg("a"), false, false},
+		{"dynamic,dynamic", mkDynamic(msg("a")), mkDynamic(msg("b")), msg("a"), false, false},
+		{"msg1,msg2", msg("1"), msg2("2"), msg2("2"), false, true},
+		{"msg2,msg1", msg2("2"), msg("1"), msg("1"), false, true},
+		{"msg1,dynamic2", msg("1"), mkDynamic(msg2("2")), msg2("2"), false, true},
+		{"dynamic2,msg1", mkDynamic(msg2("2")), msg("1"), msg("1"), false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r != nil {
+					if !tt.wantPanic {
+						t.Errorf("unexpected panic: %v", r)
+					}
+				} else if tt.wantPanic {
+					t.Error("expected panic")
+				}
+			}()
+
+			cr := copyRecver{from: tt.src}
+			if err := cr.RecvMsg(tt.dst); (err != nil) != tt.wantErr {
+				t.Errorf("RecvMsg() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// proto.Equal doesn't work for messages with different descriptors
+			if diff := cmp.Diff(tt.want, tt.dst, protocmp.Transform()); diff != "" {
+				t.Errorf("RecvMsg() (-want,+got)\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The cause of the panic was proto.Merge not behaving as advertised when merging proto.Messages that have equivalent but != protoreflect.Descriptor instances, like we have on the gateway as we use protodesc and dynamicpb packages to create dynamic descriptors and messages.

The fix is to fall back to the slow path in these cases and round trip the merge via proto.Mershal/Unmarshal. proto.Merge is advertised to be equivalent to this anyway.

Fixes SC-1002