### PR TITLE
ui/ops: add card on device sidebar for the transport trait

### DIFF
--- a/ui/ops/src/api/sc/traits/transport.js
+++ b/ui/ops/src/api/sc/traits/transport.js
@@ -1,0 +1,81 @@
+import {fieldMaskFromObject, setProperties} from '@/api/convpb.js';
+import {clientOptions} from '@/api/grpcweb.js';
+import {pullResource, setValue, trackAction} from '@/api/resource.js';
+import {
+  TransportApiPromiseClient,
+  TransportInfoPromiseClient
+} from '@vanti-dev/sc-bos-ui-gen/proto/transport_grpc_web_pb.js';
+import {DescribeTransportRequest, PullTransportRequest} from '@vanti-dev/sc-bos-ui-gen/proto/transport_pb';
+
+/**
+ * @param {Partial<PullTransportRequest.AsObject>} request
+ * @param {ResourceValue<Transport.AsObject, PullTransportResponse>} resource
+ */
+export function pullTransport(request, resource) {
+  pullResource('Transport.pullTransport', resource, endpoint => {
+    const api = apiClient(endpoint);
+    const stream = api.pullTransport(pullTransportRequestFromObject(request));
+    stream.on('data', msg => {
+      const changes = msg.getChangesList();
+      for (const change of changes) {
+        setValue(resource, change.getTransport().toObject());
+      }
+    });
+    return stream;
+  });
+}
+
+/**
+ *
+ * @param {Partial<DescribeTransportRequest.AsObject>} request
+ * @param {ActionTracker<TransportSupport.AsObject>} [tracker]
+ * @return {Promise<TransportSupport.AsObject>}
+ */
+export function describeTransport(request, tracker) {
+  return trackAction('Transport.describeTransport', tracker ?? {}, endpoint => {
+    const api = infoClient(endpoint);
+    return api.describeTransport(describeTransportRequestFromObject(request));
+  });
+}
+
+/**
+ * @param {string} endpoint
+ * @return {TransportApiPromiseClient}
+ */
+function apiClient(endpoint) {
+  return new TransportApiPromiseClient(endpoint, null, clientOptions());
+}
+
+/**
+ * @param {string} endpoint
+ * @return {TransportInfoPromiseClient}
+ */
+function infoClient(endpoint) {
+  return new TransportInfoPromiseClient(endpoint, null, clientOptions());
+}
+
+/**
+ * @param {Partial<DescribeTransportRequest.AsObject>} obj
+ * @return {undefined|DescribeTransportRequest}
+ */
+function describeTransportRequestFromObject(obj) {
+  if (!obj) return undefined;
+  const dst = new DescribeTransportRequest();
+  setProperties(dst, obj, 'name');
+  return dst;
+}
+
+
+/**
+ * @param {Partial<PullTransportRequest.AsObject>} obj
+ * @return {PullTransportRequest|undefined}
+ */
+function pullTransportRequestFromObject(obj) {
+  if (!obj) return undefined;
+
+  const dst = new PullTransportRequest();
+  setProperties(dst, obj, 'name', 'updatesOnly');
+  dst.setReadMask(fieldMaskFromObject(obj.readMask));
+  return dst;
+}
+

--- a/ui/ops/src/routes/devices/components/DeviceSideBarContent.vue
+++ b/ui/ops/src/routes/devices/components/DeviceSideBarContent.vue
@@ -29,6 +29,10 @@
       <v-divider class="mt-4 mb-1"/>
       <meter-card v-bind="resource" :info="info?.response"/>
     </with-meter>
+    <with-transport v-if="traits['smartcore.bos.Transport']" :name="deviceId" v-slot="{resource, info}">
+      <v-divider class="mt-4 mb-1"/>
+      <transport-card v-bind="resource" :info="info?.response"/>
+    </with-transport>
     <v-divider v-if="traits['smartcore.bsp.EmergencyLight']" class="mt-4 mb-1"/>
     <emergency-light :name="deviceId" v-if="traits['smartcore.bsp.EmergencyLight']"/>
     <v-divider v-if="traits['smartcore.traits.Mode']" class="mt-4 mb-1"/>
@@ -55,6 +59,8 @@ import OccupancyCard from '@/traits/occupancy/OccupancyCard.vue';
 import WithOccupancy from '@/traits/occupancy/WithOccupancy.vue';
 import StatusLogCard from '@/traits/status/StatusLogCard.vue';
 import WithStatus from '@/traits/status/WithStatus.vue';
