### PR TITLE
ui/ops: reorder and reword the main menu

### DIFF
--- a/ui/ops/src/components/AppMenu.vue
+++ b/ui/ops/src/components/AppMenu.vue
@@ -39,24 +39,23 @@ const showMenu = ref(false);
 
 const menuItems = [
   {
-    title: 'Auth',
-    subtitle: 'Edit user accounts, and create API tokens',
-    icon: 'mdi-key',
-    link: {name: 'auth'}
-  },
-  {
-    title: 'Devices',
-    subtitle:
-        'Add/update/delete devices from the system, view device\'s status and configuration, ' +
-        'and control device settings',
-    icon: 'mdi-devices',
-    link: {name: 'devices'}
-  },
-  {
     title: 'Operations',
     subtitle: 'View status dashboards, check notifications and events',
     icon: 'mdi-bell-ring',
     link: {name: 'ops'}
+  },
+  {
+    title: 'Devices',
+    subtitle:
+        'View all devices, check status, and control settings',
+    icon: 'mdi-devices',
+    link: {name: 'devices'}
+  },
+  {
+    title: 'Access Management',
+    subtitle: 'Manage user accounts, and create API tokens',
+    icon: 'mdi-key',
+    link: {name: 'auth'}
   },
   {
     title: 'Workflows & Automations',


### PR DESCRIPTION
Remove wording for things you can't do (like creating devices) and rename Auto to Access Management

Now looks like this

![image](https://github.com/user-attachments/assets/158565e4-93b6-449f-a9a1-bae0674f1df6)
