### PR TITLE
auto/wordpress: support multiple authorization headers in auth config for CDNs

### DIFF
--- a/cmd/tools/test-wordpress/main.go
+++ b/cmd/tools/test-wordpress/main.go
@@ -92,12 +92,18 @@ const (
   "name":     "wordpress-test",
   "type":     "wordpress",
   "disabled": false,
-  "baseUrl": "https://vanti-plugin-test-com.stackstaging.com/wp-json/recording/v1/create",
+  "baseUrl": "https://app-my-paradise-co-uk.corestaging.co.uk/wp-json/recording/v1/create",
   "site":     "abc-test1",
-  "authentication": {
-	"type":       "Bearer",
-	"secretFile": "./.data/secrets/wordpress"
-  },
+  "authentication": [
+    {
+        "type":       "Basic",
+        "secretFile": "./.data/secrets/wordpress-basic"
+    },
+    {
+        "type":       "Bearer",
+        "secretFile": "./.data/secrets/wordpress-bearer"
+    }
+  ],
   "sources": {
 	"occupancy":    {
 	  "path": "occupancy",


### PR DESCRIPTION
Since the staging and production environments can require authentication with a CDN, as well as the actual WordPress plugin, the config for the WordPress automation needs to support multiple Authorization headers; joined using ` , `.

The config should declare these header strings in the order they will be sent and read by a REST server.


Example `Basic` auth secret data file:
```
username:m7Rand0mP@ssw0rd
```
The string in this file will then be Base64 Encoded as per the Basic Authorization header specification.