### PR TITLE
ui/ops: fix useCollection race

### DIFF
--- a/ui/ops/src/composables/action.js
+++ b/ui/ops/src/composables/action.js
@@ -1,0 +1,64 @@
+import {newActionTracker} from '@/api/resource.js';
+import {reactive, ref, toRefs, toValue, watch} from 'vue';
+
+/**
+ * @typedef {import('@/api/resource.js').ActionTracker<Res>} UseActionResponse
+ * @property {function(): void} refresh - re-executes the action in the background
+ * @template Res
+ */
+
+/**
+ * Calls action whenever request changes, returning a reactive tracker to monitor the action.
+ * If request is null or undefined, the action is not called and the trackers response is reset.
+ * If request changes frequently, only the latest request is processed.
+ *
+ * @param {import('vue').MaybeRefOrGetter<Partial<Req> | null | undefined>} request
+ * @param {function(Req, ActionTracker<Res>): Promise<Res>} action
+ * @return {ToRefs<UnwrapNestedRefs<UseActionResponse<Res>>>}
+ * @template Req
+ * @template Res
+ */
+export function useAction(request, action) {
+  const tracker = reactive(/** @type {ActionTracker<Res>} */ newActionTracker());
+
+  // What follows is a race safe way to perform requests whenever request changes.
+  // We queue up tasks (calls to action) and only process the latest one.
+  const activeTask = ref(null); // the task we are awaiting
+  const nextTask = ref(null); // our queue, except we only care about the tip
+  watch(() => toValue(request), (request) => {
+    nextTask.value = {request};
+  }, {immediate: true});
+  watch(nextTask, (task) => {
+    if (!task) return; // break the loop
+    if (activeTask.value) {
+      // todo: cancel active request, grpc doesn't let us do this yet
+      return;
+    }
+    activeTask.value = task;
+    nextTask.value = null;
+  }, {immediate: true});
+  watch(activeTask, async (task) => {
+    if (!task) return; // break the loop
+    try {
+      const {request} = task;
+      if (!request) {
+        tracker.response = null;
+        activeTask.value = null;
+        return;
+      }
+
+      await action(request, tracker);
+    } finally {
+      const next = nextTask.value;
+      nextTask.value = null;
+      activeTask.value = next;
+    }
+  }, {immediate: true});
+
+  return {
+    ...toRefs(tracker),
+    refresh() {
+      nextTask.value = {request: toValue(request)};
+    }
+  };
+}

--- a/ui/ops/src/composables/collection.js
+++ b/ui/ops/src/composables/collection.js
@@ -44,6 +44,7 @@ import {computed, onScopeDispose, reactive, ref, toValue, watch} from 'vue';
  * @property {Ref<boolean>} loading
  * @property {Ref<boolean>} loadingNextPage
  * @property {Ref<ResourceError[]>} errors
+ * @property {function(): void} refresh
  */
 
 /**
@@ -163,6 +164,15 @@ export default function useCollection(request, client, options) {
     lastListResponse.value = pageResponse;
 
     unprocessedChanges.value.push(...pageResponse.items.map(v => ({newValue: v})));
+  }
+
+  /**
+   * Force the collection to refresh, clearing all items and listing items again from page 1.
+   */
+  function refresh() {
+    items.value = [];
+    lastListResponse.value = null;
+    unprocessedChanges.value = [];
   }
 
   /**
@@ -307,6 +317,8 @@ export default function useCollection(request, client, options) {
     loading,
     loadingNextPage,
     errors,
+
+    refresh,
 
     _listTracker: listTracker,
     _pullResource: pullResource


### PR DESCRIPTION
These changes combine to fix the race we have in useCollection that causes rapid request changes to show old results.

The fix comes in the form of a new `useAction` utility that _correctly_ handles the request change vs async request race and converting the list part of useCollection to use this utility. Future changes will make use of `useAction` too, which is why it's been factored out.

While the refresh func isn't required for this fix, it is part of a wider change for which this fix has been extracted. The change was small enough that I thought it better to include it here than to create dependent PRs. Especially as the code changes once the actual fix lands.

Fixes SC-985