### PR TITLE
auto/wordpress: make use of confidence measure in occupancy response

### DIFF
--- a/pkg/auto/wordpress/job/occupancy.go
+++ b/pkg/auto/wordpress/job/occupancy.go
@@ -41,6 +41,8 @@ func (o *OccupancyJob) Do(ctx context.Context, sendFn sender) error {
 			continue
 		}
 
+		// confidence value semantics can vary between driver implementations
+		// 0.2 can be a bad threshold. We will assume it isn't for WordPress
 		if resp.GetConfidence() > 0.2 {
 			hasCounted = true
 			sum += resp.GetPeopleCount()


### PR DESCRIPTION
Make use of Occupancy trait's confidence value so we don't send bad counts to WordPress.