### PR TITLE
auto/exporthttp: use correct meter list for water job

### DIFF
--- a/pkg/auto/exporthttp/job/job.go
+++ b/pkg/auto/exporthttp/job/job.go
@@ -174,7 +174,7 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 				Ticker: time.NewTicker(interval),
 				Logger: logger,
 			},
-			Meters:     cfg.Sources.Energy.Meters,
+			Meters:     cfg.Sources.Water.Meters,
 			Interval:   interval,
 			client:     gen.NewMeterHistoryClient(node.ClientConn()),
 			infoClient: gen.NewMeterInfoClient(node.ClientConn()),


### PR DESCRIPTION
I just noticed I was using the `energy` meter list for `water` reporting.