### PR TITLE
auto/wordpress: iaq rounding

### DIFF
--- a/pkg/auto/wordpress/job/air_quality.go
+++ b/pkg/auto/wordpress/job/air_quality.go
@@ -3,6 +3,7 @@ package job
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"time"
 
 	"github.com/pkg/errors"
@@ -58,7 +59,7 @@ func (a *AirQualityJob) Do(ctx context.Context, sendFn sender) error {
 			Timestamp: time.Now(),
 		},
 		AverageCo2: types.Float32Measure{
-			Value: average,
+			Value: float32(math.Floor(float64(average))),
 			Units: "ppm",
 		},
 	}


### PR DESCRIPTION
This is a hot fix to get prettier Co2 Levels displayed from WordPress.
![Screenshot 2025-02-11 at 15 39 33](https://github.com/user-attachments/assets/549ecbdb-8b29-46d6-a7ca-1901b8dd2a6f)
