### PR TITLE
service/retry: add min delay for retrying

### DIFF
--- a/pkg/task/service/retry.go
+++ b/pkg/task/service/retry.go
@@ -27,6 +27,7 @@ func (a abortRetry) Unwrap() error {
 type retryOptions struct {
 	InitialDelay time.Duration // time between the first and second attempt
 	MaxDelay     time.Duration // maximum time between attempts
+	MinDelay     time.Duration // minimum time between attempts
 	Factor       float64       // factor by which to increase the delay between attempts
 	MaxAttempts  int           // maximum number of attempts, 0 means unlimited
 
@@ -59,6 +60,7 @@ type RetryOption func(*retryOptions)
 var defaultRetryOptions = retryOptions{
 	InitialDelay: 500 * time.Millisecond,
 	MaxDelay:     30 * time.Second,
+	MinDelay:     500 * time.Millisecond,
 	Factor:       1.5,
 	MaxAttempts:  0,
 	Logger:       func(logContext RetryContext) {},

--- a/pkg/task/service/service.go
+++ b/pkg/task/service/service.go
@@ -312,6 +312,8 @@ func (l *Service[C]) applyConfig(state State, config C) (State, error) {
 			retry.Delay = time.Duration(float64(l.retry.InitialDelay) * math.Pow(l.retry.Factor, float64(retry.Attempt-1)))
 			if retry.Delay > l.retry.MaxDelay {
 				retry.Delay = l.retry.MaxDelay
+			} else if retry.Delay < l.retry.MinDelay {
+				retry.Delay = l.retry.MinDelay
 			}
 
 			// abort if we've exhausted our retry attempts


### PR DESCRIPTION
For reasons I am yet to figure out, the delay became negative {"delay": "-2562047h47m16.854775808s"} which caused the driver to retry at a very fast rate see https://vanti.youtrack.cloud/issue/OCW-133/when-driver-applyConfig-fails-for-a-while-it-retries-very-rapidly

This just adds a simple guard against this behaviour
