### PR TITLE
ui/ops: add meter/ConsumptionCard widget

### DIFF
--- a/ui/ops/src/dynamic/widgets/pallet.js
+++ b/ui/ops/src/dynamic/widgets/pallet.js
@@ -10,6 +10,7 @@ export const builtinWidgets = {
   'notifications/ZoneNotifications': defineAsyncComponent(() => import('@/dynamic/widgets/notifications/ZoneNotifications.vue')),
   // from elsewhere in our codebase
   'lighting/LightIcon': defineAsyncComponent(() => import('@/traits/light/LightIcon.vue')),
+  'meter/ConsumptionCard': defineAsyncComponent(() => import('@/traits/meter/ConsumptionCard.vue')),
   'environmental/AirTemperatureChip': defineAsyncComponent(() => import('@/traits/airTemperature/AirTemperatureChip.vue')),
   'devices/DeviceTable': defineAsyncComponent(() => import('@/routes/devices/components/DeviceTable.vue'))
 };

--- a/ui/ops/src/traits/meter/ConsumptionCard.vue
+++ b/ui/ops/src/traits/meter/ConsumptionCard.vue
@@ -1,0 +1,196 @@
+<template>
+  <v-card>
+    <v-tooltip activator="parent" location="bottom">
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <span v-html="tooltipStr"/>
+    </v-tooltip>
+    <v-card-title v-if="titleStr">{{ titleStr }}</v-card-title>
+    <template v-if="isMeterReset">
+      <v-card-text class="text-h6 font-weight-light">The meter was reset</v-card-text>
+    </template>
+    <template v-else>
+      <v-card-text>
+        <span class="value text-h1 font-weight-light">{{ usageStr }}</span>
+        <span v-if="unit" class="unit text-subtitle-1 font-weight-light">&nbsp;{{ unit }}</span>
+      </v-card-text>
+    </template>
+    <v-card-text class="text-body-1 pt-0">{{ timePeriodStr }}</v-card-text>
+  </v-card>
+</template>
+
+<script setup>
+import {useStartOf} from '@/composables/time.js';
+import {usePullMetadata} from '@/traits/metadata/metadata.js';
+import {
+  useDescribeMeterReading,
+  useMeterReading,
+  useMeterReadingAt,
+  usePullMeterReading
+} from '@/traits/meter/meter.js';
+import {isNullOrUndef} from '@/util/types.js';
+import {add} from 'date-fns';
+import {computed, effectScope, onScopeDispose, reactive, watch} from 'vue';
+
+const props = defineProps({
+  name: {
+    type: String,
+    default: ''
+  },
+  paused: {
+    type: Boolean,
+    default: false
+  },
+  period: {
+    type: [String],
+    default: 'day' // 'minute', 'hour', 'day', 'month', 'year'
+  },
+  offset: {
+    type: [Number, String],
+    default: 0 // Used via Math.abs, {period: 'day', offset: 1} means yesterday, and so on
+  },
+  title: {
+    type: String,
+    default: null // default to metadata.appearance.title
+  }
+});
+const _offset = computed(() => Math.abs(parseInt(props.offset)));
+const applyOffset = (d) => {
+  if (_offset.value === 0) {
+    return d;
+  }
+  return add(d, {[`${props.period}s`]: -_offset.value});
+}
+
+const {response: meterReadingInfo} = useDescribeMeterReading(() => props.name);
+
+// calculate the start date, and the reading at that date.
+const start = reactive({value: /** @type {Date|null} */ null});
+let startCalcScope = null;
+onScopeDispose(() => {
+  if (startCalcScope) {
+    startCalcScope();
+  }
+})
+watch(() => props.period, period => {
+  if (startCalcScope) {
+    startCalcScope();
+  }
+  if (Object.hasOwn(useStartOf, period)) {
+    const scope = effectScope();
+    scope.run(() => {
+      const d = useStartOf[period]();
+      start.value = computed(() => applyOffset(d.value));
+    });
+    startCalcScope = () => scope.stop();
+  }
+  // todo: decide on a better fallback behaviour
+}, {immediate: true});
+const readingAtStart = useMeterReadingAt(() => props.name, () => start.value);
+
+// calculate the reading at the end.
+// If offset is 0 then the reading is the live reading and we can use pullMeterReading.
+// If not then we have to fetch the reading from the history.
+// We assume that the offset is old enough that history includes the values we need without rechecking.
+const end = computed(() => {
+  if (_offset.value === 0) {
+    return null;
+  }
+  return add(start.value, {[`${props.period}s`]: _offset.value});
+});
+let endCalcScope = null;
+const readingAtEnd = reactive({value: null});
+watch(end, end => {
+  if (endCalcScope) {
+    endCalcScope();
+  }
+  const scope = effectScope();
+  endCalcScope = () => scope.stop();
+  scope.run(() => {
+    if (isNullOrUndef(end)) {
+      const {value: meterReading} = usePullMeterReading(() => props.name);
+      readingAtEnd.value = meterReading;
+    } else {
+      readingAtEnd.value = useMeterReadingAt(() => props.name, end);
+    }
+  });
+}, {immediate: true});
+
+const readingDiff = computed(() => {
+  const start = readingAtStart.value;
+  const end = readingAtEnd.value;
+  if (isNullOrUndef(start) || isNullOrUndef(end)) {
+    return null;
+  }
+  return {usage: end.usage - start.usage};
+});
+const isMeterReset = computed(() => readingDiff.value?.usage < 0);
+
+// Properties for the tooltip, e.g. "On 24th: 100 kWh / On 25th: 200 kWh"
+const {usageStr: startUsageStr} = useMeterReading(readingAtStart, meterReadingInfo);
+const {usageStr: endUsageStr} = useMeterReading(() => readingAtEnd.value, meterReadingInfo);
+const startStr = computed(() => {
+  console.debug('startStr start.value=', start.value);
+  if (!start.value) return 'loading';
+  switch (props.period) {
+    case 'minute':
+    case 'hour':
+      return 'At ' + start.value.toLocaleTimeString();
+    default:
+      return 'On ' + start.value.toLocaleDateString();
+  }
+});
+const endStr = computed(() => {
+  if (_offset.value === 0) return 'Last reading';
+  switch (props.period) {
+    case 'minute':
+    case 'hour':
+      return 'At ' + end.value.toLocaleTimeString();
+    default:
+      return 'On ' + end.value.toLocaleDateString();
+  }
+})
+const tooltipStr = computed(() => {
+  const unitStr = meterReadingInfo.value?.unit ?? '';
+  return `${startStr.value}: ${startUsageStr.value} ${unitStr}<br/>${endStr.value}: ${endUsageStr.value} ${unitStr}`;
+});
+
+// The card title is either the title prop or grabbed from the metadata
+const {value: md} = usePullMetadata(() => props.name, () => Boolean(props.title));
+const titleStr = computed(() => {
+  if (props.title) {
+    return props.title;
+  }
+  return md.value?.appearance?.title ?? '';
+})
+const {usageStr, unit} = useMeterReading(readingDiff, meterReadingInfo);
+// outputs text like "yesterday" or "2 days ago" or "last month"
+const relativeTimeFormat = new Intl.RelativeTimeFormat(undefined, {
+  numeric: 'auto',
+  style: 'long'
+});
+const timePeriodStr = computed(() => {
+  if (_offset.value === 0) {
+    switch (props.period) {
+      case 'minute':
+        return 'So far this minute';
+      case 'hour':
+        return 'So far this hour';
+      case 'day':
+        return 'So far today';
+      case 'week':
+        return 'So far this week';
+      case 'month':
+        return 'So far this month';
+      case 'year':
+        return 'So far this year';
+    }
+    return 'So far';
+  } else {
+    return relativeTimeFormat.format(-_offset.value, props.period);
+  }
+});
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
This widget shows the meter consumption between two dates, where one of the dates can be `now`.

