### PR TITLE
ui/ops/energy: add EnergyHistoryCard widget

### DIFF
--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -595,6 +595,115 @@
               ]
             }
           ]
+        },
+        {
+          "title": "Energy",
+          "icon": "mdi-flash",
+          "layout": "builtin:LayoutMainSide",
+          "path": "energy",
+          "mainWidgetMinHeight": 0,
+          "sideWidth": 420,
+          "main": [
+            {
+              "component": "builtin:energy/EnergyHistoryCard",
+              "props": {
+                "title": "Electricity Usage",
+                "totalConsumptionName": "van/uk/brum/ugs/zones/building",
+                "totalProductionName": "van/uk/brum/ugs/zones/building/generated",
+                "subConsumptionNames": [
+                  "van/uk/brum/ugs/zones/floors/ground",
+                  "van/uk/brum/ugs/zones/floors/basement"
+                ]
+              }
+            },
+            {
+              "component": "builtin:power-history/PowerHistoryCard",
+              "props": {
+                "demand": "van/uk/brum/ugs/zones/building",
+                "generated": "van/uk/brum/ugs/zones/building/generated",
+                "occupancy": "van/uk/brum/ugs/zones/building"
+              }
+            }
+          ],
+          "after": [
+            {
+              "component": "builtin:container/FlexRow",
+              "props": {
+                "itemMinWidth": "14em",
+                "title": "Total Today",
+                "items": [
+                  {
+                    "component": "builtin:meter/ConsumptionCard",
+                    "props": {
+                      "name": "van/uk/brum/ugs/zones/building",
+                      "period": "day",
+                      "title": "Consumed"
+                    }
+                  },
+                  {
+                    "component": "builtin:meter/ConsumptionCard",
+                    "props": {
+                      "name": "van/uk/brum/ugs/zones/building/generated",
+                      "period": "day",
+                      "title": "Produced"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "component": "builtin:container/FlexRow",
+              "props": {
+                "itemMinWidth": "14em",
+                "title": "Total Month",
+                "items": [
+                  {
+                    "component": "builtin:meter/ConsumptionCard",
+                    "props": {
+                      "name": "van/uk/brum/ugs/zones/building",
+                      "period": "month",
+                      "title": "Consumed"
+                    }
+                  },
+                  {
+                    "component": "builtin:meter/ConsumptionCard",
+                    "props": {
+                      "name": "van/uk/brum/ugs/zones/building/generated",
+                      "period": "month",
+                      "title": "Produced"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "component": "builtin:container/FlexRow",
+              "props": {
+                "itemMinWidth": "14em",
+                "title": "Last Month",
+                "items": [
+                  {
+                    "component": "builtin:meter/ConsumptionCard",
+                    "props": {
+                      "name": "van/uk/brum/ugs/zones/building",
+                      "period": "month",
+                      "offset": 1,
+                      "title": "Consumed"
+                    }
+                  },
+                  {
+                    "component": "builtin:meter/ConsumptionCard",
+                    "props": {
+                      "name": "van/uk/brum/ugs/zones/building/generated",
+                      "period": "month",
+                      "offset": 1,
+                      "title": "Produced"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },

--- a/ui/ops/package.json
+++ b/ui/ops/package.json
@@ -32,6 +32,7 @@
     "lodash": "^4.17.21",
     "pinia": "^2.3.0",
     "qrcode": "^1.5.3",
+    "safe-timers": "^1.1.0",
     "vue": "^3.5.13",
     "vue-chartjs": "^5.3.1",
     "vue-router": "^4.4.5",

--- a/ui/ops/src/composables/time.js
+++ b/ui/ops/src/composables/time.js
@@ -1,4 +1,6 @@
+import {isNullOrUndef} from '@/util/types.js';
 import {
+  add,
   addDays,
   addHours,
   addMinutes,
@@ -12,7 +14,8 @@ import {
   startOfWeek,
   startOfYear
 } from 'date-fns';
-import {computed, onMounted, onScopeDispose, onUnmounted, ref, toValue} from 'vue';
+import {computed, effectScope, onMounted, onScopeDispose, onUnmounted, reactive, ref, toValue, watch} from 'vue';
+import {setTimeout, clearTimeout} from 'safe-timers'
 
 /**
  * Returns values that can show time since a given time.
@@ -117,4 +120,162 @@ export const useStartOf = {
   week: () => useStartOfPeriod(startOfWeek, addWeeks),
   month: () => useStartOfPeriod(startOfMonth, addMonths),
   year: () => useStartOfPeriod(startOfYear, addYears)
+}
+
+/**
+ * @typedef {keyof useStartOf} NamedPeriod
+ */
+
+/**
+ * Returns whether the given period is a known named period.
+ * Named periods can be used with functions like usePeriod and exist in useStartOf.
+ *
+ * @param {any} period
+ * @return {boolean}
+ */
+export function isNamedPeriod(period) {
+  return typeof period === 'string' && Object.hasOwn(useStartOf, period);
+}
+
+/**
+ * @type {Record<keyof useStartOf, keyof useStartOf>}
+ */
+export const previousNamedPeriod = {
+  hour: 'minute',
+  day: 'hour',
+  week: 'day',
+  month: 'day',
+  year: 'month'
+}
+
+/**
+ * Tracks a period of time.
+ * The start and end dates can be named periods like 'day' or 'week', in which case the period will represent the current period.
+ * When using named dates, offset can be used to adjust the period in use.
+ * For example an offset of -1 with a period of 'day' will represent the previous day.
+ *
+ * @param {import('vue').MaybeRefOrGetter<keyof useStartOf | string | number | Date>} start
+ * @param {import('vue').MaybeRefOrGetter<keyof useStartOf | string | number | Date>} end
+ * @param {import('vue').MaybeRefOrGetter<null | undefined | number | string>} [offset]
+ * @return {{
+ *   start: import('vue').Ref<Date | null>,
+ *   end: import('vue').Ref<Date | null>
+ * }}
+ */
+export function usePeriod(start, end, offset) {
+  const _offset = computed(() => {
+    const o = toValue(offset);
+    if (!o) return 0;
+    return parseInt(o);
+  });
+  /**
+   * @param {string} period
+   * @param {import('vue').MaybeRefOrGetter<Date>} t
+   * @param {number} [plus]
+   * @return {ComputedRef<Date>}
+   */
+  const useOffset = (period, t, plus = 0) => {
+    return computed(() => {
+      const o = _offset.value + plus;
+      if (o === 0) return toValue(t);
+      return add(toValue(t), {[`${period}s`]: o});
+    });
+  }
+
+  /**
+   * A helper composable that returns a ref to a date at the start of t + plus.
+   *
+   * @param {import('vue').MaybeRefOrGetter<NamedPeriod | Date | number | string>} t
+   * @param {number} [plus]
+   * @return {import('vue').ComputedRef<null | Date>}
+   */
+  const usePeriodBound = (t, plus = 0) => {
+    const res = reactive({value: /** @type {Date | null} */ null});
+
+    let closeScope = () => {};
+    onScopeDispose(() => closeScope());
+
+    watch(() => toValue(t), (t, oldT) => {
+      if (oldT === t) return;
+      closeScope();
+      if (isNullOrUndef(t)) {
+        res.value = null;
+        return;
+      }
+      if (isNamedPeriod(t)) {
+        const scope = effectScope();
+        closeScope = () => scope.stop();
+        scope.run(() => {
+          const d = useStartOf[t]();
+          res.value = useOffset(t, d, plus);
+        });
+        return;
+      }
+
+      // There's a quirk of Vue that we have to work around here.
+      // If res.value had ever been a ref, i.e. t used to be a named period,
+      // then when we reassign res.value here Vue will check that whether that
+      // assignment should be written to the current ref value.
+      // As our named period branch assigns it to a computed prop, Vue will
+      // fail at that step because computed props are read-only.
+      //
+      // To get around this we assign a ref to res.value which causes Vue to
+      // replace res.value with the new ref instead of trying to write to the old ref.
+      res.value = computed(() => {
+        if (typeof t === 'number') return new Date(t);
+        if (typeof t === 'string') return new Date(t);
+        if (t instanceof Date) return t;
+        return null;
+      });
+    }, {immediate: true});
+
+    return computed(() => res.value);
+  }
+
+  return {
+    start: usePeriodBound(start),
+    end: usePeriodBound(end, 1)
+  }
+}
+
+/**
+ * Returns a ref containing the leading segment of dates that are in the past.
+ *
+ * @example
+ * // if now is 14:10
+ * const dates = usePastDates([13:00, 14:00, 15:00, 16:00]);
+ * // dates.value will be [13:00, 14:00]
+ *
+ * @param {import('vue').MaybeRefOrGetter<Date[]>} dates
+ * @return {import('vue').ComputedRef<Date[]>}
+ */
+export function usePastDates(dates) {
+  const now = ref(new Date()); // the current time, but in a resolution suitable for working out the tense of dates
+  let nowHandle = 0;
+  onScopeDispose(() => clearTimeout(nowHandle));
+
+  watch(() => toValue(dates), (dates) => {
+    const updateNow = () => {
+      clearTimeout(nowHandle);
+      const t = new Date();
+      now.value = t;
+      const nextDate = dates.find((b) => b.getTime() > t.getTime());
+      if (!nextDate) return;
+      const delay = nextDate.getTime() - t.getTime();
+      nowHandle = setTimeout(() => updateNow(), delay);
+    }
+    updateNow();
+  }, {immediate: true});
+
+  return computed(() => {
+    const t = now.value.getTime();
+    const _dates = toValue(dates);
+    if (_dates[_dates.length - 1].getTime() < t) return _dates;
+    const res = [];
+    for (let i = 0; i < _dates.length; i++) {
+      if (_dates[i].getTime() > t) break;
+      res.push(_dates[i]);
+    }
+    return res;
+  });
 }

--- a/ui/ops/src/dynamic/widgets/energy/EnergyHistoryCard.vue
+++ b/ui/ops/src/dynamic/widgets/energy/EnergyHistoryCard.vue
@@ -2,7 +2,7 @@
   <v-card class="px-6 py-4">
     <v-toolbar class="chart-header" color="transparent">
       <slot name="title">
-        <v-toolbar-title class="pa-0 mr-auto">{{ props.title }}</v-toolbar-title>
+        <v-toolbar-title class="text-h4 pa-0 mr-auto">{{ props.title }}</v-toolbar-title>
       </slot>
       <v-btn
           icon="mdi-dots-vertical"

--- a/ui/ops/src/dynamic/widgets/energy/EnergyHistoryCard.vue
+++ b/ui/ops/src/dynamic/widgets/energy/EnergyHistoryCard.vue
@@ -1,0 +1,245 @@
+<template>
+  <v-card class="px-6 py-4">
+    <v-toolbar class="chart-header" color="transparent">
+      <slot name="title">
+        <v-toolbar-title class="pa-0 mr-auto">{{ props.title }}</v-toolbar-title>
+      </slot>
+      <v-btn
+          icon="mdi-dots-vertical"
+          size="small"
+          variant="text">
+        <v-icon size="24"/>
+        <v-menu activator="parent" location="bottom right" offset="8" :close-on-content-click="false">
+          <v-card min-width="24em">
+            <v-list density="compact">
+              <v-list-subheader title="Sources"/>
+              <v-list-item
+                  v-for="(item, index) in legendItems"
+                  :key="index"
+                  @click="item.onClick(item.hidden)"
+                  :title="item.text">
+                <template #prepend>
+                  <v-list-item-action start>
+                    <v-checkbox-btn :model-value="!item.hidden" readonly :color="item.bgColor" density="compact"/>
+                  </v-list-item-action>
+                </template>
+              </v-list-item>
+            </v-list>
+            <v-list>
+              <v-list-subheader title="Data"/>
+              <period-chooser-rows v-model:start="_start" v-model:end="_end" v-model:offset="_offset"/>
+            </v-list>
+          </v-card>
+        </v-menu>
+      </v-btn>
+    </v-toolbar>
+    <v-card-text>
+      <div class="chart__container">
+        <bar :options="chartOptions" :data="chartData" :plugins="[vueLegendPlugin, themeColorPlugin]"/>
+      </div>
+    </v-card-text>
+    <energy-tooltip :data="tooltipData" :edges="edges" :tick-unit="tickUnit" :unit="unit"/>
+  </v-card>
+</template>
+
+<script setup>
+import {
+  computeDatasets,
+  useExternalTooltip,
+  useThemeColorPlugin,
+  useVueLegendPlugin
+} from '@/dynamic/widgets/energy/chart.js';
+import {useDateScale} from '@/dynamic/widgets/energy/date.js';
+import EnergyTooltip from '@/dynamic/widgets/energy/EnergyTooltip.vue';
+import PeriodChooserRows from '@/dynamic/widgets/energy/PeriodChooserRows.vue';
+import {useDescribeMeterReading} from '@/traits/meter/meter.js';
+import {isNullOrUndef} from '@/util/types.js';
+import {BarElement, Chart as ChartJS, Legend, LinearScale, TimeScale, Title, Tooltip} from 'chart.js'
+import {startOfDay, startOfYear} from 'date-fns';
+import {computed, ref, toRef, toValue, watch} from 'vue';
+import {Bar} from 'vue-chartjs';
+import 'chartjs-adapter-date-fns';
+import {useMeterConsumption, useMetersConsumption} from './consumption.js';
+
+ChartJS.register(Title, Tooltip, BarElement, LinearScale, TimeScale, Legend);
+
+const props = defineProps({
+  title: {
+    type: String,
+    default: 'Energy Usage'
+  },
+  totalConsumptionName: {
+    type: String,
+    default: undefined,
+  },
+  totalProductionName: {
+    type: String,
+    default: undefined,
+  },
+  subConsumptionNames: {
+    type: [Array],
+    default: () => [],
+  },
+  subProductionNames: {
+    type: [Array],
+    default: () => [],
+  },
+  start: {
+    type: [String, Number, Date],
+    default: 'day', // 'month', 'day', etc. meaning 'start of <day>' or a Date-like object
+  },
+  end: {
+    type: [String, Number, Date],
+    default: 'day' // 'month', 'day', etc. meaning 'end of <day>' or a Date-like object
+  },
+  offset: {
+    type: [Number, String],
+    default: 0, // when start/End is 'month', 'day', etc. offset that value into the past, like 'last month'
+  }
+});
+
+// we assume here that all the meters share the same unit, so asking about any will be enough.
+const nameForDescribe = computed(() => {
+  if (!isNullOrUndef(props.totalConsumptionName)) return props.totalConsumptionName;
+  if (!isNullOrUndef(props.totalProductionName)) return props.totalProductionName;
+  const toName = (item) => {
+    if (typeof item === 'string') return item;
+    return item.name;
+  }
+  if (props.subConsumptionNames.length > 0) return toName(props.subConsumptionNames[0]);
+  if (props.subProductionNames.length > 0) return toName(props.subProductionNames[0]);
+  return undefined;
+})
+const {response: meterInfo} = useDescribeMeterReading(nameForDescribe);
+const unit = computed(() => meterInfo.value?.unit);
+
+/**
+ * @template T
+ * @param {import('vue').MaybeRefOrGetter<T>} prop
+ * @return {import('vue').Ref<T>}
+ */
+const useLocalProp = (prop) => {
+  const local = ref(toValue(prop.value));
+  watch(() => toValue(prop), (value) => {
+    local.value = value;
+  });
+  return local;
+}
+const _start = useLocalProp(toRef(props, 'start'));
+const _end = useLocalProp(toRef(props, 'end'));
+const _offset = useLocalProp(toRef(props, 'offset'));
+
+const {edges, pastEdges, tickUnit} = useDateScale(_start, _end, _offset);
+
+const totalConsumption = useMeterConsumption(toRef(props, 'totalConsumptionName'), pastEdges);
+const totalProduction = useMeterConsumption(toRef(props, 'totalProductionName'), pastEdges);
+
+const subConsumptions = useMetersConsumption(toRef(props, 'subConsumptionNames'), pastEdges);
+const subProductions = useMetersConsumption(toRef(props, 'subProductionNames'), pastEdges);
+
+const {
+  external: tooltipExternal,
+  data: tooltipData,
+} = useExternalTooltip(edges, tickUnit, unit);
+const {legendItems, vueLegendPlugin} = useVueLegendPlugin();
+const {themeColorPlugin} = useThemeColorPlugin();
+
+const chartOptions = computed(() => {
+  return /** @type {import('chart.js').ChartOptions} */ {
+    responsive: true,
+    maintainAspectRatio: false,
+    borderRadius: 3,
+    borderWidth: 1,
+    interaction: {
+      mode: 'index', // a single tooltip with all stacked datasets at the same x location in it
+    },
+    plugins: {
+      tooltip: {
+        enabled: false,
+        external: tooltipExternal
+      },
+      legend: {
+        display: false, // we use a custom legend plugin and vue for this
+      }
+    },
+    scales: {
+      y: {
+        stacked: true,
+        border: {
+          color: 'transparent'
+        },
+        grid: {
+          color(ctx) {
+            if (ctx.tick.value === 0) return '#fff4';
+            return '#fff1';
+          },
+          drawTicks: false,
+        },
+        ticks: {
+          callback(value) {
+            return new Intl.NumberFormat(undefined, {}).format(Math.abs(value));
+          },
+          color: '#fff',
+          padding: 8
+        },
+      },
+      x: {
+        type: 'time',
+        stacked: true,
+        grid: {
+          offset: false, // bars default to true here, put ticks back inline with grid lines
+          color: '#fff1'
+        },
+        ticks: {
+          maxTicksLimit: 11,
+          includeBounds: true,
+          callback(value) {
+            const unit = tickUnit.value;
+            if (unit === 'month' && value === startOfYear(value).getTime()) return this.format(value, this.options.time.displayFormats['year']);
+            if (unit === 'hour' && value === startOfDay(value).getTime()) return this.format(value, this.options.time.displayFormats['day']);
+            return this.format(value);
+          },
+          color: '#fff',
+          padding: 8,
+          maxRotation: 0
+        },
+        time: {
+          unit: tickUnit.value,
+          displayFormats: {
+            hour: 'H:mm', // default: 4:00 AM
+            day: 'd MMM', // default: Feb 10
+            month: 'MMM', // default: Feb 2025 - we fix the ambiguity in ticks.callback
+          }
+        }
+      }
+    }
+  };
+});
+
+const chartData = computed(() => {
+  return {
+    labels: edges.value,
+    datasets: [
+      ...computeDatasets('Consumption', totalConsumption, toRef(props, 'subConsumptionNames'), subConsumptions),
+      ...computeDatasets('Production', totalProduction, toRef(props, 'subProductionNames'), subProductions, true),
+    ]
+  };
+});
+</script>
+
+<style scoped lang="scss">
+.chart-header {
+  align-items: center;
+
+  :deep(.v-toolbar__content) {
+    justify-content: end;
+    flex-wrap: wrap;
+  }
+}
+
+.chart__container {
+  min-height: 500px;
+  /* The chart seems to have a padding no mater what we do, this gets rid of it */
+  margin: -6px;
+}
+</style>

--- a/ui/ops/src/dynamic/widgets/energy/EnergyHistoryCard.vue
+++ b/ui/ops/src/dynamic/widgets/energy/EnergyHistoryCard.vue
@@ -165,6 +165,10 @@ const chartOptions = computed(() => {
     scales: {
       y: {
         stacked: true,
+        title: {
+          display: true,
+          text: unit.value
+        },
         border: {
           color: 'transparent'
         },

--- a/ui/ops/src/dynamic/widgets/energy/EnergyTooltip.vue
+++ b/ui/ops/src/dynamic/widgets/energy/EnergyTooltip.vue
@@ -1,0 +1,160 @@
+<template>
+  <v-menu :target="target" :model-value="visible"
+          location="end" :offset="20" transition="slide-x-transition"
+          content-class="no-pointer-events">
+    <v-card>
+      <v-card-title>{{ titleStr }}</v-card-title>
+      <v-defaults-provider :defaults="{VListItem: {minHeight: '1.5em'}}">
+        <template v-if="consumptionRows.length > 0">
+          <v-card-subtitle>Consumption</v-card-subtitle>
+          <v-list density="compact">
+            <v-list-item v-for="(row, index) in consumptionRows" :key="index" :title="row.title">
+              <template #prepend>
+                <v-avatar :color="row.prependColor" size="1.5em"/>
+              </template>
+              <template #append>
+                <span class="ml-4">{{ row.append }}</span>
+              </template>
+            </v-list-item>
+            <v-list-item v-if="totalConsumptionRow && consumptionRows.length > 1"
+                         :title="totalConsumptionRow.title"
+                         active>
+              <template #prepend>
+                <v-avatar icon="mdi-sigma" size="1.5em"/>
+              </template>
+              <template #append>
+                <span class="ml-4">{{ totalConsumptionRow.append }}</span>
+              </template>
+            </v-list-item>
+          </v-list>
+        </template>
+        <template v-if="productionRows.length > 0">
+          <v-card-subtitle>Production</v-card-subtitle>
+          <v-list density="compact">
+            <v-list-item v-for="(row, index) in productionRows" :key="index" :title="row.title">
+              <template #prepend>
+                <v-avatar :color="row.prependColor" size="1.5em"/>
+              </template>
+              <template #append>
+                <span class="ml-4">{{ row.append }}</span>
+              </template>
+            </v-list-item>
+            <v-list-item v-if="totalProductionRow && productionRows.length > 1"
+                         :title="totalProductionRow.title"
+                         active>
+              <template #prepend>
+                <v-avatar icon="mdi-sigma" size="1.5em"/>
+              </template>
+              <template #append>
+                <span class="ml-4">{{ totalProductionRow.append }}</span>
+              </template>
+            </v-list-item>
+          </v-list>
+        </template>
+      </v-defaults-provider>
+    </v-card>
+  </v-menu>
+</template>
+
+<script setup>
+import {usageToString} from '@/traits/meter/meter.js';
+import {format} from 'date-fns';
+import {computed, toRef} from 'vue';
+
+const props = defineProps({
+  data: {
+    type: Object, // of type TooltipData
+    default: null
+  },
+  edges: {
+    type: Array, // of Date
+    required: true,
+  },
+  tickUnit: {
+    type: String,
+    default: 'hour'
+  },
+  unit: {
+    type: String,
+    default: undefined
+  }
+});
+const data = computed(() => /** @type {TooltipData} */ props.data);
+const edges = computed(() => /** @type {Date[]} */ props.edges);
+const tickUnit = toRef(props, 'tickUnit');
+const unit = toRef(props, 'unit');
+
+const visible = computed(() => data.value?.opacity > 0);
+const target = computed(() => {
+  const tt = data.value;
+  if (!tt) return [0, 0];
+  return [tt.x, tt.y];
+});
+const titleStr = computed(() => {
+  const tt = data.value;
+  if (!tt || tt.dataPoints.length === 0) return '';
+
+  // the tooltip title should match the tick label where possible.
+  // For short timeUnits (minutes, hours) we explicitly show the range to make it more obvious.
+  // For larger timeUnits this disambiguation isn't needed: Feb 10 or 2024 are clear enough
+  const formatStr = tt.displayFormats[tickUnit.value];
+  const index = tt.dataPoints[0].dataIndex;
+  switch (tickUnit.value) {
+    case 'minute':
+    case 'hour':
+      return `${format(edges.value[index], formatStr)}—${format(edges.value[index + 1], formatStr)}`
+    default:
+      return format(edges.value[index], formatStr);
+  }
+});
+
+const consumptionData = computed(() => {
+  const tt = data.value;
+  if (!tt) return null;
+  return tt.dataPoints.filter((dp) => !dp.dataset._inverted);
+})
+const productionData = computed(() => {
+  const tt = data.value;
+  if (!tt) return null;
+  return tt.dataPoints.filter((dp) => dp.dataset._inverted);
+})
+
+const consumptionRows = computed(() => {
+  return (consumptionData.value ?? []).map((dp) => {
+    return {
+      title: dp.dataset.label,
+      prependColor: dp.dataset.borderColor,
+      append: usageToString(dp.parsed.y, unit.value),
+    };
+  });
+});
+const productionRows = computed(() => {
+  return (productionData.value ?? []).map((dp) => {
+    return {
+      title: dp.dataset.label,
+      prependColor: dp.dataset.borderColor,
+      append: usageToString(-dp.parsed.y, unit.value),
+    };
+  });
+});
+
+const totalConsumptionRow = computed(() => {
+  const total = consumptionData.value?.reduce((acc, dp) => acc + dp.parsed.y, 0);
+  return {
+    title: 'Total Consumption',
+    append: usageToString(total, unit.value),
+  };
+});
+const totalProductionRow = computed(() => {
+  const total = productionData.value?.reduce((acc, dp) => acc + dp.parsed.y, 0);
+  return {
+    title: 'Total Production',
+    append: usageToString(-total, unit.value),
+  };
+});
+
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/ops/src/dynamic/widgets/energy/PeriodChooserRows.vue
+++ b/ui/ops/src/dynamic/widgets/energy/PeriodChooserRows.vue
@@ -1,0 +1,103 @@
+<template>
+  <v-list-item title="Range">
+    <template #append>
+      <v-btn-toggle
+          v-model="periodSelected"
+          variant="outlined"
+          density="compact"
+          divided
+          mandatory
+          class="ml-4">
+        <v-btn
+            v-for="item in periodSelections"
+            :key="item.text ?? item.icon"
+            :value="item"
+            :text="item.text"
+            :icon="item.icon"
+            size="small"
+            width="2.5rem"
+            min-width="auto"
+            class="px-0"
+            v-tooltip:bottom="item.tooltip"/>
+      </v-btn-toggle>
+    </template>
+  </v-list-item>
+  <v-list-item v-if="!periodSelectionIsDates" title="Offset">
+    <template #append>
+      <v-btn-toggle
+          mandatory v-model="offset"
+          variant="outlined" density="compact"
+          divided class="ml-4">
+        <v-btn :value="-1" size="small" text="Last" v-tooltip:bottom="'Show the previous period'"/>
+        <v-btn :value="0" size="small" text="Current Period" v-tooltip:bottom="'Show the current period'"/>
+      </v-btn-toggle>
+    </template>
+  </v-list-item>
+  <v-list-item v-if="periodSelectionIsDates">
+    <v-date-input
+        v-model="periodSelectedDates" multiple="range"
+        label="Custom date range" placeholder="from - to" persistent-placeholder
+        hide-details/>
+  </v-list-item>
+</template>
+
+<script setup>
+import {isNamedPeriod} from '@/composables/time.js';
+import {computed, ref, watch} from 'vue';
+import {VDateInput} from 'vuetify/labs/components';
+
+const start = defineModel('start', {type: [Date, String], required: true});
+const end = defineModel('end', {type: [Date, String], required: true});
+const offset = defineModel('offset', {type: Number, default: 0});
+
+// user editable date selection
+const propPeriod = computed(() => {
+  if (isNamedPeriod(start.value) && start.value === end.value) {
+    return start.value;
+  }
+  return undefined;
+})
+/**
+ * @typedef {Object} PeriodSelection
+ * @property {string} [text] - the text to display on the button
+ * @property {string} [value] - the value to set when selected
+ * @property {string} [icon] - the icon to display on the button
+ * @property {string} [tooltip] - the tooltip to display when hovering over the button
+ */
+
+/** @type {PeriodSelection[]} */
+const periodSelections = [
+  {text: 'D', value: 'day', tooltip: 'Day'},
+  {text: 'W', value: 'week', tooltip: 'Week'},
+  {text: 'M', value: 'month', tooltip: 'Month'},
+  {text: 'Y', value: 'year', tooltip: 'Year'},
+  {icon: 'mdi-calendar', tooltip: 'Custom date range'},
+];
+const periodSelected = ref(periodSelections[0]);
+watch(propPeriod, (period) => {
+  if (period) {
+    const selection = periodSelections.find((s) => s.value === period);
+    if (selection) {
+      periodSelected.value = selection;
+      return;
+    }
+  }
+  periodSelected.value = periodSelections[periodSelections.length - 1];
+}, {immediate: true});
+const periodSelectionIsDates = computed(() => !Object.hasOwn(periodSelected.value, 'value'));
+const periodSelectedDates = ref([]);
+watch([periodSelected, periodSelectedDates], ([period, dates]) => {
+  if (period.value) {
+    start.value = period.value;
+    end.value = period.value;
+    return;
+  }
+  if (dates.length === 0) return;
+  start.value = dates[0];
+  end.value = dates[dates.length - 1];
+})
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/ops/src/dynamic/widgets/energy/chart.js
+++ b/ui/ops/src/dynamic/widgets/energy/chart.js
@@ -1,0 +1,199 @@
+import {computed, ref, toValue} from 'vue';
+import * as colors from 'vuetify/util/colors';
+
+const toChartDataset = (title, consumption) => {
+  return {
+    label: title,
+    data: toValue(consumption).map((c) => c.y),
+  }
+}
+
+/**
+ * Creates a Chart.js dataset for each subValue and a remaining dataset for the total.
+ *
+ * @param {string} key - appended to titles to distinguish between different datasets, e.g. 'Consumption' or 'Production'
+ * @param {import('vue').MaybeRefOrGetter<{x:Date, y:number|null}[]>} totals
+ * @param {import('vue').MaybeRefOrGetter<(string|{name:string})[]>} subNames - specifies the order of the subValues
+ * @param {import('vue').Reactive<Record<string, SubConsumption>>} subValues
+ * @param {boolean} invert - if true, the dataset will be placed below the x-axis
+ * @return {import('chart.js').ChartDataSets[]}
+ */
+export function computeDatasets(key, totals, subNames, subValues, invert = false) {
+  const _subNames = toValue(subNames) ?? [];
+
+  const datasets = [];
+  const remaining = toChartDataset(_subNames.length === 0 ? `Total ${key}` : `Other ${key}`, totals);
+  if (_subNames.length > 0) {
+    // muted colours for the remaining dataset
+    remaining.backgroundColor = '#cccccc80';
+    remaining.borderColor = '#cccccc';
+  }
+  for (const name of _subNames) {
+    const subValue = subValues[name];
+    if (!subValue) continue;
+    const dataset = toChartDataset(toValue(subValue.title), subValue.consumption);
+    let hasAny = false;
+    for (let i = 0; i < dataset.data.length; i++) {
+      if (dataset.data[i] !== null) {
+        hasAny = true;
+        if (remaining.data[i] !== null) {
+          remaining.data[i] -= dataset.data[i];
+        }
+      }
+    }
+    if (!hasAny) continue;
+    datasets.push(dataset);
+  }
+
+  // get rid of negative remaining values
+  remaining.data = remaining.data.map((v) => v <= 0 ? null : v);
+  if (remaining.data.some((v) => v !== null)) {
+    datasets.push(remaining);
+  }
+
+  if (invert) {
+    // make all values negative so the bars appear below the x-axis
+    for (const dataset of datasets) {
+      dataset.data = dataset.data.map((v) => v === null ? null : -v);
+      dataset._inverted = true;
+    }
+  }
+
+  return datasets;
+}
+/**
+ * Helper to give type assistance to chart.js plugins.
+ *
+ * @template {import('chart.js').Plugin} T
+ * @param {T} plugin
+ * @return {T}
+ */
+export function definePlugin(plugin) {
+  return plugin;
+}
+
+/**
+ * Captures legend items using a Chart.js plugin.
+ *
+ * @return {{
+ *   legendItems: Ref<{
+ *     text: string,
+ *     hidden: boolean,
+ *     bgColor: string,
+ *     onClick: (e: MouseEvent) => void
+ *   }[]>,
+ *   vueLegendPlugin: import('chart.js').Plugin
+ * }}
+ */
+export function useVueLegendPlugin() {
+  const legendItems = ref([]);
+  return {
+    legendItems,
+    vueLegendPlugin: definePlugin({
+      id: 'vueLegend',
+      afterUpdate(chart) {
+        const items = chart.options.plugins.legend.labels.generateLabels(chart);
+        legendItems.value = items.map((item) => {
+          return {
+            text: item.text,
+            hidden: item.hidden,
+            bgColor: item.strokeStyle,
+            onClick: (e) => {
+              const {type} = chart.config;
+              if (type === 'pie' || type === 'doughnut') {
+                // Pie and doughnut charts only have a single dataset and visibility is per item
+                chart.setDatasetVisibility(item.index, e);
+              } else {
+                chart.setDatasetVisibility(item.datasetIndex, e);
+              }
+              chart.update();
+            }
+          };
+        });
+      }
+    })
+  }
+}
+
+/**
+ * Colours dataset based on the current theme.
+ *
+ * @return {{themeColorPlugin: import('chart.js').Plugin}}
+ */
+export function useThemeColorPlugin() {
+  const datasetColors = computed(() => {
+    return [
+      colors.blue.base,
+      colors.green.base,
+      colors.orange.base,
+      colors.yellow.base,
+      colors.red.base,
+    ].filter(Boolean);
+  });
+  return {
+    themeColorPlugin: definePlugin({
+      id: 'themeColor',
+      beforeLayout(chart) {
+        const colors = datasetColors.value;
+        let i = 0;
+        chart.data.datasets.forEach((dataset) => {
+          if (dataset.backgroundColor && !dataset._pluginColor) return;
+          const color = colors[i % colors.length];
+          i++;
+          dataset.backgroundColor = color + '80'; // 80 is 50% opacity
+          dataset.borderColor = color;
+          dataset._pluginColor = true;
+        });
+      }
+    })
+  }
+}
+
+
+/**
+ * @typedef {Object} TooltipData
+ * @property {number} x
+ * @property {number} y
+ * @property {number} opacity
+ * @property {import('chart.js').TooltipItem[]} dataPoints
+ * @property {Record<string,string>} displayFormats
+ */
+
+/**
+ * @typedef {function} ExternalFunc
+ * @this {import('chart.js').TooltipModel}
+ * @property {{
+ *   chart: import('chart.js').Chart,
+ *   tooltip: import('chart.js').TooltipModel
+ * }} args
+ * @return {void}
+ */
+
+/**
+ * Returns a function that can be used by chart.js tooltip.external and a ref containing the data.
+ *
+ * @return {{
+ *   data: import('vue').Ref<TooltipData | null>,
+ *   external: ExternalFunc
+ * }}
+ */
+export function useExternalTooltip() {
+  const data = ref(null);
+  return {
+    data,
+    external: (ctx) => {
+      if (!ctx.tooltip) {
+        data.value = null;
+        return;
+      }
+      const canvasBounds = ctx.chart.canvas.getBoundingClientRect();
+      data.value = {
+        x: ctx.tooltip.caretX + canvasBounds.left,
+        y: ctx.tooltip.caretY + canvasBounds.top,
+        opacity: ctx.tooltip.opacity,
+        dataPoints: ctx.tooltip.dataPoints,
+        displayFormats: ctx.chart.options.scales.x.time.displayFormats,
+      };
+    }
+  }
+}

--- a/ui/ops/src/dynamic/widgets/energy/consumption.js
+++ b/ui/ops/src/dynamic/widgets/energy/consumption.js
@@ -1,0 +1,90 @@
+import {usePullMetadata} from '@/traits/metadata/metadata.js';
+import {useMeterReadingsAt} from '@/traits/meter/meter.js';
+import {computed, effectScope, reactive, toValue, watch} from 'vue';
+
+/**
+ * Returns the consumption (diff between two readings) for each edge for the given name.
+ * The consumption at index i is the diff between the reading at edges[i] and edges[i+1].
+ *
+ * @param {import('vue').MaybeRefOrGetter<string>} name
+ * @param {import('vue').MaybeRefOrGetter<Date[]>} edges
+ * @return {import('vue').ComputedRef<{x:Date, y:number|null}[]>}
+ */
+export function useMeterConsumption(name, edges) {
+  const readings = useMeterReadingsAt(name, edges);
+  return computed(() => {
+    const res = [];
+    const _edges = toValue(edges);
+    const _readings = toValue(readings);
+    for (let i = 1; i < _edges.length; i++) {
+      const startEdge = _edges[i - 1];
+      const startReading = _readings[i - 1];
+      const endReading = _readings[i];
+      if (!startReading || !endReading) {
+        res.push({x: startEdge, y: null});
+        continue;
+      }
+      res.push({x: startEdge, y: endReading.usage - startReading.usage});
+    }
+    return res;
+  })
+}
+
+
+/**
+ * @typedef {Object} SubConsumption
+ * @property {import('vue').MaybeRefOrGetter<string>} title
+ * @property {import('vue').ComputedRef<{x:Date, y:number|null}[]>} consumption
+ * @property {function():void} stop
+ */
+/**
+ * @typedef {Object} ConfigSubName
+ * @property {string} name
+ * @property {string} [title]
+ */
+/**
+ * @param {import('vue').MaybeRefOrGetter<(string|ConfigSubName)[]>} names
+ * @param {import('vue').MaybeRefOrGetter<Date[]>} edges
+ * @return {import('vue').Reactive<Record<string, SubConsumption>>}
+ */
+export function useMetersConsumption(names, edges) {
+  const res = reactive({});
+  watch(() => toValue(names), (names) => {
+    const toStop = Object.fromEntries(Object.entries(res)); // clone
+    for (const item of names) {
+      let name = item;
+      let title = undefined;
+      if (typeof name === 'object') {
+        name = item.name;
+        title = item.title;
+      }
+      if (res[name]) {
+        delete toStop[name];
+        continue;
+      }
+      const scope = effectScope();
+      scope.run(() => {
+        const consumption = {consumption: useMeterConsumption(name, edges), stop: () => scope.stop()};
+        // use the configured title if possible, otherwise get it from the metadata, or just fall back to the name
+        if (title) {
+          consumption.title = title;
+        } else {
+          const {value: md} = usePullMetadata(name);
+          consumption.title = computed(() => {
+            const mdTitle = md.value?.appearance?.title;
+            if (mdTitle) return mdTitle;
+            return name;
+          })
+        }
+
+        res[name] = consumption;
+      });
+    }
+
+    for (const [name, {stop}] of Object.entries(toStop)) {
+      stop();
+      delete res[name];
+    }
+  }, {immediate: true});
+  return res;
+}

--- a/ui/ops/src/dynamic/widgets/energy/date.js
+++ b/ui/ops/src/dynamic/widgets/energy/date.js
@@ -1,0 +1,72 @@
+import {DAY, HOUR} from '@/components/now.js';
+import {isNamedPeriod, previousNamedPeriod, usePastDates, usePeriod} from '@/composables/time.js';
+import {
+  eachDayOfInterval,
+  eachHourOfInterval,
+  eachMinuteOfInterval,
+  eachMonthOfInterval,
+  eachYearOfInterval
+} from 'date-fns';
+import {computed, toValue} from 'vue';
+
+/**
+ * @param {import('vue').MaybeRefOrGetter<keyof useStartOf | string | number | Date>} start
+ * @param {import('vue').MaybeRefOrGetter<keyof useStartOf | string | number | Date>} end
+ * @param {import('vue').MaybeRefOrGetter<null | undefined | number | string>} offset
+ * @return {{
+ *   edges: import('vue').ComputedRef<Date[]>,
+ *   pastEdges: import('vue').ComputedRef<Date[]>,
+ *   tickUnit: import('vue').ComputedRef<string>,
+ *   startDate: import('vue').Ref<Date|null>,
+ *   endDate: import('vue').Ref<Date|null>
+ * }}
+ */
+export function useDateScale(start, end, offset) {
+  const {start: startDate, end: endDate} = usePeriod(start, end, offset);
+
+  // Returns a named period that should be used for calculating how many ticks between startDate and endDate we should use.
+  // For example, if start and end date encompass a single day, then the ticks should be in hours.
+  const tickUnit = computed(() => {
+    if (isNamedPeriod(toValue(start)) && toValue(start) === toValue(end)) {
+      return previousNamedPeriod[toValue(start)] ?? 'year';
+    }
+    const diff = endDate.value.getTime() - startDate.value.getTime();
+    if (diff <= 12 * HOUR) return 'minute';
+    if (diff <= 3 * DAY) return 'hour';
+    if (diff <= 2 * 30 * DAY) return 'day';
+    if (diff <= 5 * 365 * DAY) return 'month';
+    return 'year';
+  })
+
+  const edges = computed(() => {
+    const start = startDate.value;
+    const end = endDate.value;
+    if (!start || !end || start >= end) return [];
+
+    // we want to maintain no more than about 60 edges, so we increase the gaps between edges as the range increases
+    switch (tickUnit.value) {
+      case 'minute':
+        return eachMinuteOfInterval({start, end}, {step: 5});
+      case 'hour':
+        return eachHourOfInterval({start, end});
+      case 'day':
+        return eachDayOfInterval({start, end});
+      case 'month':
+        return eachMonthOfInterval({start, end});
+      case 'year':
+      default: {
+        const years = Math.ceil((end.getTime() - start.getTime()) / (365 * DAY));
+        return eachYearOfInterval({start, end}, {step: Math.ceil(years / 60)});
+      }
+    }
+  });
+
+  // work out which edges are in the past, these are the ones we want to fetch data for
+  const pastEdges = usePastDates(edges);
+
+  return {
+    edges, pastEdges,
+    tickUnit,
+    startDate, endDate
+  }
+}

--- a/ui/ops/src/dynamic/widgets/pallet.js
+++ b/ui/ops/src/dynamic/widgets/pallet.js
@@ -1,6 +1,7 @@
 import {defineAsyncComponent} from 'vue';
 
 export const builtinWidgets = {
+  'energy/EnergyHistoryCard': defineAsyncComponent(() => import('@/dynamic/widgets/energy/EnergyHistoryCard.vue')),
   'environmental/EnvironmentalCard': defineAsyncComponent(
       () => import('@/dynamic/widgets/environmental/EnvironmentalCard.vue')),
   'graphic/LayeredGraphic': defineAsyncComponent(() => import('@/dynamic/widgets/graphic/LayeredGraphic.vue')),

--- a/ui/ops/src/style.scss
+++ b/ui/ops/src/style.scss
@@ -12,6 +12,10 @@ p {
   margin-bottom: 16px;
 }
 
+.no-pointer-events {
+  pointer-events: none !important;
+}
+
 .v-text-field--outlined {
   background: var(--v-neutral-lighten1);
   border-color: var(--v-neutral-lighten2);

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2705,6 +2705,11 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+safe-timers@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-timers/-/safe-timers-1.1.0.tgz#c58ae8325db8d3b067322f0a4ef3a0cad67aad83"
+  integrity sha512-9aqY+v5eMvmRaluUEtdRThV1EjlSElzO7HuCj0sTW9xvp++8iJ9t/RWGNWV6/WHcUJLHpyT2SNf/apoKTU2EpA==
+
 sass@^1.77.4:
   version "1.81.0"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.81.0.tgz#a9010c0599867909dfdbad057e4a6fbdd5eec941"


### PR DESCRIPTION
The EnergyHistoryCard is a widget that shows stacked energy usage for a number of sources, intended to break down (for example) a building by floors to give a broader overview of energy use where ancestry is known.

This change also updates the ConsumptionCard widget as additional time utils have been written that this component can make use of.

I've added the chart to a new dashboard page for the ugs example so it should be easy to test with.

![image](https://github.com/user-attachments/assets/7d634e36-32d1-4e2c-a182-d4d3c765166a)

![image](https://github.com/user-attachments/assets/5b644105-5a95-4027-a245-f2a03f765372)

![image](https://github.com/user-attachments/assets/6ed2c7c4-08f6-4c54-b98e-3391e8e9816f)

![image](https://github.com/user-attachments/assets/8daa3529-59c3-4957-b52f-71ed370d929f)

![image](https://github.com/user-attachments/assets/fda16a2e-75b3-40f7-af69-4df5b331e1a7)

**Known Issues/Additions**

1. The chart is a little jumpy as data is loaded into it. This could be solved with a loading indicator of some kind but I feel like that can be added as a future change
2. There's no way to download the data in the chart. I intend for this to download all meter data over the selected range, rather than just the consumption you see in the charts. This requires updates to the history download feature to support a list of device names instead of a query object.
3. The chart can perform a lot of requests at the same time: num sources * edges (bars + 1) * 2, for a day showing 5 floors that would be 5 * 25 * 2 = 250 requests to the server. When testing locally this seems to be fine but as a future addition we might want to revisit how dashboard data is computed, cached, and delivered to the ui
4. If meter readings decrease things can get a little strange. While this shouldn't happen frequently on site, it's still something that could cause strange data for a short period. I'm not sure what the correct solution is for this so am treating it as _fix it when it happens_.
5. I would like to add a _compare to previous_ option so you can compare energy use between today and yesterday, or this month and last month (for example). This would double the requests but not increase other resource usage significantly (I believe). I think this can be added as a future addition though.
6. I would prefer weekly views to show Mon, Tue, Wed instead of 5th, 6th, 7th but this turned out to be harder to do that I was willing to spend. We can add it as a future addition.
7. When the x-axis crosses a period boundary (3rd-4th or 2024-2025, etc) I would prefer a tick that shows this crossing. Instead the current chart just shows 20:00, 23:00, 2:00, 5:00. Again this ended up being harder than I anticipated so am pushing this to a future addition. If a tick _happens_ to be rendered at this boundary it does the expected thing: 20:00, 22:00, 3rd Mar, 2:00, 4:00, etc
