### PR TITLE
system/gateway: use local descriptors where possible

### DIFF
--- a/pkg/system/gateway/scan.go
+++ b/pkg/system/gateway/scan.go
@@ -4,9 +4,9 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"slices"
 
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	reflectionpb "google.golang.org/grpc/reflection/grpc_reflection_v1"


### PR DESCRIPTION
Change the ServiceDescriptor used by the gateway to the one in protoregistry.GlobalFiles if it exists. This makes our dynamic services more consistent with assumptions in the proto package (proto.Equal, proto.Merge) which assume a message is described by a single service descriptor, this wasn't true before this change.

I've implemented the change in a way that avoids additional reflection calls on the remote node if we already know how to describe the service.

Fixes SC-1004
Fixes SC-1002 - #334 also fixes it more locally