### PR TITLE
ui/ops: add page to view waste records

### DIFF
--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -22,8 +22,6 @@
         "clientId": "scos-opsui"
       }
     },
-    "wasteRecordsSource" : "van/uk/brum/ugs/devices/waste",
-    "wasteRecordUnit" : "kg",
     "ops": {
       "pages": [
         {
@@ -598,7 +596,11 @@
             }
           ]
         }
-      ]
+      ],
+      "waste" : {
+        "source" : "van/uk/brum/ugs/devices/waste",
+        "unit" : "kg"
+      }
     },
     "proxy": true,
     "siteFloorPlans": [

--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -22,6 +22,8 @@
         "clientId": "scos-opsui"
       }
     },
+    "wasteRecordsSource" : "van/uk/brum/ugs/devices/waste",
+    "wasteRecordUnit" : "kg",
     "ops": {
       "pages": [
         {

--- a/ui/ops/package.json
+++ b/ui/ops/package.json
@@ -11,7 +11,7 @@
     "lint:nofix": "eslint ."
   },
   "dependencies": {
-    "@smart-core-os/sc-api-grpc-web": "^1.0.0-beta.48",
+    "@smart-core-os/sc-api-grpc-web": "^1.0.0-beta.51",
     "@vanti-dev/sc-bos-panzoom-package": "1.0.1-vanti.0",
     "@vanti-dev/sc-bos-ui-gen": "1.0.0-beta.19",
     "binary-search": "^1.3.6",

--- a/ui/ops/src/api/ui/waste.js
+++ b/ui/ops/src/api/ui/waste.js
@@ -61,7 +61,7 @@ function listWasteRecordsRequestFromObject(obj) {
 function pullWasteRecordsRequestFromObject(obj) {
   if (!obj) return undefined;
   const dst = new PullWasteRecordsRequest();
-  setProperties(dst, obj, 'name', 'pageToken', 'pageSize');
+  setProperties(dst, obj, 'name', 'updatesOnly');
   dst.setReadMask(fieldMaskFromObject(obj.readMask));
   return dst;
 }

--- a/ui/ops/src/api/ui/waste.js
+++ b/ui/ops/src/api/ui/waste.js
@@ -18,7 +18,7 @@ export function listWasteRecords(request, tracker) {
 
 /**
  * @param {Partial<PullWasteRecordsRequest.AsObject>} request
- * @param {ResourceCollection<Alert.AsObject, PullWasteRecordsResponse>} resource
+ * @param {ResourceCollection<WasteRecord.AsObject, PullWasteRecordsResponse>} resource
  */
 export function pullWasteRecords(request, resource) {
   pullResource('Waste.pullWasteRecords', resource, endpoint => {

--- a/ui/ops/src/api/ui/waste.js
+++ b/ui/ops/src/api/ui/waste.js
@@ -1,0 +1,67 @@
+import {fieldMaskFromObject, setProperties} from '@/api/convpb.js';
+import {clientOptions} from '@/api/grpcweb.js';
+import {pullResource, setCollection, trackAction} from '@/api/resource.js';
+import {WasteApiPromiseClient} from '@smart-core-os/sc-api-grpc-web/traits/waste_grpc_web_pb.js';
+import {ListWasteRecordsRequest, PullWasteRecordsRequest} from '@smart-core-os/sc-api-grpc-web/traits/waste_pb';
+
+/**
+ * @param {Partial<ListWasteRecordsRequest.AsObject>} request
+ * @param {ActionTracker<ListWasteRecordsResponse.AsObject>} [tracker]
+ * @return {Promise<ListWasteRecordsResponse.AsObject>}
+ */
+export function listWasteRecords(request, tracker) {
+  return trackAction('Waste.listWasteRecords', tracker ?? {}, endpoint => {
+    const api = apiClient(endpoint);
+    return api.listWasteRecords(listWasteRecordsRequestFromObject(request));
+  });
+}
+
+/**
+ * @param {Partial<PullWasteRecordsRequest.AsObject>} request
+ * @param {ResourceCollection<Alert.AsObject, PullWasteRecordsResponse>} resource
+ */
+export function pullWasteRecords(request, resource) {
+  pullResource('Waste.pullWasteRecords', resource, endpoint => {
+    const api = apiClient(endpoint);
+    const stream = api.pullWasteRecords(pullWasteRecordsRequestFromObject(request));
+    stream.on('data', msg => {
+      const changes = msg.getChangesList();
+      for (const change of changes) {
+        setCollection(resource, change, v => v.id);
+      }
+    });
+    return stream;
+  });
+}
+
+/**
+ * @param {string} endpoint
+ * @return {WasteApiPromiseClient}
+ */
+function apiClient(endpoint) {
+  return new WasteApiPromiseClient(endpoint, clientOptions());
+}
+
+/**
+ * @param {Partial<ListWasteRecordsRequest.AsObject>} obj
+ * @return {ListWasteRecordsRequest}
+ */
+function listWasteRecordsRequestFromObject(obj) {
+  if (!obj) return undefined;
+  const dst = new ListWasteRecordsRequest();
+  setProperties(dst, obj, 'name', 'pageToken', 'pageSize');
+  dst.setReadMask(fieldMaskFromObject(obj.readMask));
+  return dst;
+}
+
+/**
+ * @param {Partial<PullWasteRecordsRequest.AsObject>} obj
+ * @return {PullWasteRecordsRequest|undefined}
+ */
+function pullWasteRecordsRequestFromObject(obj) {
+  if (!obj) return undefined;
+  const dst = new PullWasteRecordsRequest();
+  setProperties(dst, obj, 'name', 'pageToken', 'pageSize');
+  dst.setReadMask(fieldMaskFromObject(obj.readMask));
+  return dst;
+}

--- a/ui/ops/src/composables/waste.js
+++ b/ui/ops/src/composables/waste.js
@@ -1,0 +1,33 @@
+import {timestampToDate} from '@/api/convpb.js';
+import {listWasteRecords, pullWasteRecords} from '@/api/ui/waste.js';
+import useCollection from '@/composables/collection.js';
+import {cmpDesc} from '@/util/date.js';
+import {computed, toValue} from 'vue';
+
+/**
+ * @param {MaybeRefOrGetter<Partial<ListWasteRecordsRequest.AsObject>>} request
+ * @param {MaybeRefOrGetter<Partial<UseCollectionOptions<WasteRecord.AsObject>>>?} options
+ * @return {UseCollectionResponse<WasteRecord.AsObject>}
+ */
+export function useWasteRecordsCollection(request, options) {
+  const normOpts = computed(() => {
+    return {
+      cmp: (a, b) => cmpDesc(timestampToDate(a.wasteCreateTime), timestampToDate(b.wasteCreateTime)),
+      ...toValue(options)
+    };
+  });
+  const client = {
+    async listFn(req, tracker) {
+      const res = await listWasteRecords(req, tracker);
+      return {
+        items: res.wasterecordsList,
+        nextPageToken: res.nextPageToken,
+        totalSize: res.totalSize
+      };
+    },
+    pullFn(req, resource) {
+      pullWasteRecords(req, resource);
+    }
+  };
+  return useCollection(request, client, normOpts);
+}

--- a/ui/ops/src/routes/ops/OpsNav.vue
+++ b/ui/ops/src/routes/ops/OpsNav.vue
@@ -139,6 +139,12 @@ const menuItems = computed(() => [
     icon: 'mdi-shield-alert',
     link: {path: '/ops/security-events'},
     badgeType: null
+  },
+  {
+    title: 'Waste Records',
+    icon: 'mdi-recycle',
+    link: {path: '/ops/waste'},
+    badgeType: null
   }
 ]);
 

--- a/ui/ops/src/routes/ops/route.js
+++ b/ui/ops/src/routes/ops/route.js
@@ -2,6 +2,7 @@ import SidebarPage from '@/components/pages/SidebarPage.vue';
 import notifications from '@/routes/ops/notifications/route.js';
 import securityEvents from '@/routes/ops/security-events/route.js';
 import overview from '@/routes/ops/overview/route.js';
+import waste from '@/routes/ops/waste/route.js';
 import {useUiConfigStore} from '@/stores/uiConfig.js';
 
 import {route} from '@/util/router.js';
@@ -23,6 +24,8 @@ export default {
       return '/ops/security';
     } else if (uiConfig.pathEnabled('/ops/security-events')) {
       return '/ops/security-events';
+    } else if (uiConfig.pathEnabled('/ops/waste')) {
+      return '/ops/waste';
     }
     return '/ops/loading';
   },
@@ -64,7 +67,8 @@ export default {
       }
     },
     ...route(notifications),
-    ...route(securityEvents)
+    ...route(securityEvents),
+    ...route(waste),
   ],
   meta: {
     authentication: {
@@ -88,6 +92,8 @@ export default {
         next('/ops/security');
       } else if (appConfig.pathEnabled('/ops/security-events')) {
         return '/ops/security-events';
+      } else if (appConfig.pathEnabled('/ops/waste')) {
+        next('/ops/waste');
       }
     } else {
       next();

--- a/ui/ops/src/routes/ops/waste/WasteTable.vue
+++ b/ui/ops/src/routes/ops/waste/WasteTable.vue
@@ -16,7 +16,7 @@
           {{ timestampToDate(item.wasteCreateTime).toLocaleString() }}
         </template>
         <template #item.weight="{ item }">
-          {{ item.weight.toFixed(2) }} {{ uiConfig.config.wasteRecordUnit ?? "kg" }}
+          {{ item.weight.toFixed(2) }} {{ uiConfig.config.ops.waste.unit ?? "kg" }}
         </template>
         <template #item.disposalMethod="{ item }">
           {{ getDisposalMethod(item.disposalMethod) }}
@@ -37,7 +37,7 @@ import {computed, ref} from 'vue';
 
 const uiConfig = useUiConfigStore();
 const cohort = useCohortStore();
-const name = computed(() => uiConfig.config.wasteRecordsSource ?? cohort.hubNode?.name ?? '');
+const name = computed(() => uiConfig.config.ops.waste.source ?? cohort.hubNode?.name ?? '');
 
 const wasteRecordsRequest = computed(() => ({
   name: name.value

--- a/ui/ops/src/routes/ops/waste/WasteTable.vue
+++ b/ui/ops/src/routes/ops/waste/WasteTable.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="ml-2">
+    <v-row class="mt-0 ml-0 pl-0">
+      <h3 class="text-h3 pt-2 pb-6">Waste Records</h3>
+      <v-spacer/>
+    </v-row>
+
+    <content-card class="px-8 mt-8">
+      <v-data-table-server
+          :headers="allHeaders"
+          v-bind="tableAttrs"
+          disable-sort
+          :items-length="queryTotalCount"
+          class="pt-4">
+        <template #item.createTime="{ item }">
+          {{ timestampToDate(item.wasteCreateTime).toLocaleString() }}
+        </template>
+        <template #item.weight="{ item }">
+          {{ item.weight.toFixed(2) }} {{ uiConfig.config.wasteRecordUnit }}
+        </template>
+        <template #item.disposalMethod="{ item }">
+          {{ getDisposalMethod(item.disposalMethod) }}
+        </template>
+      </v-data-table-server>
+    </content-card>
+  </div>
+</template>
+
+<script setup>
+import {timestampToDate} from '@/api/convpb.js';
+import ContentCard from '@/components/ContentCard.vue';
+import {useDataTableCollection} from '@/composables/table.js';
+import {useWasteRecordsCollection} from '@/composables/waste.js';
+import {useCohortStore} from '@/stores/cohort.js';
+import {useUiConfigStore} from '@/stores/uiConfig.js';
+import {computed, ref} from 'vue';
+
+const uiConfig = useUiConfigStore();
+const cohort = useCohortStore();
+const name = computed(() => uiConfig.config.wasteRecordsSource ?? cohort.hubNode?.name ?? '');
+
+const wasteRecordsRequest = computed(() => ({
+  name: name.value
+}));
+const wantCount = ref(20);
+const wasteRecordsOptions = computed(() => ({
+  wantCount: wantCount.value
+}));
+const wasteRecordsCollection = useWasteRecordsCollection(wasteRecordsRequest, wasteRecordsOptions);
+const tableAttrs = useDataTableCollection(wantCount, wasteRecordsCollection);
+
+// Calculate the total number of items in the query
+const queryTotalCount = computed(() => {
+  return wasteRecordsCollection.totalItems.value;
+});
+
+const allHeaders = [
+  {title: 'Waste Created', value: 'createTime', width: '15em'},
+  {title: 'Area', value: 'area', width: '40%'},
+  {title: 'Disposal Method', value: 'disposalMethod', width: '30%'},
+  {title: 'Weight', value: 'weight', width: '10em', align: 'end'},
+  {title: 'Stream', value: 'stream', width: '30%'},
+  {title: 'System', value: 'system', width: '30%'}
+];
+
+const getDisposalMethod = (disposalMethod) => {
+  switch (disposalMethod) {
+    case 1:
+      return 'General Waste';
+    case 2:
+      return 'Recycling';
+    default:
+      return 'Unknown';
+  }
+}
+
+</script>
+
+<style scoped>
+:deep(table) {
+  table-layout: fixed;
+}
+
+.hide-pagination {
+  :deep(.v-data-table-footer__info),
+  :deep(.v-pagination__last) {
+    display: none;
+  }
+
+  :deep(.v-pagination__first) {
+    margin-left: 16px;
+  }
+}
+</style>

--- a/ui/ops/src/routes/ops/waste/WasteTable.vue
+++ b/ui/ops/src/routes/ops/waste/WasteTable.vue
@@ -16,7 +16,7 @@
           {{ timestampToDate(item.wasteCreateTime).toLocaleString() }}
         </template>
         <template #item.weight="{ item }">
-          {{ item.weight.toFixed(2) }} {{ uiConfig.config.ops.waste.unit ?? "kg" }}
+          {{ item.weight.toFixed(2) }} {{ uiConfig.config?.ops?.waste?.unit ?? "kg" }}
         </template>
         <template #item.disposalMethod="{ item }">
           {{ getDisposalMethod(item.disposalMethod) }}
@@ -37,7 +37,7 @@ import {computed, ref} from 'vue';
 
 const uiConfig = useUiConfigStore();
 const cohort = useCohortStore();
-const name = computed(() => uiConfig.config.ops.waste.source ?? cohort.hubNode?.name ?? '');
+const name = computed(() => uiConfig.config?.ops?.waste?.source ?? cohort.hubNode?.name ?? '');
 
 const wasteRecordsRequest = computed(() => ({
   name: name.value

--- a/ui/ops/src/routes/ops/waste/WasteTable.vue
+++ b/ui/ops/src/routes/ops/waste/WasteTable.vue
@@ -16,7 +16,7 @@
           {{ timestampToDate(item.wasteCreateTime).toLocaleString() }}
         </template>
         <template #item.weight="{ item }">
-          {{ item.weight.toFixed(2) }} {{ uiConfig.config.wasteRecordUnit }}
+          {{ item.weight.toFixed(2) }} {{ uiConfig.config.wasteRecordUnit ?? "kg" }}
         </template>
         <template #item.disposalMethod="{ item }">
           {{ getDisposalMethod(item.disposalMethod) }}

--- a/ui/ops/src/routes/ops/waste/route.js
+++ b/ui/ops/src/routes/ops/waste/route.js
@@ -1,0 +1,17 @@
+export default [
+  {
+    path: 'waste',
+    components: {
+      default: () => import('./WasteTable.vue')
+    },
+    props: {
+      default: true,
+      sidebar: false
+    },
+    meta: {
+      authentication: {
+        rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+      }
+    }
+  }
+];

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -870,6 +870,14 @@
     google-protobuf "^3.21.2"
     grpc-web "^1.5.0"
 
+"@smart-core-os/sc-api-grpc-web@^1.0.0-beta.51":
+  version "1.0.0-beta.51"
+  resolved "https://npm.pkg.github.com/download/@smart-core-os/sc-api-grpc-web/1.0.0-beta.51/2111364c63f9ef4f6e7ced717a11d9ec39dc1667#2111364c63f9ef4f6e7ced717a11d9ec39dc1667"
+  integrity sha512-9Y9w0EkMo6r64Uw6f3MzWNPjHLETIbcFwRGllIA+Phm1GjhSQM1Z6jDcDlZ1rAOudnwCepe5cHSk+ScZaNDHWQ==
+  dependencies:
+    google-protobuf "^3.21.2"
+    grpc-web "^1.5.0"
+
 "@sphinxxxx/color-conversion@^2.2.2":
   version "2.2.2"
   resolved "https://registry.npmjs.org/@sphinxxxx/color-conversion/-/color-conversion-2.2.2.tgz"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -862,14 +862,6 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz#719df7fb41766bc143369eaa0dd56d8dc87c9958"
   integrity sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==
 
-"@smart-core-os/sc-api-grpc-web@^1.0.0-beta.48":
-  version "1.0.0-beta.48"
-  resolved "https://npm.pkg.github.com/download/@smart-core-os/sc-api-grpc-web/1.0.0-beta.48/b833c42f262b0f07c3cd5c7a43417f7b06989c69#b833c42f262b0f07c3cd5c7a43417f7b06989c69"
-  integrity sha512-ngaHoSu5RTXK5kGKj/Q67vDRPyCHA4IC0kVo9/3cjZQDC96CJPmBkq8iosnDdQ7otIUno/WN4m957BQeKWSvrw==
-  dependencies:
-    google-protobuf "^3.21.2"
-    grpc-web "^1.5.0"
-
 "@smart-core-os/sc-api-grpc-web@^1.0.0-beta.51":
   version "1.0.0-beta.51"
   resolved "https://npm.pkg.github.com/download/@smart-core-os/sc-api-grpc-web/1.0.0-beta.51/2111364c63f9ef4f6e7ced717a11d9ec39dc1667#2111364c63f9ef4f6e7ced717a11d9ec39dc1667"


### PR DESCRIPTION
Adds a page under the ops section to view waste records. Functionality is MVP, just has to be able to view records at this point.

Not sure about the icon as it is not really just about recycling, could use mdi-basket-fill or possibly a trash can, but I thought that was too much like delete.

The vanti ugs example is already configured to generate mock waste records too