### PR TITLE
Implement a modbus driver that doesn't support conversion to trait values (yet)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/eclipse/paho.mqtt.golang v1.4.2
 	github.com/go-jose/go-jose/v4 v4.0.5
+	github.com/goburrow/modbus v0.1.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/renameio/v2 v2.0.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
@@ -58,6 +59,7 @@ require (
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/goburrow/serial v0.1.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,10 @@ github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/goburrow/modbus v0.1.0 h1:DejRZY73nEM6+bt5JSP6IsFolJ9dVcqxsYbpLbeW/ro=
+github.com/goburrow/modbus v0.1.0/go.mod h1:Kx552D5rLIS8E7TyUwQ/UdHEqvX5T8tyiGBTlzMcZBg=
+github.com/goburrow/serial v0.1.0 h1:v2T1SQa/dlUqQiYIT8+Cu7YolfqAi3K96UmhwYyuSrA=
+github.com/goburrow/serial v0.1.0/go.mod h1:sAiqG0nRVswsm1C97xsttiYCzSLBmUZ/VSlVLZJ8haA=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=

--- a/pkg/driver/alldrivers/factory.go
+++ b/pkg/driver/alldrivers/factory.go
@@ -5,6 +5,7 @@ import (
 	"github.com/vanti-dev/sc-bos/pkg/driver/airthings"
 	"github.com/vanti-dev/sc-bos/pkg/driver/bacnet"
 	"github.com/vanti-dev/sc-bos/pkg/driver/mock"
+	"github.com/vanti-dev/sc-bos/pkg/driver/modbusip"
 	"github.com/vanti-dev/sc-bos/pkg/driver/pestsense"
 	"github.com/vanti-dev/sc-bos/pkg/driver/proxy"
 	seWiserKnx "github.com/vanti-dev/sc-bos/pkg/driver/se/wiser-knx"
@@ -19,6 +20,7 @@ func Factories() map[string]driver.Factory {
 		airthings.DriverName:  airthings.Factory,
 		bacnet.DriverName:     bacnet.Factory,
 		mock.DriverName:       mock.Factory,
+		modbusip.DriverName:   modbusip.Factory,
 		pestsense.DriverName:  pestsense.Factory,
 		proxy.DriverName:      proxy.Factory,
 		seWiserKnx.DriverName: seWiserKnx.Factory,

--- a/pkg/driver/modbusip/client.go
+++ b/pkg/driver/modbusip/client.go
@@ -1,0 +1,304 @@
+package modbusip
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/goburrow/modbus"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+	"github.com/smart-core-os/sc-golang/pkg/trait"
+	"github.com/vanti-dev/sc-bos/pkg/driver/modbusip/config"
+	"github.com/vanti-dev/sc-bos/pkg/gen"
+	"github.com/vanti-dev/sc-bos/pkg/gentrait/statuspb"
+)
+
+type Client struct {
+	cli modbus.Client
+
+	handler Handle
+
+	traits.UnimplementedEnergyStorageApiServer
+	traits.UnimplementedEmergencyApiServer
+	gen.UnimplementedStatusApiServer
+
+	logger *zap.Logger
+
+	fuel      *resource.Value
+	faults    *resource.Value
+	emergency *resource.Value
+
+	group  *errgroup.Group
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+type Handle interface {
+	io.Closer
+	Connect() error
+	modbus.ClientHandler
+}
+
+func NewClient(ctx context.Context, handler Handle) *Client {
+	cli := modbus.NewClient(handler)
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	group, ctx := errgroup.WithContext(ctx)
+
+	return &Client{
+		cli:     cli,
+		handler: handler,
+
+		group:  group,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+func (c *Client) Connect(pdu config.PDUAddress, resourceType string, address, quantity uint16) error {
+	err := c.handler.Connect()
+
+	if err != nil {
+		return err
+	}
+
+	switch resourceType {
+	case fuel:
+		c.fuel = resource.NewValue(resource.WithNoDuplicates())
+	case faults:
+		c.faults = resource.NewValue(resource.WithNoDuplicates())
+	case monitor:
+		c.emergency = resource.NewValue(resource.WithNoDuplicates())
+	default:
+		return fmt.Errorf("unknown resource type %s", resourceType)
+	}
+
+	// TODO: the below calculations and bit ops should really be configurable based on the device
+	// TODO: but we don't have much information about how the modbus registers correspond to trait values
+	// TODO: so this is approximated (or hardcoded) for now
+	c.group.Go(func() error {
+		throttle := time.NewTicker(time.Second)
+
+		for {
+			select {
+			case <-throttle.C:
+				var value uint16
+				switch pdu {
+				case config.HoldingRegister:
+					res, err := c.cli.ReadHoldingRegisters(address, quantity)
+
+					if err != nil {
+						c.logger.Error("reading holding registers", zap.Error(err))
+						continue
+					}
+
+					if res == nil || len(res) == 0 {
+						return fmt.Errorf("invalid holding registers response")
+					}
+
+					value = uint16(res[0])<<8 | uint16(res[1]) // big endian
+				case config.Coil:
+					res, err := c.cli.ReadCoils(address, quantity)
+
+					if err != nil {
+						c.logger.Error("reading coils", zap.Error(err))
+						continue
+					}
+
+					if res == nil || len(res) == 0 {
+						return fmt.Errorf("invalid coils response")
+					}
+
+					value = uint16(res[0])
+				case config.InputRegister:
+					res, err := c.cli.ReadInputRegisters(address, quantity)
+
+					if err != nil {
+						c.logger.Error("reading input registers", zap.Error(err))
+						continue
+					}
+
+					if res == nil || len(res) == 0 {
+						return fmt.Errorf("invalid input registers response")
+					}
+
+					value = uint16(res[0])<<8 | uint16(res[1]) // big endian
+				case config.DiscreteInput:
+					res, err := c.cli.ReadDiscreteInputs(address, quantity)
+
+					if err != nil {
+						c.logger.Error("reading discrete inputs", zap.Error(err))
+						continue
+					}
+
+					if res == nil || len(res) == 0 {
+						return fmt.Errorf("invalid discrete inputs response")
+					}
+
+					value = uint16(res[0])
+				}
+
+				switch resourceType {
+				case fuel:
+					if _, err := c.fuel.Set(&traits.EnergyLevel{
+						Quantity: &traits.EnergyLevel_Quantity{
+							Percentage: float32(value),
+						},
+					}); err != nil {
+						c.logger.Error("setting fuel", zap.Error(err))
+						continue
+					}
+				case faults:
+					if _, err := c.faults.Set(&gen.StatusLog{
+						Level: gen.StatusLog_NOMINAL,
+					}); err != nil {
+						c.logger.Error("setting faults", zap.Error(err))
+						continue
+					}
+				case monitor:
+					if _, err := c.emergency.Set(&traits.Emergency{
+						Level: traits.Emergency_OK,
+					}); err != nil {
+						c.logger.Error("setting monitor", zap.Error(err))
+						continue
+					}
+				}
+			case <-c.ctx.Done():
+				return c.ctx.Err()
+			}
+		}
+	})
+
+	return nil
+}
+
+func (c *Client) Close() error {
+	defer c.cancel()
+	return c.handler.Close()
+}
+
+const (
+	fuel    = "fuel"
+	faults  = "faults"
+	monitor = "monitor"
+)
+
+func (c *Client) GetEmergency(_ context.Context, request *traits.GetEmergencyRequest) (*traits.Emergency, error) {
+	if c.emergency == nil {
+		return nil, status.Errorf(codes.Unimplemented, "%s not implemented", trait.Emergency)
+	}
+	return c.emergency.Get(resource.WithReadMask(request.GetReadMask())).(*traits.Emergency), nil
+}
+
+func (c *Client) UpdateEmergency(_ context.Context, _ *traits.UpdateEmergencyRequest) (*traits.Emergency, error) {
+	return nil, status.Error(codes.Unimplemented, "update emergency not implemented")
+}
+
+func (c *Client) PullEmergency(request *traits.PullEmergencyRequest, server traits.EmergencyApi_PullEmergencyServer) error {
+	if c.emergency == nil {
+		return status.Errorf(codes.Unimplemented, "%s not implemented", trait.Emergency)
+	}
+
+	changes := c.faults.Pull(server.Context(), resource.WithReadMask(request.GetReadMask()))
+
+	for {
+		select {
+		case change := <-changes:
+			if err := server.Send(&traits.PullEmergencyResponse{
+				Changes: []*traits.PullEmergencyResponse_Change{
+					{
+						Name:       request.GetName(),
+						ChangeTime: timestamppb.New(change.ChangeTime),
+						Emergency:  change.Value.(*traits.Emergency),
+					},
+				},
+			}); err != nil {
+				return err
+			}
+		case <-server.Context().Done():
+			return server.Context().Err()
+		}
+	}
+}
+
+func (c *Client) GetCurrentStatus(_ context.Context, request *gen.GetCurrentStatusRequest) (*gen.StatusLog, error) {
+	if c.faults == nil {
+		return nil, status.Errorf(codes.Unimplemented, "%s not implemented", statuspb.TraitName)
+	}
+
+	return c.faults.Get(resource.WithReadMask(request.GetReadMask())).(*gen.StatusLog), nil
+}
+
+func (c *Client) PullCurrentStatus(request *gen.PullCurrentStatusRequest, server gen.StatusApi_PullCurrentStatusServer) error {
+	if c.faults == nil {
+		return status.Errorf(codes.Unimplemented, "%s not implemented", statuspb.TraitName)
+	}
+
+	changes := c.faults.Pull(server.Context(), resource.WithReadMask(request.GetReadMask()))
+
+	for {
+		select {
+		case <-server.Context().Done():
+			return server.Context().Err()
+		case change := <-changes:
+			if err := server.Send(&gen.PullCurrentStatusResponse{
+				Changes: []*gen.PullCurrentStatusResponse_Change{
+					{
+						Name:          request.GetName(),
+						ChangeTime:    timestamppb.New(change.ChangeTime),
+						CurrentStatus: change.Value.(*gen.StatusLog),
+					},
+				}}); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (c *Client) GetEnergyLevel(_ context.Context, request *traits.GetEnergyLevelRequest) (*traits.EnergyLevel, error) {
+	if c.fuel == nil {
+		return nil, status.Errorf(codes.Unimplemented, "%s not implemented", trait.EnergyStorage)
+	}
+
+	return c.fuel.Get(resource.WithReadMask(request.GetReadMask())).(*traits.EnergyLevel), nil
+}
+
+func (c *Client) PullEnergyLevel(request *traits.PullEnergyLevelRequest, server traits.EnergyStorageApi_PullEnergyLevelServer) error {
+	if c.fuel == nil {
+		return status.Errorf(codes.Unimplemented, "%s not implemented", trait.EnergyStorage)
+	}
+
+	changes := c.fuel.Pull(server.Context(), resource.WithReadMask(request.GetReadMask()))
+
+	for {
+		select {
+		case <-server.Context().Done():
+			return server.Context().Err()
+		case change := <-changes:
+			if err := server.Send(&traits.PullEnergyLevelResponse{
+				Changes: []*traits.PullEnergyLevelResponse_Change{
+					{
+						Name:        request.GetName(),
+						ChangeTime:  timestamppb.New(change.ChangeTime),
+						EnergyLevel: change.Value.(*traits.EnergyLevel),
+					},
+				},
+			}); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (c *Client) Charge(_ context.Context, _ *traits.ChargeRequest) (*traits.ChargeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "charge not implemented")
+}

--- a/pkg/driver/modbusip/client.go
+++ b/pkg/driver/modbusip/client.go
@@ -64,7 +64,7 @@ func NewClient(ctx context.Context, handler Handle) *Client {
 	}
 }
 
-func (c *Client) Connect(pdu config.PDUAddress, resourceType string, address, quantity uint16) error {
+func (c *Client) Connect(pdu config.PDUAddress, resourceType string, address, quantity uint16, interval time.Duration) error {
 	err := c.handler.Connect()
 
 	if err != nil {
@@ -86,7 +86,7 @@ func (c *Client) Connect(pdu config.PDUAddress, resourceType string, address, qu
 	// TODO: but we don't have much information about how the modbus registers correspond to trait values
 	// TODO: so this is approximated (or hardcoded) for now
 	c.group.Go(func() error {
-		throttle := time.NewTicker(time.Second)
+		throttle := time.NewTicker(interval)
 
 		for {
 			select {

--- a/pkg/driver/modbusip/config/root.go
+++ b/pkg/driver/modbusip/config/root.go
@@ -69,6 +69,8 @@ type DeviceTrait struct {
 	Address uint16 `json:"address"`
 	// quantity of the device trait
 	Quantity uint16 `json:"quantity"`
+	// interval to poll the device trait
+	PollInterval *jsontypes.Duration `json:"pollInterval"`
 }
 
 type PDUAddress int

--- a/pkg/driver/modbusip/config/root.go
+++ b/pkg/driver/modbusip/config/root.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/trait"
+	"github.com/vanti-dev/sc-bos/pkg/driver"
+	"github.com/vanti-dev/sc-bos/pkg/util/jsontypes"
+)
+
+type Root struct {
+	driver.BaseConfig
+	// smart core name prefix to bind the supported traits to
+	ScNamePrefix string `json:"scNamePrefix"`
+	// devices to be controlled by the modbus driver
+	Devices []Device `json:"devices"`
+}
+
+type TCPHandler struct {
+	// IP or hostname address of the modbus over IP device
+	Address string `json:"address"`
+	// port number of the modbus over IP device
+	Port int `json:"port"`
+	// timeout for the client to wait for
+	Timeout *jsontypes.Duration `json:"timeout"`
+	// slave id of the modbus over IP device
+	SlaveId byte `json:"slaveId"`
+}
+
+type RTUHandler struct {
+	// IP or hostname address of the modbus over IP device
+	Address string `json:"address"`
+	// timeout for the client to wait for
+	Timeout *jsontypes.Duration `json:"timeout"`
+	// Baud rate (default 19200)
+	BaudRate int `json:"baudRate"`
+	// Data bits: 5, 6, 7 or 8 (default 8)
+	DataBits int `json:"dataBits"`
+	// Stop bits: 1 or 2 (default 1)
+	StopBits int `json:"stopBits"`
+	// Parity: N - None, E - Even, O - Odd (default E)
+	// (The use of no parity requires 2 stop bits.)
+	Parity string `json:"parity"`
+	// slave id of the modbus over IP device
+	SlaveId byte `json:"slaveId"`
+}
+
+type Device struct {
+	// unique name of the device (smart core name suffix)
+	Name string `json:"name"`
+	// tcp handler for the modbus over IP device
+	TcpHandle *TCPHandler `json:"tcpHandle,omitempty"`
+	// rtu handler for the modbus over IP device
+	RTUHandle *RTUHandler `json:"rtuHandle,omitempty"`
+	// traits this device supports
+	Traits []DeviceTrait `json:"traits"`
+	// meta data
+	Metadata *traits.Metadata `json:"metadata,omitempty"`
+}
+
+type DeviceTrait struct {
+	// smart core name of trait
+	Name trait.Name `json:"name"`
+	// where the device trait sits in side the modbus memory heap
+	PDU *PDUAddress `json:"pdu"`
+	// the address of the device trait
+	Address uint16 `json:"address"`
+	// quantity of the device trait
+	Quantity uint16 `json:"quantity"`
+}
+
+type PDUAddress int
+
+const (
+	DiscreteInput PDUAddress = iota
+	Coil
+	InputRegister
+	HoldingRegister
+)
+
+var (
+	pduAddress = map[PDUAddress]string{
+		DiscreteInput:   "DiscreteInput",
+		Coil:            "Coil",
+		InputRegister:   "InputRegister",
+		HoldingRegister: "HoldingRegister",
+	}
+
+	addressPdu = map[string]PDUAddress{
+		"DiscreteInput":   DiscreteInput,
+		"Coil":            Coil,
+		"InputRegister":   InputRegister,
+		"HoldingRegister": HoldingRegister,
+	}
+)
+
+func (p *PDUAddress) MarshalJSON() ([]byte, error) {
+	if str, ok := pduAddress[*p]; ok {
+		return json.Marshal(str)
+	}
+
+	return nil, fmt.Errorf("%d pdu address is not valid", p)
+}
+
+func (p *PDUAddress) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+
+	if pdu, ok := addressPdu[str]; ok {
+		*p = pdu
+		return nil
+	}
+
+	return fmt.Errorf("%s pdu address is not valid", str)
+}

--- a/pkg/driver/modbusip/driver.go
+++ b/pkg/driver/modbusip/driver.go
@@ -23,7 +23,8 @@ import (
 const (
 	DriverName = "modbus"
 
-	defaultTimeout = 5 * time.Second
+	defaultTimeout      = 5 * time.Second
+	defaultPollInterval = 30 * time.Second
 )
 
 type factory struct{}
@@ -98,7 +99,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 				)
 
 				// connect the client
-				if err := client.Connect(*deviceTrait.PDU, fuel, deviceTrait.Address, deviceTrait.Quantity); err != nil {
+				if err := client.Connect(*deviceTrait.PDU, fuel, deviceTrait.Address, deviceTrait.Quantity, deviceTrait.PollInterval.Or(defaultPollInterval)); err != nil {
 					d.logger.Error("connecting client", zap.String("device", device.Name), zap.Error(err))
 				}
 				continue
@@ -115,7 +116,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 				)
 
 				// connect the client
-				if err := client.Connect(*deviceTrait.PDU, faults, deviceTrait.Address, deviceTrait.Quantity); err != nil {
+				if err := client.Connect(*deviceTrait.PDU, faults, deviceTrait.Address, deviceTrait.Quantity, deviceTrait.PollInterval.Or(defaultPollInterval)); err != nil {
 					d.logger.Error("connecting client", zap.String("device", device.Name), zap.Error(err))
 				}
 				continue
@@ -132,7 +133,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 				)
 
 				// connect the client
-				if err := client.Connect(*deviceTrait.PDU, monitor, deviceTrait.Address, deviceTrait.Quantity); err != nil {
+				if err := client.Connect(*deviceTrait.PDU, monitor, deviceTrait.Address, deviceTrait.Quantity, deviceTrait.PollInterval.Or(defaultPollInterval)); err != nil {
 					d.logger.Error("connecting client", zap.String("device", device.Name), zap.Error(err))
 				}
 				continue

--- a/pkg/driver/modbusip/driver.go
+++ b/pkg/driver/modbusip/driver.go
@@ -1,0 +1,160 @@
+package modbusip
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/smart-core-os/sc-golang/pkg/trait"
+	"github.com/smart-core-os/sc-golang/pkg/trait/emergencypb"
+	"github.com/smart-core-os/sc-golang/pkg/trait/energystoragepb"
+	"github.com/vanti-dev/sc-bos/pkg/driver"
+	"github.com/vanti-dev/sc-bos/pkg/driver/modbusip/config"
+	"github.com/vanti-dev/sc-bos/pkg/gen"
+	"github.com/vanti-dev/sc-bos/pkg/gentrait/statuspb"
+	"github.com/vanti-dev/sc-bos/pkg/node"
+	"github.com/vanti-dev/sc-bos/pkg/task/service"
+)
+
+const (
+	DriverName = "modbus"
+
+	defaultTimeout = 5 * time.Second
+)
+
+type factory struct{}
+
+var Factory driver.Factory = factory{}
+
+func (f factory) New(services driver.Services) service.Lifecycle {
+	d := &Driver{logger: services.Logger.Named(DriverName)}
+
+	d.Service = service.New(
+		service.MonoApply(d.applyConfig),
+		service.WithRetry[config.Root](service.RetryWithLogger(func(logCtx service.RetryContext) {
+			logCtx.LogTo("applyConfig", d.logger)
+		})),
+		service.WithOnStop[config.Root](d.Clean),
+	)
+	d.node = services.Node
+
+	return d
+}
+
+type Driver struct {
+	*service.Service[config.Root]
+	node   node.Announcer
+	logger *zap.Logger
+
+	clients sync.Map
+}
+
+func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
+	announcer := node.NewReplaceAnnouncer(d.node).Replace(ctx)
+
+	for _, device := range cfg.Devices {
+		var client *Client
+		if device.TcpHandle != nil {
+			handler := NewTCPClientHandler(
+				fmt.Sprintf("%s:%d", device.TcpHandle.Address, device.TcpHandle.Port),
+				WithTCPTimeout(device.TcpHandle.Timeout.Or(defaultTimeout)),
+				WithTCPSlaveId(device.TcpHandle.SlaveId),
+				WithTCPLogger(d.logger.Named(device.Name)),
+			)
+			client = NewClient(ctx, handler)
+		}
+
+		if device.RTUHandle != nil {
+			handler := NewRTUClientHandler(
+				device.RTUHandle.Address,
+				WithRTUBaudRate(device.RTUHandle.BaudRate),
+				WithRTUDataBits(device.RTUHandle.DataBits),
+				WithRTUStopBits(device.RTUHandle.StopBits),
+				WithRTUParity(device.RTUHandle.Parity),
+				WithRTUTimeout(device.RTUHandle.Timeout.Or(defaultTimeout)),
+				WithRTUSlaveId(device.RTUHandle.SlaveId),
+				WithRTULogger(d.logger.Named(device.Name)),
+			)
+			client = NewClient(ctx, handler)
+		}
+
+		if client == nil {
+			continue
+		}
+
+		for _, deviceTrait := range device.Traits {
+			if deviceTrait.Name == trait.EnergyStorage {
+				fuelName, err := url.JoinPath(cfg.ScNamePrefix, device.Name, fuel)
+				if err != nil {
+					return err
+				}
+				announcer.Announce(fuelName,
+					node.HasTrait(trait.EnergyStorage, node.WithClients(energystoragepb.WrapApi(client))),
+					node.HasMetadata(device.Metadata),
+				)
+
+				// connect the client
+				if err := client.Connect(*deviceTrait.PDU, fuel, deviceTrait.Address, deviceTrait.Quantity); err != nil {
+					d.logger.Error("connecting client", zap.String("device", device.Name), zap.Error(err))
+				}
+				continue
+			}
+
+			if deviceTrait.Name == trait.Emergency {
+				faultsName, err := url.JoinPath(cfg.ScNamePrefix, device.Name, faults)
+				if err != nil {
+					return err
+				}
+				announcer.Announce(faultsName,
+					node.HasTrait(trait.Emergency, node.WithClients(emergencypb.WrapApi(client))),
+					node.HasMetadata(device.Metadata),
+				)
+
+				// connect the client
+				if err := client.Connect(*deviceTrait.PDU, faults, deviceTrait.Address, deviceTrait.Quantity); err != nil {
+					d.logger.Error("connecting client", zap.String("device", device.Name), zap.Error(err))
+				}
+				continue
+			}
+
+			if deviceTrait.Name == statuspb.TraitName {
+				monitorName, err := url.JoinPath(cfg.ScNamePrefix, device.Name, monitor)
+				if err != nil {
+					return err
+				}
+				announcer.Announce(monitorName,
+					node.HasTrait(statuspb.TraitName, node.WithClients(gen.WrapStatusApi(client))),
+					node.HasMetadata(device.Metadata),
+				)
+
+				// connect the client
+				if err := client.Connect(*deviceTrait.PDU, monitor, deviceTrait.Address, deviceTrait.Quantity); err != nil {
+					d.logger.Error("connecting client", zap.String("device", device.Name), zap.Error(err))
+				}
+				continue
+			}
+		}
+
+		d.clients.Store(device.Name, client)
+
+	}
+
+	return nil
+}
+
+func (d *Driver) Clean() {
+	d.clients.Range(func(key, value any) bool {
+		client := value.(*Client)
+		if err := client.Close(); err != nil {
+			d.logger.Error("failed to close client", zap.Error(err))
+			return true
+		}
+		// remove the client
+		d.clients.Delete(key)
+		return true
+	})
+}

--- a/pkg/driver/modbusip/rtu_handler.go
+++ b/pkg/driver/modbusip/rtu_handler.go
@@ -1,0 +1,78 @@
+package modbusip
+
+import (
+	"time"
+
+	"github.com/goburrow/modbus"
+	"go.uber.org/zap"
+)
+
+type RtuHandler struct {
+	Handle
+}
+
+func NewRTUClientHandler(address string, opts ...RTUOption) *RtuHandler {
+	handler := modbus.NewRTUClientHandler(address)
+
+	for _, opt := range opts {
+		opt(handler)
+	}
+
+	return &RtuHandler{handler}
+}
+
+type RTUOption func(*modbus.RTUClientHandler)
+
+func (r *RtuHandler) Connect() error {
+	return r.Connect()
+}
+
+func (r *RtuHandler) Close() error {
+	return r.Close()
+}
+
+func WithRTUBaudRate(baudRate int) RTUOption {
+	return func(handler *modbus.RTUClientHandler) {
+		handler.BaudRate = baudRate
+	}
+}
+
+func WithRTUDataBits(dataBits int) RTUOption {
+	return func(handler *modbus.RTUClientHandler) {
+		handler.DataBits = dataBits
+	}
+}
+
+func WithRTUStopBits(stopBits int) RTUOption {
+	return func(handler *modbus.RTUClientHandler) {
+		handler.StopBits = stopBits
+	}
+}
+
+func WithRTUParity(parity string) RTUOption {
+	return func(handler *modbus.RTUClientHandler) {
+		handler.Parity = parity
+	}
+}
+
+func WithRTUTimeout(timeout time.Duration) RTUOption {
+	return func(handler *modbus.RTUClientHandler) {
+		handler.Timeout = timeout
+	}
+}
+func WithRTUSlaveId(slaveId byte) RTUOption {
+	return func(handler *modbus.RTUClientHandler) {
+		handler.SlaveId = slaveId
+	}
+}
+
+func WithRTULogger(l *zap.Logger) RTUOption {
+	return func(handler *modbus.RTUClientHandler) {
+		var err error
+		handler.Logger, err = zap.NewStdLogAt(l, zap.DebugLevel)
+
+		if err != nil {
+			l.Error("modbus rtu logger init failed", zap.Error(err))
+		}
+	}
+}

--- a/pkg/driver/modbusip/tcp_handler.go
+++ b/pkg/driver/modbusip/tcp_handler.go
@@ -1,0 +1,57 @@
+package modbusip
+
+import (
+	"time"
+
+	"github.com/goburrow/modbus"
+	"go.uber.org/zap"
+)
+
+type TcpHandler struct {
+	Handle
+}
+
+func NewTCPClientHandler(address string, opts ...TCPOption) *TcpHandler {
+	handler := modbus.NewTCPClientHandler(address)
+
+	for _, opt := range opts {
+		opt(handler)
+	}
+
+	return &TcpHandler{handler}
+}
+
+// Connect the handler to the address supplied
+func (t *TcpHandler) Connect() error {
+	return t.Connect()
+}
+
+// Close  when done using the handler
+func (t *TcpHandler) Close() error {
+	return t.Close()
+}
+
+type TCPOption func(*modbus.TCPClientHandler)
+
+func WithTCPTimeout(timeout time.Duration) TCPOption {
+	return func(handler *modbus.TCPClientHandler) {
+		handler.Timeout = timeout
+	}
+}
+
+func WithTCPSlaveId(slaveId byte) TCPOption {
+	return func(handler *modbus.TCPClientHandler) {
+		handler.SlaveId = slaveId
+	}
+}
+
+func WithTCPLogger(l *zap.Logger) TCPOption {
+	return func(handler *modbus.TCPClientHandler) {
+		var err error
+		handler.Logger, err = zap.NewStdLogAt(l, zap.DebugLevel)
+
+		if err != nil {
+			l.Error("modbus tcp logger init failed", zap.Error(err))
+		}
+	}
+}


### PR DESCRIPTION
The modbus driver allows:
 - defining many devices each with their own connection type and connection (IP or serial)
 - each device connection can implement: status, emergency and energyStorage traits
 - clean up after tear down
 - configurable poll intervals