### PR TITLE
ui/space: add air quality widget

### DIFF
--- a/example/config/vanti-ugs/space-ui.json
+++ b/example/config/vanti-ugs/space-ui.json
@@ -5,7 +5,7 @@
   "config": {
     "home": "/home",
     "auth": {
-      "disabled": false,
+      "disabled": true,
       "keycloak": {
         "realm": "Smart_Core",
         "url": "http://localhost:8888/",
@@ -21,6 +21,15 @@
           "altText": "Smart Core logo - representing nodes and connections",
           "src": ""
         }
+      }
+    },
+    "pages": {
+      "home": {
+        "widgets": [
+          {"name": "air-quality"},
+          {"name": "lighting"},
+          {"name": "temperature"}
+        ]
       }
     }
   }

--- a/ui/space/package.json
+++ b/ui/space/package.json
@@ -14,6 +14,7 @@
     "@smart-core-os/sc-api-grpc-web": "^1.0.0-beta.48",
     "@vanti-dev/sc-bos-ui-gen": "^1.0.0-beta.19",
     "debounce": "^1.2.1",
+    "fast-deep-equal": "^3.1.3",
     "keycloak-js": "^25.0.2",
     "pinia": "^2.3.0",
     "pinia-plugin-persistedstate": "^4.2.0",

--- a/ui/space/src/components/CircularGauge.vue
+++ b/ui/space/src/components/CircularGauge.vue
@@ -1,0 +1,151 @@
+<template>
+  <v-sheet elevation="0" color="transparent" class="gauge">
+    <svg xmlns="http://www.w3.org/2000/svg"
+         xml:space="preserve"
+         viewBox="0 0 100 100"
+         :width="props.size"
+         :height="props.size">
+      <circle class="track" :style="trackStyles" :class="trackClasses"
+              cx="50" cy="50" :r="radius"
+              :stroke-width="trackStrokeWidth"
+              pathLength="100" stroke-dasharray="100 100" :stroke-dashoffset="trackStrokeDashOffset"/>
+      <circle class="remainder" :style="remainderStyles" :class="remainderClasses"
+              cx="50" cy="50" :r="radius"
+              :stroke-width="remainderStrokeWidth"
+              pathLength="100" stroke-dasharray="100 100" :stroke-dashoffset="remainderStrokeDashOffset"/>
+      <circle class="fill" :style="fillStyles" :class="fillClasses"
+              cx="50" cy="50" :r="radius"
+              :stroke-width="fillStrokeWidth"
+              pathLength="100" stroke-dasharray="100 100" :stroke-dashoffset="fillStrokeDashOffset"/>
+    </svg>
+  </v-sheet>
+</template>
+
+<script setup>
+import {computed, toRef} from 'vue';
+import {useTextColor} from 'vuetify/lib/composables/color';
+
+const props = defineProps({
+  value: {
+    type: Number,
+    default: 30
+  },
+  min: {
+    type: [Number, String],
+    default: 0.
+  },
+  max: {
+    type: [Number, String],
+    default: 100
+  },
+  arcStart: {
+    type: [Number, String],
+    default: -120,
+  },
+  arcEnd: {
+    type: [Number, String],
+    default: 120
+  },
+  size: {
+    type: [Number, String],
+    default: 155
+  },
+  fillColor: {
+    type: String,
+    default: 'primary'
+  },
+  trackColor: {
+    type: String,
+    default: 'currentColor'
+  },
+  remainderColor: {
+    type: String,
+    default: 'transparent'
+  },
+  width: {
+    type: [Number, String],
+    default: 10
+  },
+  trackWidth: {
+    type: [Number, String],
+    default: undefined // defaults to width
+  },
+  fillWidth: {
+    type: [Number, String],
+    default: undefined // defaults to width
+  },
+  remainderWidth: {
+    type: [Number, String],
+    default: undefined // defaults to width
+  },
+  innerGap: {
+    type: [Number, String],
+    default: 5 // in degrees
+  }
+});
+
+const _min = computed(() => parseFloat(props.min));
+const _max = computed(() => parseFloat(props.max));
+const _value = computed(() => Math.min(Math.max(parseFloat(props.value), _min.value), _max.value));
+const _innerGap = computed(() => parseFloat(props.innerGap));
+
+const trackStrokeWidth = computed(() => parseFloat(props.trackWidth ?? props.width));
+const fillStrokeWidth = computed(() => parseFloat(props.fillWidth ?? props.width));
+const remainderStrokeWidth = computed(() => parseFloat(props.remainderWidth ?? props.width));
+const maxStrokeWidth = computed(() => Math.max(trackStrokeWidth.value, fillStrokeWidth.value, remainderStrokeWidth.value));
+
+const radius = computed(() => 50 - maxStrokeWidth.value / 2);
+const rotation = computed(() => parseFloat(props.arcStart) - 90);
+const arcLength = computed(() => Math.abs(parseFloat(props.arcEnd) - parseFloat(props.arcStart)));
+const arcPathLength = computed(() => arcLength.value / 360 * 100)
+const trackStrokeDashOffset = computed(() => 100 - arcPathLength.value);
+const fillPercent = computed(() => (_value.value - _min.value) / (_max.value - _min.value));
+const fillStrokeDashOffset = computed(() => 100 - arcPathLength.value * fillPercent.value);
+const remainderStrokeDashOffset = computed(() => {
+  if (fillPercent.value === 0) {
+    return 100 - arcPathLength.value; // remove inner gap
+  }
+  return 100 - (arcPathLength.value * (1 - fillPercent.value) - (_innerGap.value / 360 * 100));
+});
+const remainderRotation = computed(() => {
+  if (fillPercent.value === 0) {
+    return rotation.value; // remove inner gap
+  }
+  return rotation.value + (arcLength.value * fillPercent.value) + _innerGap.value;
+});
+
+const {textColorClasses: trackClasses, textColorStyles: trackStyles} = useTextColor(toRef(props, 'trackColor'));
+const {textColorClasses: fillClasses, textColorStyles: fillStyles} = useTextColor(toRef(props, 'fillColor'));
+const {
+  textColorClasses: remainderClasses,
+  textColorStyles: remainderStyles
+} = useTextColor(toRef(props, 'remainderColor'));
+</script>
+
+<style scoped>
+.gauge {
+  display: grid;
+  align-items: center;
+  justify-items: center;
+}
+
+svg {
+  /* get rid of the descendent for baseline alignment */
+  vertical-align: top;
+}
+
+svg circle {
+  transform-origin: center;
+  transform: rotate(calc(v-bind(rotation) * 1deg));
+  fill: transparent;
+  stroke: currentColor;
+}
+
+circle.remainder {
+  transform: rotate(calc(v-bind(remainderRotation) * 1deg));
+}
+
+.track {
+  stroke: color-mix(in srgb, currentColor, transparent calc(100% * (1 - var(--v-border-opacity))));
+}
+</style>

