### PR TITLE
SC-1056: Fix ListRoles error when Role has no permissions

### DIFF
--- a/internal/account/convert.go
+++ b/internal/account/convert.go
@@ -84,5 +84,8 @@ func roleAssignmentToProto(assignment queries.RoleAssignment) *gen.RoleAssignmen
 
 // in SQL queries that return a list of permissions per row, they are joined comma-separated
 func splitPermissions(permissions string) []string {
+	if permissions == "" {
+		return nil
+	}
 	return strings.Split(permissions, ",")
 }

--- a/internal/account/queries/queries.sql
+++ b/internal/account/queries/queries.sql
@@ -101,7 +101,7 @@ SELECT COUNT(*) AS count
 FROM roles;
 
 -- name: ListRolesAndPermissions :many
-SELECT sqlc.embed(roles), group_concat(role_permissions.permission, ',') AS permissions
+SELECT sqlc.embed(roles), group_concat(coalesce(role_permissions.permission, ''), ',') AS permissions
 FROM roles
 LEFT OUTER JOIN role_permissions ON roles.id = role_permissions.role_id
 WHERE roles.id > :after_id

--- a/internal/account/queries/queries.sql.go
+++ b/internal/account/queries/queries.sql.go
@@ -703,7 +703,7 @@ func (q *Queries) ListRoles(ctx context.Context, arg ListRolesParams) ([]Role, e
 }
 
 const listRolesAndPermissions = `-- name: ListRolesAndPermissions :many
-SELECT roles.id, roles.display_name, roles.description, group_concat(role_permissions.permission, ',') AS permissions
+SELECT roles.id, roles.display_name, roles.description, group_concat(coalesce(role_permissions.permission, ''), ',') AS permissions
 FROM roles
 LEFT OUTER JOIN role_permissions ON roles.id = role_permissions.role_id
 WHERE roles.id > ?1

--- a/internal/account/server.go
+++ b/internal/account/server.go
@@ -607,8 +607,7 @@ func (s *Server) ListRoles(ctx context.Context, req *gen.ListRolesRequest) (*gen
 		}
 
 		for _, role := range page {
-			permissions := splitPermissions(role.Permissions)
-			res.Roles = append(res.Roles, roleToProto(role.Role, permissions))
+			res.Roles = append(res.Roles, roleToProto(role.Role, role.PermissionIDs))
 		}
 
 		return nil

--- a/internal/account/server_test.go
+++ b/internal/account/server_test.go
@@ -1525,6 +1525,7 @@ func TestServer_Role(t *testing.T) {
 	t.Log("CreateRole:")
 	for i := range numRoles {
 		displayName := fmt.Sprintf("Role %d", i)
+		numPermissions := i % numPermissions // test roles with different numbers of permissions
 		role, err := server.CreateRole(ctx, &gen.CreateRoleRequest{
 			Role: &gen.Role{
 				DisplayName: displayName,

--- a/internal/account/store.go
+++ b/internal/account/store.go
@@ -165,6 +165,27 @@ func (tx *Tx) GenerateServiceCredential(ctx context.Context, create queries.Serv
 	}, nil
 }
 
+func (tx *Tx) ListRolesAndPermissions(ctx context.Context, params queries.ListRolesAndPermissionsParams) ([]RoleAndPermissions, error) {
+	data, err := tx.Queries.ListRolesAndPermissions(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	roleAndPermissions := make([]RoleAndPermissions, len(data))
+	for i, d := range data {
+		roleAndPermissions[i] = RoleAndPermissions{
+			Role:          d.Role,
+			PermissionIDs: splitPermissions(d.Permissions),
+		}
+	}
+	return roleAndPermissions, nil
+}
+
+type RoleAndPermissions struct {
+	Role          queries.Role
+	PermissionIDs []string
+}
+
 type GeneratedServiceCredential struct {
 	queries.ServiceCredential
 	Secret string


### PR DESCRIPTION
When ListRoles encounters a Role with an empty permissions list, an internal error is returned.

Expected behavior is to return the Role with an empty permissions list.

Also fix bug with incorrect error code being returned by CreateRole and UpdateRole when the supplied `display_name` for create/update conflicts with an existing role.