+import TransportCard from '@/traits/transport/TransportCard.vue';
+import WithTransport from '@/traits/transport/WithTransport.vue';
 import UdmiCard from '@/traits/udmi/UdmiCard.vue';
 
 defineProps({

--- a/ui/ops/src/traits/transport/TransportCard.vue
+++ b/ui/ops/src/traits/transport/TransportCard.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-card elevation="0" tile>
+    <v-list tile class="ma-0 pa-0">
+      <v-list-subheader class="text-title-caps-large text-neutral-lighten-3">Transport</v-list-subheader>
+      <v-list-item v-for="item of table" :key="item.label" class="py-1">
+        <v-list-item-title class="text-body-small text-capitalize">
+          {{ item.label }}
+        </v-list-item-title>
+
+        <template #append>
+          <v-list-item-subtitle class="text-body-1">
+            {{ item.value }} {{ item.unit }}
+          </v-list-item-subtitle>
+        </template>
+      </v-list-item>
+    </v-list>
+
+    <v-progress-linear color="primary" indeterminate :active="loading"/>
+  </v-card>
+</template>
+
+<script setup>
+
+import {useTransport} from '@/traits/transport/transport.js';
+
+const props = defineProps({
+  value: {
+    type: Object, // of type Transport.AsObject
+    default: () => {
+    }
+  },
+  info: {
+    type: Object, // of type TransportInfo.AsObject
+    default: () => null
+  },
+  loading: {
+    type: Boolean,
+    default: false
+  }
+});
+
+const {table} = useTransport(() => props.value, () => props.info);
+</script>
+
+<style scoped>
+.v-list-item {
+  min-height: auto;
+}
+
+.v-progress-linear {
+  width: auto;
+}
+</style>

--- a/ui/ops/src/traits/transport/WithTransport.vue
+++ b/ui/ops/src/traits/transport/WithTransport.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <slot :resource="transportValue" :info="transportInfo"/>
+  </div>
+</template>
+
+<script setup>
+import {useDescribeTransport, usePullTransport} from '@/traits/transport/transport.js';
+import {reactive} from 'vue';
+
+const props = defineProps({
+  // unique name of the device
+  name: {
+    type: String,
+    default: ''
+  },
+  request: {
+    type: Object, // of type PullTransportRequest.AsObject
+    default: () => {
+    }
+  },
+  paused: {
+    type: Boolean,
+    default: false
+  }
+});
+
+const transportValue = reactive(usePullTransport(() => props.name || props.request, () => props.paused));
+const transportInfo = reactive(useDescribeTransport(() => props.name));
+</script>

--- a/ui/ops/src/traits/transport/transport.js
+++ b/ui/ops/src/traits/transport/transport.js
@@ -1,0 +1,197 @@
+import {closeResource, newActionTracker, newResourceValue} from '@/api/resource.js';
+import {describeTransport, pullTransport} from '@/api/sc/traits/transport.js';
+import {toQueryObject, watchResource} from '@/util/traits.js';
+import {Transport} from '@vanti-dev/sc-bos-ui-gen/proto/transport_pb';
+import {computed, onScopeDispose, reactive, toRefs, toValue} from 'vue';
+
+/**
+ * @typedef {import('@vanti-dev/sc-bos-ui-gen/proto/transport_pb').DescribeTransportRequest} DescribeTransportRequest
+ * @typedef {import('@vanti-dev/sc-bos-ui-gen/proto/transport_pb').PullTransportRequest} PullTransportRequest
+ * @typedef {import('@vanti-dev/sc-bos-ui-gen/proto/transport_pb').PullTransportResponse} PullTransportResponse
+ * @typedef {import('@vanti-dev/sc-bos-ui-gen/proto/transport_pb').Transport} Transport
+ * @typedef {import('@vanti-dev/sc-bos-ui-gen/proto/transport_pb').TransportSupport} TransportSupport
+ * @typedef {import('vue').UnwrapNestedRefs} UnwrapNestedRefs
+ * @typedef {import('vue').ToRefs} ToRefs
+ * @typedef {import('vue').ComputedRef} ComputedRef
+ * @typedef {import('vue').MaybeRefOrGetter} MaybeRefOrGetter
+ * @typedef {import('@/api/resource').ResourceValue} ResourceValue
+ */
+
+/**
+ * @param {MaybeRefOrGetter<string|PullTransportRequest.AsObject>} query
+ * @param {MaybeRefOrGetter<boolean>=} paused
+ * @return {ToRefs<ResourceValue<Transport.AsObject, PullTransportResponse>>}
+ */
+export function usePullTransport(query, paused = false) {
+  const resource = reactive(
+      /** @type {ResourceValue<Transport.AsObject, PullTransportResponse>} */
+      newResourceValue()
+  );
+  onScopeDispose(() => closeResource(resource));
+
+  const queryObject = computed(() => toQueryObject(query));
+
+  watchResource(
+      () => toValue(queryObject),
+      () => toValue(paused),
+      (req) => {
+        pullTransport(req, resource);
+        return () => closeResource(resource);
+      }
+  );
+
+  return toRefs(resource);
+}
+
+/**
+ * @param {MaybeRefOrGetter<string|DescribeTransportRequest.AsObject>} query - The name of the device or a query
+ *   object
+ * @return {ToRefs<ActionTracker<TransportSupport.AsObject>>}
+ */
+export function useDescribeTransport(query) {
+  const tracker = reactive(
+      /** @type {ActionTracker<TransportSupport.AsObject>} */
+      newActionTracker()
+  );
+
+  const queryObject = computed(() => toQueryObject(query));
+
+  watchResource(
+      () => toValue(queryObject),
+      false,
+      (req) => {
+        describeTransport(req, tracker);
+        return () => closeResource(tracker);
+      }
+  );
+
+  return toRefs(tracker);
+}
+
+/**
+ * Convert a proto enum value to a display name. e.g. "DOOR_OPEN" -> "Door Open"
+ * replace underscores with spaces, capitalize the first letter of each word
+ *
+ * @param {string} e
+ * @return {string}
+ */
+function enumToDisplayName(e) {
+  // replace underscores in with spaces, change the letters to lower case
+  e = e.replace(/_/g, ' ').toLowerCase();
+  // then capitalize the first letter eof each word
+  e = e.replace(/\b\w/g, l => l.toUpperCase());
+  return e;
+}
+
+/**
+ * @param {MaybeRefOrGetter<Transport.AsObject|null>} value
+ * @param {MaybeRefOrGetter<TransportSupport.AsObject|null>=} support
+ * @return {{
+ *   actualPosition: ComputedRef<string>,
+ *   doorStatus: ComputedRef<Array<{label:string, value:string}>>,
+ *   movingDirection: ComputedRef<string>,
+ *   nextDestination: ComputedRef<string>,
+ *   load: ComputedRef<string>,
+ *   table: ComputedRef<Array<{label:string, value:string}>>
+ * }}
+ */
+export function useTransport(value, support = null) {
+  const _v = computed(() => toValue(value));
+  const _s = computed(() => toValue(support));
+
+  const movingDirectionById = Object.entries(Transport.Direction).reduce((all, [name, id]) => {
+    all[id] = name;
+    return all;
+  }, {});
+
+  const doorStatusById = Object.entries(Transport.Door.DoorStatus).reduce((all, [name, id]) => {
+    all[id] = name;
+    return all;
+  }, {});
+
+  const actualPosition = computed(() => {
+    const v = _v.value;
+    if (!v) return '';
+    return v.actualPosition?.floor ?? '';
+  });
+
+  const doorStatus = computed(() => {
+    const v = _v.value;
+    if (!v) return [];
+    let res = [];
+    for (const door of v.doorsList) {
+      res.push({
+        label: door.title,
+        value: enumToDisplayName(doorStatusById[door.status] ?? '')
+      });
+    }
+    return res;
+  });
+
+  const movingDirection = computed(() => {
+    const v = _v.value;
+    if (!v) return '';
+    return enumToDisplayName(movingDirectionById[v.movingDirection] ?? '');
+  });
+
+  const nextDestination = computed(() => {
+    const v = _v.value;
+    if (!v) return '';
+    if (v.nextDestinationsList.length > 0) {
+      return v.nextDestinationsList[0]?.floor ?? 'N/A';
+    } else {
+      return 'N/A';
+    }
+  });
+
+  const loadUnit = computed(() => {
+    return _s.value?.loadUnit ?? 'kg';
+  });
+
+  const load = computed(() => {
+    const v = _v.value;
+    if (!v) return '';
+    return v.load?.toFixed(2);
+  });
+
+  const loadStr = computed(() => {
+    if (load.value)
+    {
+        return `${load.value} ${loadUnit.value}`;
+    }
+    return '-';
+  });
+
+  const table = computed(() => {
+    let t = [{
+      label: 'Actual Position',
+      value: actualPosition.value
+    },
+    {
+      label: 'Moving Direction',
+      value: movingDirection.value
+    },
+    {
+      label: 'Next Destination',
+      value: nextDestination.value
+    }];
+
+    for (const door of doorStatus.value) {
+      t.push(door);
+    }
+    t.push({
+      label: 'Load',
+      value: loadStr.value
+    });
+    return t;
+  });
+
+  return {
+    actualPosition,
+    doorStatus,
+    movingDirection,
+    nextDestination,
+    loadStr,
+    table
+  };
+}


### PR DESCRIPTION
Add a basic card on the device sidebar for the transport trait. This implementation only displays the minimum properties that we would expect from a lift/elevator which implements the Transport trait. 