### PR TITLE
drivers/mock: add support for the waste trait

### DIFF
--- a/cmd/tools/client-waste/main.go
+++ b/cmd/tools/client-waste/main.go
@@ -1,0 +1,97 @@
+// Command client_waste provides a CLI tool for interacting with the [traits.WasteApiClient].
+
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/vanti-dev/sc-bos/pkg/util/client"
+)
+
+var clientConfig client.Config
+
+func init() {
+	flag.StringVar(&clientConfig.Endpoint, "endpoint", "localhost:23557", "smart core endpoint")
+	flag.BoolVar(&clientConfig.Get, "get", true, "perform a get request")
+	flag.BoolVar(&clientConfig.Pull, "pull", true, "pull changes")
+	flag.StringVar(&clientConfig.Name, "name", "", "smart core name for requests")
+	flag.BoolVar(&clientConfig.TLS.InsecureNoClientCert, "insecure-no-client-cert", false, "")
+	flag.BoolVar(&clientConfig.TLS.InsecureSkipVerify, "insecure-skip-verify", false, "")
+}
+
+func main() {
+	flag.Parse()
+
+	err := run()
+	if err != nil {
+		log.Fatalf("error: %s", err)
+	}
+}
+
+func run() error {
+	log.Printf("dialling: %s", clientConfig.Endpoint)
+	conn, err := client.NewConnection(clientConfig)
+	if err != nil {
+		return err
+	}
+	log.Printf("dialled")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	wc := traits.NewWasteApiClient(conn)
+
+	get := func(c context.Context, name string) error {
+		req := traits.ListWasteRecordsRequest{Name: name}
+		for {
+			log.Printf("ListWasteRecords %s", name)
+			res, err := wc.ListWasteRecords(c, &req)
+			if err != nil {
+				return err
+			}
+			log.Printf("got %d events for %s", len(res.WasteRecords), name)
+			if res.NextPageToken == "" {
+				break
+			}
+			req.PageToken = res.NextPageToken
+		}
+		return nil
+	}
+
+	pull := func(c context.Context, name string) error {
+		log.Printf("PullWasteRecords %s", name)
+		stream, err := wc.PullWasteRecords(c, &traits.PullWasteRecordsRequest{Name: name})
+		if err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		for {
+			res, err := stream.Recv()
+			if err != nil {
+				return err
+			}
+			for _, change := range res.Changes {
+				log.Printf("got change for %s: %v", name, change.NewValue)
+			}
+		}
+	}
+
+	grp, ctx := errgroup.WithContext(ctx)
+	if clientConfig.Get {
+		grp.Go(func() error {
+			return get(ctx, clientConfig.Name)
+		})
+	}
+	if clientConfig.Pull {
+		grp.Go(func() error {
+			return pull(ctx, clientConfig.Name)
+		})
+	}
+
+	return grp.Wait()
+}

--- a/example/config/vanti-ugs/app.conf.json
+++ b/example/config/vanti-ugs/app.conf.json
@@ -767,6 +767,21 @@
           "appearance": {"title": "Security Events"}
         }
       ]