--- a/ui/space/src/components/StatusChip.vue
+++ b/ui/space/src/components/StatusChip.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="status-chip">
+    <span class="indicator d-flex align-center justify-center" :class="backgroundColorClasses" :style="backgroundColorStyles">
+      <v-icon :icon="indicatorIcon" size="1em"/>
+    </span>
+    <span class="label"><slot>{{ props.label }}</slot></span>
+  </div>
+</template>
+
+<script setup>
+import {computed} from 'vue';
+import {useBackgroundColor} from 'vuetify/lib/composables/color';
+
+const props = defineProps({
+  label: {
+    type: String,
+    default: ''
+  },
+  status: {
+    type: String,
+    default: 'success' // one of 'success', 'warning', 'error', 'info'
+  }
+});
+
+
+const indicatorColor = computed(() => props.status)
+const indicatorIcon = computed(() => {
+  switch (props.status) {
+    case 'success':
+      return 'mdi-check';
+    case 'warning':
+      return 'mdi-exclamation';
+    case 'error':
+      return 'mdi-close';
+    case 'info':
+      return 'mdi-information-symbol';
+    default:
+      return '';
+  }
+})
+
+const {backgroundColorClasses, backgroundColorStyles} = useBackgroundColor(indicatorColor)
+</script>
+
+<style scoped>
+.status-chip {
+  display: flex;
+  align-items: center;
+  column-gap: .5em;
+}
+
+.indicator {
+  display: inline-block;
+  width: 1.5em;
+  height: 1.5em;
+  border-radius: 100%;
+  border: .15em solid currentColor;
+}
+
+.label {
+  line-height: 1;
+}
+</style>

