### PR TITLE
history: fix performance issues with reading history pages

### DIFF
--- a/pkg/history/pgxstore/schema.sql
+++ b/pkg/history/pgxstore/schema.sql
@@ -6,5 +6,7 @@ CREATE TABLE IF NOT EXISTS history
     payload     BYTEA       NULL
 );
 
-CREATE INDEX IF NOT EXISTS history_source_idx ON history (source);
-CREATE INDEX IF NOT EXISTS history_create_time_idx ON history (create_time);
+DROP INDEX IF EXISTS history_create_time_idx; -- replaced by history_id_source_idx;
+DROP INDEX IF EXISTS history_source_idx; -- replaced by history_source_create_time_idx
+CREATE INDEX IF NOT EXISTS history_id_source_idx ON history (id, source);
+CREATE INDEX IF NOT EXISTS history_source_create_time_idx ON history (source, create_time);

--- a/pkg/history/pgxstore/store.go
+++ b/pkg/history/pgxstore/store.go
@@ -265,7 +265,7 @@ func (s slice) readRangeClause(clauses []string, args []any) ([]string, []any, e
 		args = append(args, s.to.CreateTime)
 		clauses = append(clauses, fmt.Sprintf(`id <= (
 	select max(id) from history where source = $%[1]d and create_time = (
-		select max(create_time) from history where source = $%[1]d and create_time <= $%[2]d
+		select max(create_time) from history where source = $%[1]d and create_time < $%[2]d
 	)
 )`, sourceIdx, timeIdx))
 	}


### PR DESCRIPTION
This change adjusts the queries and indexes used by the postgres history store to be ~10,000x more performant. In general the changes involved replacing AND clauses with inner selects in certain cases where indexes could not be used for either selection or sorting.

I assume the difference in performance is due to Postgres not being aware that the create_time col is also consistently ordered, just like the PK. The change to the query makes use of this fact to better optimise how the query is run using nested selects.