### PR TITLE
driver/steinel: update data when first starting driver

### DIFF
--- a/pkg/driver/steinel/hpd/poller.go
+++ b/pkg/driver/steinel/hpd/poller.go
@@ -35,6 +35,7 @@ func NewPoller(client *Client, pollInterval time.Duration, logger *zap.Logger, s
 func (p *Poller) startPoll(ctx context.Context) {
 	ticker := time.NewTicker(p.pollInterval)
 	defer ticker.Stop()
+	p.process()
 
 	for {
 		select {


### PR DESCRIPTION
get a data update immediately when the driver starts instead of waiting for first timer elapse