--- a/ui/space/src/routes/components/AirQualityCard.vue
+++ b/ui/space/src/routes/components/AirQualityCard.vue
@@ -1,0 +1,88 @@
+<template>
+  <v-card :loading="loading">
+    <v-card-title class="text-h4 font-weight-medium d-flex align-center pl-7 pr-6">
+      <span class="mr-auto">Air Quality</span>
+      <span v-if="hasScore" class="text-uppercase font-weight-light">{{ score.label }}</span>
+    </v-card-title>
+    <circular-gauge
+        v-if="hasScore"
+        class="gauge--primary mt-2"
+        :value="score.value"
+        :min="metrics.score.min" :max="metrics.score.max"
+        arc-start="0" arc-end="240" size="80"
+        width="20"
+        fill-color="accent"/>
+    <v-card-text class="metrics text-subtitle-2 pl-7 pb-6 pt-3 pr-12">
+      <status-chip v-for="m of displayMetrics" :key="m.title" :status="m.status">
+        <!-- eslint-disable-next-line vue/no-v-text-v-html-on-component vue/no-v-html -->
+        <span v-html="m.title"/>
+      </status-chip>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup>
+import CircularGauge from '@/components/CircularGauge.vue';
+import StatusChip from '@/components/StatusChip.vue';
+import {metrics, useAirQuality, usePullAirQuality} from '@/routes/components/airQuality.js';
+import {computed} from 'vue';
+
+const props = defineProps({
+  name: {
+    type: String,
+    default: ''
+  }
+});
+
+const orderedMetrics = [
+  'volatileOrganicCompounds', 'carbonDioxideLevel',
+  'particulateMatter25', 'particulateMatter10', 'particulateMatter1',
+  'infectionRisk', 'airChangePerHour'
+];
+const {value: airQuality, loading} = usePullAirQuality(() => props.name);
+const {presentMetrics, score} = useAirQuality(airQuality);
+const displayMetrics = computed(() => {
+  const res = [];
+  const src = presentMetrics.value;
+  for (const orderedMetric of orderedMetrics) {
+    if (!Object.hasOwn(src, orderedMetric)) continue;
+    res.push({
+      status: src[orderedMetric].status,
+      title: metrics[orderedMetric].label,
+    })
+  }
+  return res;
+});
+const hasScore = computed(() => !!score.value);
+
+</script>
+
+<style scoped>
+.v-card {
+  display: grid;
+  grid-template-columns: 1fr 50px;
+  grid-template-rows: repeat(2, auto);
+}
+
+.v-card-title {
+  min-height: 72px;
+}
+
+.gauge--primary {
+  grid-column: -2 / -1;
+  grid-row: 1 / -1;
+  justify-self: end;
+  align-self: start;
+  padding: 1.2em 1em 1em 1em;
+}
+
+.metrics {
+  display: flex;
+  column-gap: 1.5em;
+  /* all these prevent overflow metrics from showing */
+  row-gap: 2em;
+  flex-wrap: wrap;
+  max-height: 3.7em;
+  overflow: hidden;
+}
+</style>

