### PR TITLE
auto/exporthttp: swap to cron schedules instead of time intervals

### DIFF
--- a/cmd/tools/test-exporthttp/main.go
+++ b/cmd/tools/test-exporthttp/main.go
@@ -83,7 +83,7 @@ func main() {
 	}()
 
 	// wait for all automations in exporthttp to finish
-	time.Sleep(15 * time.Second)
+	time.Sleep(3 * time.Minute)
 }
 
 const (
@@ -101,27 +101,27 @@ const (
   "sources": {
 	"occupancy":    {
 	  "path": "occupancy",
-	  "interval": "10s",
+	  "schedule": "0/1 * * * *",
 	  "sensors":  ["pir/01","pir/02","pir/03"]
 	},
 	"temperature": {
 	  "path": "temperature",
-	  "interval": "11s",
+	  "schedule": "0/2 * * * *",
 	  "sensors": ["FCU/01","FCU/02"]
 	},
 	"energy":       {
 	  "path": "energy",
-	  "interval": "10s",
+	  "schedule": "0/1 * * * *",
 	  "meters": ["smart-core/meters/01"]
 	},
 	"airQuality":  {
 	  "path": "air_quality",
-	  "interval": "10s",
+	  "schedule": "0/1 * * * *",
 	  "sensors": ["smart-core/iaq/01"]
 	},
 	"water": {
 	  "path": "water",
-	  "interval": "10s",
+	  "schedule": "0/1 * * * *",
 	  "meters" : ["smart-core/meters/03"]
 	}
   }

--- a/cmd/tools/test-exporthttp/sensors.go
+++ b/cmd/tools/test-exporthttp/sensors.go
@@ -13,7 +13,7 @@ import (
 
 func announceOccupancy(root node.Announcer, name string, val int32) error {
 	model := occupancysensorpb.NewModel()
-	_, err := model.SetOccupancy(&traits.Occupancy{PeopleCount: val})
+	_, err := model.SetOccupancy(&traits.Occupancy{PeopleCount: val, Confidence: 1})
 	if err != nil {
 		return err
 	}

--- a/pkg/auto/exporthttp/config/root.go
+++ b/pkg/auto/exporthttp/config/root.go
@@ -34,8 +34,8 @@ type Authentication struct {
 }
 
 type Source struct {
-	Path     string             `json:"path"`
-	Interval jsontypes.Duration `json:"interval"`
+	Path     string              `json:"path"`
+	Schedule *jsontypes.Schedule `json:"schedule"`
 }
 
 type Occupancy struct {

--- a/pkg/auto/exporthttp/job/job.go
+++ b/pkg/auto/exporthttp/job/job.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vanti-dev/sc-bos/pkg/auto/exporthttp/config"
 	"github.com/vanti-dev/sc-bos/pkg/gen"
 	"github.com/vanti-dev/sc-bos/pkg/node"
+	"github.com/vanti-dev/sc-bos/pkg/util/jsontypes"
 )
 
 var (
@@ -27,15 +28,14 @@ var (
 	errNoSensorsRetrieved = errors.New("no sensors retrieved")
 )
 
-// Job represents a WordPress automation task that executes Do to send a POST request
+// Job represents an exporthttp automation task that executes Do to send a POST request
 type Job interface {
 	GetName() string
 	GetUrl() string
 	GetSite() string
-	GetTicker() *time.Ticker
+	GetExecutionAfter(t time.Time) <-chan time.Time
 
 	Do(ctx context.Context, sendFn sender) error
-	Stop()
 }
 
 type sender func(ctx context.Context, url string, body []byte) error
@@ -43,7 +43,7 @@ type sender func(ctx context.Context, url string, body []byte) error
 // Mulpx for multiple Job easy chan fan-in
 type Mulpx struct {
 	C     chan Job
-	group errgroup.Group
+	group *errgroup.Group
 }
 
 func (m *Mulpx) WaitForDone() {
@@ -53,26 +53,29 @@ func (m *Mulpx) WaitForDone() {
 }
 
 // Multiplex receives multiple jobs and fans all the jobs into a single chan
-func Multiplex(jobs ...Job) *Mulpx {
+func Multiplex(ctx context.Context, jobs ...Job) *Mulpx {
+	group, ctx := errgroup.WithContext(ctx)
+
 	out := &Mulpx{
-		C: make(chan Job),
-		// no need to listen to parent thread's context
-		// as there should already be a listener for context.Done in the parent
-		group: errgroup.Group{},
+		C:     make(chan Job, len(jobs)),
+		group: group,
 	}
 
 	for _, job := range jobs {
 		j := job
 
 		out.group.Go(func() error {
-			// trigger after boot up so we export some values immediately
 			out.C <- j
-
-			for range j.GetTicker().C {
-				out.C <- j
+			current := time.Now().UTC()
+			for {
+				select {
+				case currentExecTime := <-j.GetExecutionAfter(current):
+					out.C <- j
+					current = currentExecTime
+				case <-ctx.Done():
+					return ctx.Err()
+				}
 			}
-
-			return nil
 		})
 	}
 
@@ -81,26 +84,27 @@ func Multiplex(jobs ...Job) *Mulpx {
 
 // BaseJob shared fields
 type BaseJob struct {
-	Url    string
-	Ticker *time.Ticker
-	Site   string
-	Logger *zap.Logger
+	Url               string
+	Schedule          *jsontypes.Schedule
+	PreviousExecution time.Time
+	Site              string
+	Logger            *zap.Logger
 }
 
 func (b *BaseJob) GetUrl() string {
 	return b.Url
 }
 
-func (b *BaseJob) GetTicker() *time.Ticker {
-	return b.Ticker
+func (b *BaseJob) GetExecutionAfter(t time.Time) <-chan time.Time {
+	if t.IsZero() {
+		t = time.Now().UTC()
+	}
+	b.PreviousExecution = t
+	return time.After(time.Until(b.Schedule.Next(t)))
 }
 
 func (b *BaseJob) GetSite() string {
 	return b.Site
-}
-
-func (b *BaseJob) Stop() {
-	b.Ticker.Stop()
 }
 
 func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
@@ -109,10 +113,10 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 	if cfg.Sources.Occupancy != nil && len(cfg.Sources.Occupancy.Sensors) > 0 {
 		occ := &OccupancyJob{
 			BaseJob: BaseJob{
-				Site:   cfg.Site,
-				Url:    fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Occupancy.Path),
-				Ticker: time.NewTicker(cfg.Sources.Occupancy.Interval.Or(time.Minute)),
-				Logger: logger,
+				Site:     cfg.Site,
+				Url:      fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Occupancy.Path),
+				Schedule: cfg.Sources.Occupancy.Schedule,
+				Logger:   logger,
 			},
 			Sensors: cfg.Sources.Occupancy.Sensors,
 			client:  traits.NewOccupancySensorApiClient(node.ClientConn()),
@@ -123,10 +127,10 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 	if cfg.Sources.Temperature != nil && len(cfg.Sources.Temperature.Sensors) > 0 {
 		temperature := &TemperatureJob{
 			BaseJob: BaseJob{
-				Site:   cfg.Site,
-				Url:    fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Temperature.Path),
-				Ticker: time.NewTicker(cfg.Sources.Temperature.Interval.Or(time.Minute)),
-				Logger: logger,
+				Site:     cfg.Site,
+				Url:      fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Temperature.Path),
+				Schedule: cfg.Sources.Temperature.Schedule,
+				Logger:   logger,
 			},
 			Sensors: cfg.Sources.Temperature.Sensors,
 			client:  traits.NewAirTemperatureApiClient(node.ClientConn()),
@@ -135,16 +139,14 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 		jobs = append(jobs, temperature)
 	}
 	if cfg.Sources.Energy != nil && len(cfg.Sources.Energy.Meters) > 0 {
-		interval := cfg.Sources.Energy.Interval.Or(24 * time.Hour)
 		energy := &EnergyJob{
 			BaseJob: BaseJob{
-				Site:   cfg.Site,
-				Url:    fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Energy.Path),
-				Ticker: time.NewTicker(interval),
-				Logger: logger,
+				Site:     cfg.Site,
+				Url:      fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Energy.Path),
+				Schedule: cfg.Sources.Energy.Schedule,
+				Logger:   logger,
 			},
 			Meters:     cfg.Sources.Energy.Meters,
-			Interval:   interval,
 			client:     gen.NewMeterHistoryClient(node.ClientConn()),
 			infoClient: gen.NewMeterInfoClient(node.ClientConn()),
 		}
@@ -154,10 +156,10 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 	if cfg.Sources.AirQuality != nil && len(cfg.Sources.AirQuality.Sensors) > 0 {
 		air := &AirQualityJob{
 			BaseJob: BaseJob{
-				Site:   cfg.Site,
-				Url:    fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.AirQuality.Path),
-				Ticker: time.NewTicker(cfg.Sources.AirQuality.Interval.Or(time.Minute)),
-				Logger: logger,
+				Site:     cfg.Site,
+				Url:      fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.AirQuality.Path),
+				Schedule: cfg.Sources.AirQuality.Schedule,
+				Logger:   logger,
 			},
 			Sensors: cfg.Sources.AirQuality.Sensors,
 			client:  traits.NewAirQualitySensorApiClient(node.ClientConn()),
@@ -166,16 +168,14 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 		jobs = append(jobs, air)
 	}
 	if cfg.Sources.Water != nil && len(cfg.Sources.Water.Meters) > 0 {
-		interval := cfg.Sources.Water.Interval.Or(24 * time.Hour)
 		water := &WaterJob{
 			BaseJob: BaseJob{
-				Site:   cfg.Site,
-				Url:    fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Water.Path),
-				Ticker: time.NewTicker(interval),
-				Logger: logger,
+				Site:     cfg.Site,
+				Url:      fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Water.Path),
+				Schedule: cfg.Sources.Water.Schedule,
+				Logger:   logger,
 			},
 			Meters:     cfg.Sources.Water.Meters,
-			Interval:   interval,
 			client:     gen.NewMeterHistoryClient(node.ClientConn()),
 			infoClient: gen.NewMeterInfoClient(node.ClientConn()),
 		}

--- a/pkg/auto/exporthttp/job/job.go
+++ b/pkg/auto/exporthttp/job/job.go
@@ -110,13 +110,16 @@ func (b *BaseJob) GetSite() string {
 func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 	var jobs []Job
 
+	now := time.Now().UTC()
+
 	if cfg.Sources.Occupancy != nil && len(cfg.Sources.Occupancy.Sensors) > 0 {
 		occ := &OccupancyJob{
 			BaseJob: BaseJob{
-				Site:     cfg.Site,
-				Url:      fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Occupancy.Path),
-				Schedule: cfg.Sources.Occupancy.Schedule,
-				Logger:   logger,
+				Site:              cfg.Site,
+				Url:               fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Occupancy.Path),
+				Schedule:          cfg.Sources.Occupancy.Schedule,
+				Logger:            logger,
+				PreviousExecution: now,
 			},
 			Sensors: cfg.Sources.Occupancy.Sensors,
 			client:  traits.NewOccupancySensorApiClient(node.ClientConn()),
@@ -127,10 +130,11 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 	if cfg.Sources.Temperature != nil && len(cfg.Sources.Temperature.Sensors) > 0 {
 		temperature := &TemperatureJob{
 			BaseJob: BaseJob{
-				Site:     cfg.Site,
-				Url:      fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Temperature.Path),
-				Schedule: cfg.Sources.Temperature.Schedule,
-				Logger:   logger,
+				Site:              cfg.Site,
+				Url:               fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Temperature.Path),
+				Schedule:          cfg.Sources.Temperature.Schedule,
+				PreviousExecution: now,
+				Logger:            logger,
 			},
 			Sensors: cfg.Sources.Temperature.Sensors,
 			client:  traits.NewAirTemperatureApiClient(node.ClientConn()),
@@ -141,10 +145,11 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 	if cfg.Sources.Energy != nil && len(cfg.Sources.Energy.Meters) > 0 {
 		energy := &EnergyJob{
 			BaseJob: BaseJob{
-				Site:     cfg.Site,
-				Url:      fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Energy.Path),
-				Schedule: cfg.Sources.Energy.Schedule,
-				Logger:   logger,
+				Site:              cfg.Site,
+				Url:               fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Energy.Path),
+				Schedule:          cfg.Sources.Energy.Schedule,
+				PreviousExecution: now,
+				Logger:            logger,
 			},
 			Meters:     cfg.Sources.Energy.Meters,
 			client:     gen.NewMeterHistoryClient(node.ClientConn()),
@@ -156,10 +161,11 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 	if cfg.Sources.AirQuality != nil && len(cfg.Sources.AirQuality.Sensors) > 0 {
 		air := &AirQualityJob{
 			BaseJob: BaseJob{
-				Site:     cfg.Site,
-				Url:      fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.AirQuality.Path),
-				Schedule: cfg.Sources.AirQuality.Schedule,
-				Logger:   logger,
+				Site:              cfg.Site,
+				Url:               fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.AirQuality.Path),
+				Schedule:          cfg.Sources.AirQuality.Schedule,
+				PreviousExecution: now,
+				Logger:            logger,
 			},
 			Sensors: cfg.Sources.AirQuality.Sensors,
 			client:  traits.NewAirQualitySensorApiClient(node.ClientConn()),
@@ -170,10 +176,11 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 	if cfg.Sources.Water != nil && len(cfg.Sources.Water.Meters) > 0 {
 		water := &WaterJob{
 			BaseJob: BaseJob{
-				Site:     cfg.Site,
-				Url:      fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Water.Path),
-				Schedule: cfg.Sources.Water.Schedule,
-				Logger:   logger,
+				Site:              cfg.Site,
+				Url:               fmt.Sprintf("%s/%s", cfg.BaseUrl, cfg.Sources.Water.Path),
+				Schedule:          cfg.Sources.Water.Schedule,
+				PreviousExecution: now,
+				Logger:            logger,
 			},
 			Meters:     cfg.Sources.Water.Meters,
 			client:     gen.NewMeterHistoryClient(node.ClientConn()),

--- a/pkg/auto/exporthttp/job/occupancy.go
+++ b/pkg/auto/exporthttp/job/occupancy.go
@@ -38,7 +38,7 @@ func (o *OccupancyJob) Do(ctx context.Context, sendFn sender) error {
 		}
 
 		// confidence value semantics can vary between driver implementations
-		// 0.2 can be a bad threshold. We will assume it isn't for WordPress
+		// 0.2 can be a bad threshold. We will assume it isn't for exporthttp
 		if resp.GetConfidence() > 0.2 {
 			hasCounted = true
 			sum += resp.GetPeopleCount()


### PR DESCRIPTION
Since time intervals may keep resetting if the controllers are restarted, using cron schedules is a more reliable way to ensure "at least 1 execution per schedule". Intervals are reset multiple times before the subsequent execution schedule meaning the automation reporting is unreliable.

I have also buffered the job chan in case an execution takes longer than the smallest unit schedule interval - by executing the job in a go-routine and buffering the multiplexed job chan, we can ensure executions which are scheduled around the same time execute concurrently.