### PR TITLE
SC-1059: allow multiple role assignments for same account & role

### DIFF
--- a/internal/account/migrations/0002_multiple_scopes.sql
+++ b/internal/account/migrations/0002_multiple_scopes.sql
@@ -1,0 +1,3 @@
+DROP INDEX role_assignments_unique;
+-- nulls are considered distinct in unique indices, so we need to use coalesce to treat them as equal
+CREATE UNIQUE INDEX role_assignments_unique ON role_assignments (account_id, role_id, coalesce(scope_resource, ''), coalesce(scope_type, ''));

--- a/internal/account/server_test.go
+++ b/internal/account/server_test.go
@@ -2359,7 +2359,7 @@ func TestServer_CreateRoleAssignment(t *testing.T) {
 			},
 			code: codes.InvalidArgument,
 		},
-		"conflict": {
+		"scoped_and_unscoped": {
 			existing: []*gen.RoleAssignment{
 				{
 					AccountId: accountPlaceholder,
@@ -2371,8 +2371,92 @@ func TestServer_CreateRoleAssignment(t *testing.T) {
 					AccountId: accountPlaceholder,
 					RoleId:    rolePlaceholder,
 					Scope: &gen.RoleAssignment_Scope{
+						ResourceType: gen.RoleAssignment_NODE,
+						Resource:     "node1",
+					},
+				},
+			},
+			code: codes.OK,
+		},
+		"different_scope_types": {
+			existing: []*gen.RoleAssignment{
+				{
+					AccountId: accountPlaceholder,
+					RoleId:    rolePlaceholder,
+					Scope: &gen.RoleAssignment_Scope{
 						ResourceType: gen.RoleAssignment_NAMED_RESOURCE,
-						Resource:     "resource name",
+						Resource:     "name1",
+					},
+				},
+			},
+			req: &gen.CreateRoleAssignmentRequest{
+				RoleAssignment: &gen.RoleAssignment{
+					AccountId: accountPlaceholder,
+					RoleId:    rolePlaceholder,
+					Scope: &gen.RoleAssignment_Scope{
+						ResourceType: gen.RoleAssignment_NODE,
+						Resource:     "node1",
+					},
+				},
+			},
+			code: codes.OK,
+		},
+		"different_scope_resources": {
+			existing: []*gen.RoleAssignment{
+				{
+					AccountId: accountPlaceholder,
+					RoleId:    rolePlaceholder,
+					Scope: &gen.RoleAssignment_Scope{
+						ResourceType: gen.RoleAssignment_NODE,
+						Resource:     "node1",
+					},
+				},
+			},
+			req: &gen.CreateRoleAssignmentRequest{
+				RoleAssignment: &gen.RoleAssignment{
+					AccountId: accountPlaceholder,
+					RoleId:    rolePlaceholder,
+					Scope: &gen.RoleAssignment_Scope{
+						ResourceType: gen.RoleAssignment_NODE,
+						Resource:     "node2",
+					},
+				},
+			},
+			code: codes.OK,
+		},
+		"conflict_unscoped": {
+			existing: []*gen.RoleAssignment{
+				{
+					AccountId: accountPlaceholder,
+					RoleId:    rolePlaceholder,
+				},
+			},
+			req: &gen.CreateRoleAssignmentRequest{
+				RoleAssignment: &gen.RoleAssignment{
+					AccountId: accountPlaceholder,
+					RoleId:    rolePlaceholder,
+				},
+			},
+			code: codes.AlreadyExists,
+		},
+		"conflict_scoped": {
+			existing: []*gen.RoleAssignment{
+				{
+					AccountId: accountPlaceholder,
+					RoleId:    rolePlaceholder,
+					Scope: &gen.RoleAssignment_Scope{
+						ResourceType: gen.RoleAssignment_NAMED_RESOURCE,
+						Resource:     "resource1",
+					},
+				},
+			},
+			req: &gen.CreateRoleAssignmentRequest{
+				RoleAssignment: &gen.RoleAssignment{
+					AccountId: accountPlaceholder,
+					RoleId:    rolePlaceholder,
+					Scope: &gen.RoleAssignment_Scope{
+						ResourceType: gen.RoleAssignment_NAMED_RESOURCE,
+						Resource:     "resource1",
 					},
 				},
 			},


### PR DESCRIPTION
By the original design, a role can only be assigned to an account once. However, this prevents joining multiple scopes of the same role. This prevents us from migrating away from the Tenant API, which supports this use case.

Loosen the uniqueness constraint, so that only completely identical role assignments (same account, role & scope) are prohibited.