--- a/ui/space/src/routes/components/airQuality.js
+++ b/ui/space/src/routes/components/airQuality.js
@@ -1,0 +1,235 @@
+import {closeResource, newResourceValue} from '@/api/resource.js';
+import {pullAirQualitySensor} from '@/api/sc/traits/air-quality-sensor';
+import {toQueryObject, watchResource} from '@/util/traits.js';
+import {AirQuality} from '@smart-core-os/sc-api-grpc-web/traits/air_quality_sensor_pb';
+import {computed, onScopeDispose, reactive, toRefs, toValue} from 'vue';
+
+/**
+ * @typedef {
+ *   import('@smart-core-os/sc-api-grpc-web/traits/air_quality_sensor_pb').PullAirQualityRequest
+ * } PullAirQualityRequest
+ * @typedef {
+ *   import('@smart-core-os/sc-api-grpc-web/traits/air_quality_sensor_pb').PullAirQualityResponse
+ * } PullAirQualityResponse
+ * @typedef {import('vue').ComputedRef} ComputedRef
+ * @typedef {import('@/api/resource').ResourceError} ResourceError
+ * @typedef {import('@/api/resource').ResourceValue} ResourceValue
+ * @typedef {import('vue').Ref} Ref
+ * @typedef {import('vue').ToRefs} ToRefs
+ * @typedef {import('vue').MaybeRefOrGetter} MaybeRefOrGetter
+ */
+
+/**
+ * @param {MaybeRefOrGetter<string|PullAirQualityRequest.AsObject>} query - The name of the device or a query object
+ * @param {MaybeRefOrGetter<boolean>=} paused - Whether to pause the data stream
+ * @return {ToRefs<ResourceValue<AirQuality.AsObject, PullAirQualityResponse>>}
+ */
+export function usePullAirQuality(query, paused = false) {
+  const resource = reactive(
+      /** @type {ResourceValue<AirQuality.AsObject, PullAirQualityResponse>} */
+      newResourceValue()
+  );
+  onScopeDispose(() => closeResource(resource));
+
+  const queryObject = computed(() => toQueryObject(query));
+
+  watchResource(
+      () => toValue(queryObject),
+      () => toValue(paused),
+      (req) => {
+        pullAirQualitySensor(req, resource);
+        return () => closeResource(resource);
+      }
+  );
+
+  return toRefs(resource);
+}
+
+/**
+ * @typedef {Object} AirQualityMetricDesc
+ * @property {string} label
+ * @property {string} unit
+ * @property {number?} min
+ * @property {number?} max
+ * @property {Array<{value: number, status: string}>} levels
+ */
+/**
+ * @type {Record<string, AirQualityMetricDesc>}
+ */
+export const metrics = {
+  'score': {
+    label: 'IAQ',
+    unit: '%',
+    min: 0,
+    max: 100,
+    levels: [
+      {value: 0, status: 'error'},
+      {value: 10, status: 'warning'},
+      {value: 50, status: 'success'}
+    ]
+  },
+  'carbonDioxideLevel': {
+    label: 'CO<sub>2</sub>',
+    unit: 'ppm',
+    min: 0,
+    max: 5000,
+    levels: [
+      {value: 0, status: 'success'},
+      {value: 1000, status: 'warning'},
+      {value: 2000, status: 'error'}
+    ]
+  },
+  'volatileOrganicCompounds': {
+    label: 'VOC',
+    unit: 'ppm',
+    min: 0,
+    max: 1,
+    levels: [
+      {value: 0, status: 'success'},
+      {value: 0.3, status: 'warning'},
+      {value: 0.5, status: 'error'}
+    ]
+  },
+  'airPressure': {
+    label: 'Air Pressure',
+    unit: 'hPa',
+    min: 0,
+    max: 1100,
+    levels: [
+      {value: 0, status: 'error'},
+      {value: 1000, status: 'success'}
+    ]
+  },
+  'infectionRisk': {
+    label: 'Infection Risk',
+    unit: '%',
+    min: 0,
+    max: 100,
+    levels: [
+      {value: 0, status: 'success'},
+      {value: 25, status: 'warning'},
+      {value: 50, status: 'error'}
+    ]
+  },
+  'particulateMatter1': {
+    label: 'PM1',
+    unit: 'µg/m³',
+    min: 0,
+    max: 50,
+    levels: [
+      {value: 0, status: 'success'},
+      {value: 10, status: 'warning'},
+      {value: 20, status: 'error'}
+    ]
+  },
+  'particulateMatter25': {
+    label: 'PM2.5',
+    unit: 'µg/m³',
+    min: 0,
+    max: 50,
+    levels: [
+      {value: 0, status: 'success'},
+      {value: 10, status: 'warning'},
+      {value: 20, status: 'error'}
+    ]
+  },
+  'particulateMatter10': {
+    label: 'PM10',
+    unit: 'µg/m³',
+    min: 0,
+    max: 50,
+    levels: [
+      {value: 0, status: 'success'},
+      {value: 10, status: 'warning'},
+      {value: 20, status: 'error'}
+    ]
+  },
+  'airChangePerHour': {
+    label: 'Air Exchange Rate',
+    unit: '/h',
+    min: 0,
+    max: 10,
+    levels: [
+      {value: 0, status: 'error'},
+      {value: 5, status: 'success'}
+    ]
+  },
+  'comfort': {
+    label: 'Comfort',
+    unit: '',
+    levels: [
+      {value: AirQuality.Comfort.COMFORTABLE, status: 'success'},
+      {value: AirQuality.Comfort.UNCOMFORTABLE, status: 'error'}
+    ]
+  }
+}
+
+/**
+ * @typedef {Object} AirQualityMetric
+ * @property {number} value
+ * @property {string} status
+ */
+
+/**
+ * @typedef {Object} AirQualityScore
+ * @property {number} value
+ * @property {string} label
+ * @property {string} status
+ */
+
+/**
+ * @param {MaybeRefOrGetter<AirQuality.AsObject>} value
+ * @return {{
+ *   presentMetrics: import('vue').ComputedRef<Record<keyof metrics, AirQualityMetric>>,
+ *   score: import('vue').ComputedRef<AirQualityScore>
+ * }}
+ */
+export function useAirQuality(value) {
+  const _v = computed(() => toValue(value));
+
+  const presentMetrics = computed(() => {
+    const result = /** @type {Record<keyof metrics, AirQualityMetric>} */ {};
+    for (const [k, v] of Object.entries(_v.value ?? {})) {
+      const m = metrics[k];
+      if (!m || !v) {
+        continue; // skip unknown metrics
+      }
+      let status = '';
+      for (const level of m.levels) {
+        if (v >= level.value) {
+          status = level.status;
+          continue;
+        }
+        break;
+      }
+      result[k] = {value: v, status};
+    }
+    return result;
+  });
+
+  const score = computed(() => {
+    const presentScore = presentMetrics.value['score'];
+    const statusToLabel = (status) => {
+      switch (status) {
+        case 'error': return 'Poor';
+        case 'warning': return 'Fair';
+        case 'success': return 'Good';
+        default: return '';
+      }
+    }
+    if (presentScore) {
+      return {
+        value: presentScore.value,
+        label: statusToLabel(presentScore.status),
+        status: presentScore.status
+      };
+    }
+
+    return null;
+  });
+
+  return {
+    presentMetrics,
+    score
+  };
+}