+    },
+    {
+      "name": "van/uk/brum/ugs/eg-bc-01/driver/building-waste",
+      "type": "mock",
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/waste",
+          "traits": [
+            {
+              "name" : "smartcore.traits.Waste"
+            }
+          ],
+          "appearance": {"title": "Waste"}
+        }
+      ]
     }
   ],
   "zones": [

--- a/go.mod
+++ b/go.mod
@@ -25,8 +25,8 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/cors v1.8.3
 	github.com/sirupsen/logrus v1.9.3
-	github.com/smart-core-os/sc-api/go v1.0.0-beta.50
-	github.com/smart-core-os/sc-golang v0.0.0-20241220144351-884672945826
+	github.com/smart-core-os/sc-api/go v1.0.0-beta.51
+	github.com/smart-core-os/sc-golang v0.0.0-20250220114548-907c4d783fe6
 	github.com/stretchr/testify v1.9.0
 	github.com/timshannon/bolthold v0.0.0-20210913165410-232392fc8a6a
 	github.com/vanti-dev/gobacnet v0.0.0-20250122134204-5b55cc2d13fe

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/rs/cors v1.8.3
 	github.com/sirupsen/logrus v1.9.3
 	github.com/smart-core-os/sc-api/go v1.0.0-beta.51
-	github.com/smart-core-os/sc-golang v0.0.0-20250220114548-907c4d783fe6
+	github.com/smart-core-os/sc-golang v0.0.0-20250220152000-a699795e09b6
 	github.com/stretchr/testify v1.9.0
 	github.com/timshannon/bolthold v0.0.0-20210913165410-232392fc8a6a
 	github.com/vanti-dev/gobacnet v0.0.0-20250122134204-5b55cc2d13fe

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smart-core-os/sc-api/go v1.0.0-beta.51 h1:ccV2wija7mcaJG00+kimXGmLDgtxLQ3k/euCe1v+2A4=
 github.com/smart-core-os/sc-api/go v1.0.0-beta.51/go.mod h1:HpHbz0skS27690VbVGBFA+tiNyEkNlZP5p68MUREIJY=
-github.com/smart-core-os/sc-golang v0.0.0-20250220114548-907c4d783fe6 h1:EmVJowg6QodrHBEg0l6p6a+eS9xNLciWl7w6e/C5Jz0=
-github.com/smart-core-os/sc-golang v0.0.0-20250220114548-907c4d783fe6/go.mod h1:aW8ROFeTAHUFIT0rM5EZYSh/TtV+6Tx+dPNbtsXqbjc=
+github.com/smart-core-os/sc-golang v0.0.0-20250220152000-a699795e09b6 h1:Q6eyD7LXKzkAUqqi09yemzyZBgulCkpJQzThAM7VujA=
+github.com/smart-core-os/sc-golang v0.0.0-20250220152000-a699795e09b6/go.mod h1:aW8ROFeTAHUFIT0rM5EZYSh/TtV+6Tx+dPNbtsXqbjc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/go.sum
+++ b/go.sum
@@ -487,10 +487,10 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/smart-core-os/sc-api/go v1.0.0-beta.50 h1:CCVJgL4Vk3F58DOWfLLwSuWkmwZ8STvZeUp2e7J+nZE=
-github.com/smart-core-os/sc-api/go v1.0.0-beta.50/go.mod h1:HpHbz0skS27690VbVGBFA+tiNyEkNlZP5p68MUREIJY=
-github.com/smart-core-os/sc-golang v0.0.0-20241220144351-884672945826 h1:QhdNISDKvh1rWqah5jPfDU0xtfuSg7I4zvHY3M0Xg1A=
-github.com/smart-core-os/sc-golang v0.0.0-20241220144351-884672945826/go.mod h1:M0885HPfN6BTzQgsgZCWrspMFyIGR9jNQyOzuTvCIxA=
+github.com/smart-core-os/sc-api/go v1.0.0-beta.51 h1:ccV2wija7mcaJG00+kimXGmLDgtxLQ3k/euCe1v+2A4=
+github.com/smart-core-os/sc-api/go v1.0.0-beta.51/go.mod h1:HpHbz0skS27690VbVGBFA+tiNyEkNlZP5p68MUREIJY=
+github.com/smart-core-os/sc-golang v0.0.0-20250220114548-907c4d783fe6 h1:EmVJowg6QodrHBEg0l6p6a+eS9xNLciWl7w6e/C5Jz0=
+github.com/smart-core-os/sc-golang v0.0.0-20250220114548-907c4d783fe6/go.mod h1:aW8ROFeTAHUFIT0rM5EZYSh/TtV+6Tx+dPNbtsXqbjc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/pkg/driver/mock/auto/waste.go
+++ b/pkg/driver/mock/auto/waste.go
@@ -1,0 +1,33 @@
+package auto
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-golang/pkg/trait/waste"
+	"github.com/vanti-dev/sc-bos/pkg/task/service"
+)
+
+func WasteRecordsAuto(model *waste.Model) *service.Service[string] {
+
+	slc := service.New(service.MonoApply(func(ctx context.Context, _ string) error {
+		ticker := time.NewTicker(30 * time.Second)
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					_, _ = model.GenerateWasteRecord(timestamppb.Now())
+				}
+			}
+		}()
+		return nil
+	}), service.WithParser(func(data []byte) (string, error) {
+		return string(data), nil
+	}))
+	_, _ = slc.Configure([]byte{})
+	return slc
+}

--- a/pkg/driver/mock/driver.go
+++ b/pkg/driver/mock/driver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/smart-core-os/sc-golang/pkg/trait/parent"
 	"github.com/smart-core-os/sc-golang/pkg/trait/publication"
 	"github.com/smart-core-os/sc-golang/pkg/trait/vending"
+	"github.com/smart-core-os/sc-golang/pkg/trait/waste"
 	"github.com/smart-core-os/sc-golang/pkg/wrap"
 	"github.com/vanti-dev/sc-bos/pkg/block"
 	"github.com/vanti-dev/sc-bos/pkg/driver"
@@ -246,6 +247,9 @@ func newMockClient(traitMd *traits.TraitMetadata, deviceName string, logger *zap
 		return nil, nil
 	case trait.Vending:
 		return []wrap.ServiceUnwrapper{vending.WrapApi(vending.NewModelServer(vending.NewModel()))}, nil
+	case trait.Waste:
+		model := waste.NewModel()
+		return []wrap.ServiceUnwrapper{waste.WrapApi(waste.NewModelServer(model))}, auto.WasteRecordsAuto(model)
 
 	case accesspb.TraitName:
 		model := accesspb.NewModel()


### PR DESCRIPTION
Closes SC-1005. Adds mock driver support for the waste trait, the config to enabled this at the UGS example and a test client for listing waste records. It relies on this PR -> https://github.com/smart-core-os/sc-golang/ and the go.mod currently references the unmerged PR in sc-golang, but this PR in sc-bos helps test the one in sc-golang

To test this, run the ugs example backend and then run the command `go run cmd/tools/client-waste/main.go --insecure-skip-verify=true --name=van/uk/brum/ugs/devices/waste` to see the waste events get listed and pulled as more are generated