A few examples:
- Show usage for yesterday
- Show usage for this week so far
- Show total usage for last year

A few examples on a test dashboard I was using

![image](https://github.com/user-attachments/assets/825f0c2d-90df-488d-a100-cce76c2163e9)

Using this mark up

```html
    <div class="d-flex ga-2 mt-4">
      <consumption-card :name="totalDemandName" period="day" title="Consumption" width="14em" variant="tonal"/>
      <consumption-card :name="totalGeneratedName" period="day" title="Generation" width="14em" variant="text" color="success"/>
      <consumption-card :name="totalDemandName" period="month" width="14em" variant="flat" color="error"/>
      <consumption-card :name="totalGeneratedName" period="year" title="Solar Panels" width="14em" variant="outlined"/>
    </div>
    <div class="d-flex ga-2 mt-4">
      <consumption-card :name="totalDemandName" period="day" offset="1" title="Consumption" width="14em" variant="tonal"/>
      <consumption-card :name="totalDemandName" period="day" offset="2" title="Consumption" width="14em" variant="tonal"/>
      <consumption-card :name="totalDemandName" period="week" offset="1" title="Consumption" width="14em" variant="tonal"/>
      <consumption-card :name="totalDemandName" period="month" offset="1" title="Consumption" width="14em" variant="tonal"/>
    </div>
```