--- a/ui/space/src/routes/components/airQuality.js
+++ b/ui/space/src/routes/components/airQuality.js
@@ -45,13 +45,19 @@ export function usePullAirQuality(query, paused = false) {
   return toRefs(resource);
 }
 
+export const status = {
+  ERROR: 'error',
+  WARNING: 'warning',
+  SUCCESS: 'success'
+}
+
 /**
  * @typedef {Object} AirQualityMetricDesc
  * @property {string} label
  * @property {string} unit
  * @property {number?} min
  * @property {number?} max
- * @property {Array<{value: number, status: string}>} levels
+ * @property {Array<{value: number, status: valueOf<status>}>} levels
  */
 /**
  * @type {Record<string, AirQualityMetricDesc>}
@@ -63,9 +69,9 @@ export const metrics = {
     min: 0,
     max: 100,
     levels: [
-      {value: 0, status: 'error'},
-      {value: 10, status: 'warning'},
-      {value: 50, status: 'success'}
+      {value: 0, status: status.ERROR},
+      {value: 10, status: status.WARNING},
+      {value: 50, status: status.SUCCESS}
     ]
   },
   'carbonDioxideLevel': {
@@ -74,9 +80,9 @@ export const metrics = {
     min: 0,
     max: 5000,
     levels: [
-      {value: 0, status: 'success'},
-      {value: 1000, status: 'warning'},
-      {value: 2000, status: 'error'}
+      {value: 0, status: status.SUCCESS},
+      {value: 1000, status: status.WARNING},
+      {value: 2000, status: status.ERROR}
     ]
   },
   'volatileOrganicCompounds': {
@@ -85,9 +91,9 @@ export const metrics = {
     min: 0,
     max: 1,
     levels: [
-      {value: 0, status: 'success'},
-      {value: 0.3, status: 'warning'},
-      {value: 0.5, status: 'error'}
+      {value: 0, status: status.SUCCESS},
+      {value: 0.3, status: status.WARNING},
+      {value: 0.5, status: status.ERROR}
     ]
   },
   'airPressure': {
@@ -96,8 +102,8 @@ export const metrics = {
     min: 0,
     max: 1100,
     levels: [
-      {value: 0, status: 'error'},
-      {value: 1000, status: 'success'}
+      {value: 0, status: status.ERROR},
+      {value: 1000, status: status.SUCCESS}
     ]
   },
   'infectionRisk': {
@@ -106,9 +112,9 @@ export const metrics = {
     min: 0,
     max: 100,
     levels: [
-      {value: 0, status: 'success'},
-      {value: 25, status: 'warning'},
-      {value: 50, status: 'error'}
+      {value: 0, status: status.SUCCESS},
+      {value: 25, status: status.WARNING},
+      {value: 50, status: status.ERROR}
     ]
   },
   'particulateMatter1': {
@@ -117,9 +123,9 @@ export const metrics = {
     min: 0,
     max: 50,
     levels: [
-      {value: 0, status: 'success'},
-      {value: 10, status: 'warning'},
-      {value: 20, status: 'error'}
+      {value: 0, status: status.SUCCESS},
+      {value: 10, status: status.WARNING},
+      {value: 20, status: status.ERROR}
     ]
   },
   'particulateMatter25': {
@@ -128,9 +134,9 @@ export const metrics = {
     min: 0,
     max: 50,
     levels: [
-      {value: 0, status: 'success'},
-      {value: 10, status: 'warning'},
-      {value: 20, status: 'error'}
+      {value: 0, status: status.SUCCESS},
+      {value: 10, status: status.WARNING},
+      {value: 20, status: status.ERROR}
     ]
   },
   'particulateMatter10': {
@@ -139,9 +145,9 @@ export const metrics = {
     min: 0,
     max: 50,
     levels: [
-      {value: 0, status: 'success'},
-      {value: 10, status: 'warning'},
-      {value: 20, status: 'error'}
+      {value: 0, status: status.SUCCESS},
+      {value: 10, status: status.WARNING},
+      {value: 20, status: status.ERROR}
     ]
   },
   'airChangePerHour': {
@@ -150,16 +156,16 @@ export const metrics = {
     min: 0,
     max: 10,
     levels: [
-      {value: 0, status: 'error'},
-      {value: 5, status: 'success'}
+      {value: 0, status: status.ERROR},
+      {value: 5, status: status.SUCCESS}
     ]
   },
   'comfort': {
     label: 'Comfort',
     unit: '',
     levels: [
-      {value: AirQuality.Comfort.COMFORTABLE, status: 'success'},
-      {value: AirQuality.Comfort.UNCOMFORTABLE, status: 'error'}
+      {value: AirQuality.Comfort.COMFORTABLE, status: status.SUCCESS},
+      {value: AirQuality.Comfort.UNCOMFORTABLE, status: status.ERROR}
     ]
   }
 }
@@ -167,14 +173,14 @@ export const metrics = {
 /**
  * @typedef {Object} AirQualityMetric
  * @property {number} value
- * @property {string} status
+ * @property {valueOf<status>} status
  */
 
 /**
  * @typedef {Object} AirQualityScore
  * @property {number} value
  * @property {string} label
- * @property {string} status
+ * @property {valueOf<status>} status
  */
 
 /**
@@ -211,9 +217,9 @@ export function useAirQuality(value) {
     const presentScore = presentMetrics.value['score'];
     const statusToLabel = (status) => {
       switch (status) {
-        case 'error': return 'Poor';
-        case 'warning': return 'Fair';
-        case 'success': return 'Good';
+        case status.ERROR: return 'Poor';
+        case status.WARNING: return 'Fair';
+        case status.SUCCESS: return 'Good';
         default: return '';
       }
     }

--- a/ui/space/src/routes/home/HomePage.vue
+++ b/ui/space/src/routes/home/HomePage.vue
@@ -1,28 +1,25 @@
 <template>
-  <div class="pa-8 d-flex flex-column fill-height">
+  <div class="home pa-8 d-flex flex-column fill-height">
     <glance-widget @admin-click="handle10Click"/>
     <v-spacer/>
-    <light-card :name="zoneId"/>
-    <air-temperature-card :name="zoneId" class="mt-6"/>
-    <img :src="uiConfigStore.theme.logoUrl" class="logo pt-14 pr-3 align-self-end" alt="Smart Core logo">
+    <component v-for="widget in widgets" :key="widget.key" :is="widget.is" v-bind="widget.props"/>
+    <img :src="uiConfigStore.theme.logoUrl" class="logo pt-3 pr-3 align-self-end" alt="Smart Core logo">
     <NotificationToast :show-alert="alertMessage.show" :message="alertMessage.message"/>
   </div>
 </template>
 
 <script setup>
 import NotificationToast from '@/components/NotificationToast.vue';
-import AirTemperatureCard from '@/routes/components/AirTemperatureCard.vue';
 import GlanceWidget from '@/routes/components/GlanceWidget.vue';
-import LightCard from '@/routes/components/LightCard.vue';
 import {useConfigStore} from '@/stores/config';
 import {useUiConfigStore} from '@/stores/ui-config.js';
 import {computed, ref} from 'vue';
+import {useHomeConfig} from './home';
 
 const configStore = useConfigStore();
-const zoneId = computed(() => configStore.zoneId);
 
 const uiConfigStore = useUiConfigStore();
-
+const {widgets} = useHomeConfig();
 
 // ----------------- 10 click safety feature ----------------- //
 const clickCount = ref(0); // Define a ref to keep track of the click count
@@ -58,6 +55,10 @@ const handle10Click = () => {
 <style>
 .logo {
   max-width: 50%;
-  max-height: 115px;
+  max-height: 75px;
+}
+
+.home {
+  gap: 1.5em;
 }
 </style>

--- a/ui/space/src/routes/home/home.js
+++ b/ui/space/src/routes/home/home.js
@@ -1,0 +1,67 @@
+import AirQualityCard from '@/routes/components/AirQualityCard.vue';
+import AirTemperatureCard from '@/routes/components/AirTemperatureCard.vue';
+import LightCard from '@/routes/components/LightCard.vue';
+import {useConfigStore} from '@/stores/config.js';
+import {useUiConfigStore} from '@/stores/ui-config.js';
+import {computed} from 'vue';
+
+/**
+ * @return {{
+ *   widgets: import('vue').ComputedRef<{
+ *     'is': import('vue').Component,
+ *     key: string,
+ *     props: Record<string, any>
+ *   }[]>
+ * }}
+ */
+export function useHomeConfig() {
+  const uiConfigStore = useUiConfigStore();
+  const uiConfig = computed(() => uiConfigStore.config);
+  const homePageConfig = computed(() => uiConfig.value?.pages?.home);
+  const widgetConfig = computed(() => homePageConfig.value?.widgets ?? []);
+
+  const appConfigStore = useConfigStore();
+  const zoneId = computed(() => appConfigStore.zoneId);
+
+  const availableWidgets = {
+    'air-quality': {
+      is: AirQualityCard,
+      props() {
+        return {name: zoneId.value};
+      }
+    },
+    'lighting': {
+      is: LightCard,
+      props() {
+        return {name: zoneId.value};
+      }
+    },
+    'temperature': {
+      is: AirTemperatureCard,
+      props() {
+        return {name: zoneId.value};
+      }
+    }
+  };
+  const widgets = computed(() => {
+    return widgetConfig.value
+        .map(cfg => {
+          const key = cfg.name;
+          const w = availableWidgets[key];
+          if (!w) {
+            console.warn(`Unknown widget: ${key}`);
+            return null;
+          }
+          return {
+            is: w.is,
+            key,
+            props: w.props()
+          };
+        })
+        .filter(Boolean);
+  });
+
+  return {
+    widgets
+  }
+}

--- a/ui/space/src/util/string.js
+++ b/ui/space/src/util/string.js
@@ -1,0 +1,9 @@
+/**
+ * Inserts spaces into camelCased string
+ *
+ * @param {string} key
+ * @return {string}
+ */
+export function camelToSentence(key) {
+  return key.replace(/([A-Z])/g, ' $1');
+}

--- a/ui/space/src/util/traits.js
+++ b/ui/space/src/util/traits.js
@@ -1,0 +1,86 @@
+import deepEqual from 'fast-deep-equal';
+import {toValue, watch} from 'vue';
+
+/**
+ * @typedef {import('@/api/resource').RemoteResource} RemoteResource
+ */
+
+/**
+ * Converts a query like value into a Smart Core query object.
+ * Queries typically look like {name: 'someName'}, so if the passed input is a string it will be converted to
+ * {name: input}.
+ *
+ * @template {{name: string}} T
+ * @param {MaybeRefOrGetter<string|T|null>} input - input value to be converted into a query object.
+ * @return {T|null} input or {name: input} if input is a string
+ */
+export const toQueryObject = (input) => {
+  const inputValue = toValue(input);
+  if (inputValue === null || inputValue === undefined) return null;
+  if (typeof inputValue === 'string') return {name: inputValue};
+  return inputValue;
+};
+
+/**
+ * Sets the name of the request if it is not already set.
+ *
+ * @template {{name: string}} T
+ * @param {T} req
+ * @param {MaybeRefOrGetter<string>} name
+ * @return {T}
+ */
+export const setRequestName = (req, name) => {
+  const nameValue = toValue(name);
+  const needsName = nameValue === null || nameValue === undefined;
+  if (needsName && !Object.hasOwn(req, 'name')) {
+    throw new Error('name is required as part of request');
+  }
+  if (!Object.hasOwn(req, 'name')) {
+    req.name = nameValue;
+  }
+  return req;
+};
+
+/**
+ * Calls apiCall each time the query changes, tracking and managing stop cleanup.
+ *
+ * @template T
+ * @param {MaybeRefOrGetter<T>} query - object representing the request to the API
+ * @param {MaybeRefOrGetter<boolean>} [paused] - boolean representing whether the data stream is paused
+ * @param {(req: T) => () => {}} apiCall - a function that starts a bg task and returns a cleanup function
+ * @example
+ * watchResource(
+ *   () => toValue(toQueryObject(query)),
+ *   () => toValue(paused),
+ *   (req) => {
+ *     pullAirTemperature(req, resource);
+ *     return () => closeResource(resource);
+ *   }
+ * );
+ */
+export const watchResource = (query, paused = false, apiCall) => {
+  let stop = null;
+
+  watch(
+      [() => toValue(query), () => toValue(paused)],
+      (newSource, oldSource) => {
+        // Check if the props have changed
+        const oldNewEqual = deepEqual(newSource, oldSource);
+
+        // If the props haven't changed, do nothing
+        if (oldNewEqual) return;
+        // Separate the array values into readable variables
+        const req = newSource[0];
+        const paused = newSource[1];
+
+        // If the props have changed (either the name or the paused state or both), close the old resources
+        // and empty the array
+        if (stop) stop();
+        stop = null; // free up memory if needed
+        if (!paused && req) { // If not paused and there is a request, pull new stop
+          stop = apiCall(req);
+        }
+      },
+      {immediate: true, deep: true, flush: 'sync'}
+  );
+};

--- a/ui/space/src/util/types.js
+++ b/ui/space/src/util/types.js
@@ -1,0 +1,77 @@
+// isObject: Checks if the given value is a non-null object and not any other type like Array.
+export const isObject = (value) => {
+  return value !== null && typeof value === 'object' && value.constructor === Object;
+};
+
+// isArray: Determines if the value is a non-null array.
+export const isArray = (value) => {
+  return value !== null && Array.isArray(value);
+};
+
+// isString: Checks if the value is a string. This includes both string literals and String objects.
+export const isString = (value) => {
+  return value !== null && (typeof value === 'string' || value instanceof String);
+};
+
+// isNumber: Verifies that the value is a number and not NaN or Infinity.
+export const isNumber = (value) => {
+  return value !== null && typeof value === 'number' && isFinite(value);
+};
+
+// isFunction: Checks if the value is a function, including both named and anonymous functions.
+export const isFunction = (value) => {
+  return value !== null && typeof value === 'function';
+};
+
+// isBoolean: Determines if the value is a boolean (true or false).
+export const isBoolean = (value) => {
+  return value !== null && typeof value === 'boolean';
+};
+
+// isNull: Specifically checks if the value is null.
+export const isNull = (value) => {
+  return value === null;
+};
+
+// isUndefined: Determines if the value is undefined, indicating an uninitialized variable.
+export const isUndefined = (value) => {
+  return typeof value === 'undefined';
+};
+
+/**
+ * Returns true if the value is null or undefined.
+ *
+ * @param {any} value
+ * @return {boolean}
+ */
+export const isNullOrUndef = (value) => {
+  return isNull(value) || isUndefined(value);
+};
+
+// isDate: Validates whether the value is a Date object and not an invalid date (NaN).
+export const isDate = (value) => {
+  return value instanceof Date && !isNaN(value);
+};
+
+// isRegExp: Checks if the value is a regular expression object.
+export const isRegExp = (value) => {
+  return value !== null && value instanceof RegExp;
+};
+
+// isSymbol: Verifies if the value is a Symbol, a unique and immutable primitive introduced in ES6.
+export const isSymbol = (value) => {
+  return typeof value === 'symbol';
+};
+
+// isBigInt: Checks if the value is a BigInt, a type of data for representing integers larger than 2^53.
+export const isBigInt = (value) => {
+  return typeof value === 'bigint';
+};
+
+// isValueAvailable: Determines if the value is 'available' by checking
+// that it's neither null, an empty array, nor an empty object.
+export const isValueAvailable = (value) => {
+  return value && !(Array.isArray(value) && value.length === 0) &&
+      !(value.constructor === Object && Object.keys(value).length === 0);
+};
+

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -732,7 +732,7 @@
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
-  resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@pkgr/core@^0.1.0":
@@ -1180,9 +1180,9 @@ chalk@^4.0.0:
     supports-color "^7.1.0"
 
 chalk@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz"
-  integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.4.1.tgz#1b48bf0963ec158dce2aacf69c093ae2dd2092d8"
+  integrity sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==
 
 change-case@^5.4.4:
   version "5.4.4"
@@ -1238,7 +1238,7 @@ cliui@^6.0.0:
 
 cliui@^8.0.1:
   version "8.0.1"
-  resolved "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
   integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
   dependencies:
     string-width "^4.2.0"
@@ -1808,7 +1808,7 @@ glob-parent@^6.0.2:
 
 glob@^10.4.2:
   version "10.4.5"
-  resolved "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
   integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
   dependencies:
     foreground-child "^3.1.0"
@@ -2456,7 +2456,7 @@ path-key@^4.0.0:
 
 path-scurry@^1.11.1:
   version "1.11.1"
-  resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
   integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
   dependencies:
     lru-cache "^10.2.0"
@@ -2630,9 +2630,9 @@ regenerator-runtime@^0.14.0:
   integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 replace-in-file@^8.1.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-8.2.0.tgz#5284a5ce0f1a04f3118b9afd4e2dfc15250c7ba8"
-  integrity sha512-hMsQtdYHwWviQT5ZbNsgfu0WuCiNlcUSnnD+aHAL081kbU9dPkPocDaHlDvAHKydTWWpx1apfcEcmvIyQk3CpQ==
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-8.3.0.tgz#53288f516fb8f3edc125c3af6b4b6adc2e5955bf"
+  integrity sha512-4VhddQiMCPIuypiwHDTM+XHjZoVu9h7ngBbSCnwGRcwdHwxltjt/m//Ep3GDwqaOx1fDSrKFQ+n7uo4uVcEz9Q==
   dependencies:
     chalk "^5.3.0"
     glob "^10.4.2"
@@ -3199,7 +3199,7 @@ wrap-ansi@^6.2.0:
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
@@ -3227,7 +3227,7 @@ y18n@^4.0.0:
 
 y18n@^5.0.5:
   version "5.0.8"
-  resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yallist@^3.0.2:
@@ -3250,7 +3250,7 @@ yargs-parser@^18.1.2:
 
 yargs-parser@^21.1.1:
   version "21.1.1"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^15.3.1:
@@ -3272,7 +3272,7 @@ yargs@^15.3.1:
 
 yargs@^17.7.2:
   version "17.7.2"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"


### PR DESCRIPTION
Also support controlling which widgets are shows via the ui config.

![localhost_5174_home(QBic Luminen 5) (3)](https://github.com/user-attachments/assets/25574aff-3fa6-490d-8a8c-2c47ccc766d1)

I expect a future commit will make the ui-config widgets more of a suggestion and then rely on the configured zone to know exactly what this space supports. But as the feature has been deprioritised that can wait.
