### PR TITLE
ui/ops: add account management pages

### DIFF
--- a/example/config/vanti-ugs/app.conf.json
+++ b/example/config/vanti-ugs/app.conf.json
@@ -1,5 +1,10 @@
 {
   "name": "van/uk/brum/ugs/eg-ac-01",
+  "metadata": {
+    "appearance": {
+      "title": "Vanti UGS 01"
+    }
+  },
   "drivers": [
     {
       "name": "van/uk/brum/ugs/eg-ac-01/driver/basement",

--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -2,7 +2,8 @@
   "features": {
     "auth": {
       "third-party": true,
-      "accounts": true
+      "accounts": true,
+      "roles": true
     },
     "device": true,
     "devices": true,

--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -1,7 +1,8 @@
 {
   "features": {
     "auth": {
-      "third-party": true
+      "third-party": true,
+      "accounts": true
     },
     "device": true,
     "devices": true,

--- a/ui/ops/src/api/ui/account.js
+++ b/ui/ops/src/api/ui/account.js
@@ -247,9 +247,9 @@ export function createRoleAssignment(request, tracker = {}) {
 }
 
 /**
- * @param {Partial<DeleteRoleRequest.AsObject>} request
- * @param {ActionTracker<DeleteRoleResponse.AsObject>} [tracker]
- * @return {Promise<DeleteRoleResponse.AsObject>}
+ * @param {Partial<DeleteRoleAssignmentRequest.AsObject>} request
+ * @param {ActionTracker<DeleteRoleAssignmentResponse.AsObject>} [tracker]
+ * @return {Promise<DeleteRoleAssignmentResponse.AsObject>}
  */
 export function deleteRoleAssignment(request, tracker = {}) {
   return trackAction('Account.deleteRoleAssignment', tracker, endpoint => {

--- a/ui/ops/src/api/ui/account.js
+++ b/ui/ops/src/api/ui/account.js
@@ -618,3 +618,14 @@ function getAccountLimitsRequestFromObject(obj) {
   setProperties(dst, obj, 'name');
   return dst;
 }
+
+/**
+ * A map from RoleAssignment.ResourceType to the enum name, the inverse of RoleAssignment.ResourceType.
+ *
+ * @type {Record<number, keyof RoleAssignment.ResourceType>}
+ */
+export const ResourceTypeById =
+    Object.entries(RoleAssignment.ResourceType).reduce((acc, [k, v]) => {
+      acc[v] = k;
+      return acc;
+    }, {});

--- a/ui/ops/src/api/ui/account.js
+++ b/ui/ops/src/api/ui/account.js
@@ -7,27 +7,25 @@ import {
   CreateAccountRequest,
   CreateRoleAssignmentRequest,
   CreateRoleRequest,
-  CreateServiceCredentialRequest,
   DeleteAccountRequest,
   DeleteRoleRequest,
-  DeleteServiceCredentialRequest,
   GetAccountLimitsRequest,
   GetAccountRequest,
   GetPermissionRequest,
   GetRoleAssignmentRequest,
   GetRoleRequest,
-  GetServiceCredentialRequest,
   ListAccountsRequest,
   ListPermissionsRequest,
   ListRoleAssignmentsRequest,
   ListRolesRequest,
-  ListServiceCredentialsRequest,
   Role,
   RoleAssignment,
-  ServiceCredential,
+  RotateAccountClientSecretRequest,
+  ServiceAccount,
   UpdateAccountPasswordRequest,
   UpdateAccountRequest,
-  UpdateRoleRequest
+  UpdateRoleRequest,
+  UserAccount
 } from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
 
 /**
@@ -103,50 +101,14 @@ export function updateAccountPassword(request, tracker = {}) {
 }
 
 /**
- * @param {Partial<GetServiceCredentialRequest.AsObject>} request
- * @param {ActionTracker<ServiceCredential.AsObject>} [tracker]
- * @return {Promise<ServiceCredential.AsObject>}
+ * @param {Partial<RotateAccountClientSecretRequest.AsObject>} request
+ * @param {ActionTracker<RotateAccountClientSecretResponse.AsObject>} [tracker]
+ * @return {Promise<RotateAccountClientSecretResponse.AsObject>}
  */
-export function getServiceCredential(request, tracker = {}) {
-  return trackAction('Account.getServiceCredential', tracker, endpoint => {
+export function rotateAccountClientSecret(request, tracker = {}) {
+  return trackAction('Account.rotateAccountClientSecret', tracker, endpoint => {
     const api = apiClient(endpoint);
-    return api.getServiceCredential(getServiceCredentialRequestFromObject(request));
-  });
-}
-
-/**
- * @param {Partial<ListServiceCredentialsRequest.AsObject>} request
- * @param {ActionTracker<ListServiceCredentialsResponse.AsObject>} [tracker]
- * @return {Promise<ListServiceCredentialsResponse.AsObject>}
- */
-export function listServiceCredentials(request, tracker = {}) {
-  return trackAction('Account.listServiceCredentials', tracker, endpoint => {
-    const api = apiClient(endpoint);
-    return api.listServiceCredentials(listServiceCredentialsRequestFromObject(request));
-  });
-}
-
-/**
- * @param {Partial<CreateServiceCredentialRequest.AsObject>} request
- * @param {ActionTracker<ServiceCredential.AsObject>} [tracker]
- * @return {Promise<ServiceCredential.AsObject>}
- */
-export function createServiceCredential(request, tracker = {}) {
-  return trackAction('Account.createServiceCredential', tracker, endpoint => {
-    const api = apiClient(endpoint);
-    return api.createServiceCredential(createServiceCredentialRequestFromObject(request));
-  });
-}
-
-/**
- * @param {Partial<DeleteServiceCredentialRequest.AsObject>} request
- * @param {ActionTracker<DeleteServiceCredentialResponse.AsObject>} [tracker]
- * @return {Promise<DeleteServiceCredentialResponse.AsObject>}
- */
-export function deleteServiceCredential(request, tracker = {}) {
-  return trackAction('Account.deleteServiceCredential', tracker, endpoint => {
-    const api = apiClient(endpoint);
-    return api.deleteServiceCredential(deleteServiceCredentialRequestFromObject(request));
+    return api.rotateAccountClientSecret(rotateAccountClientSecretRequestFromObject(request));
   });
 }
 
@@ -380,71 +342,51 @@ function updateAccountPasswordRequestFromObject(obj) {
 }
 
 /**
+ * @param {Partial<RotateAccountClientSecretRequest.AsObject>} obj
+ * @return {undefined|RotateAccountClientSecretRequest}
+ */
+function rotateAccountClientSecretRequestFromObject(obj) {
+  if (!obj) return undefined;
+  const dst = new RotateAccountClientSecretRequest();
+  setProperties(dst, obj, 'name', 'id');
+  convertProperties(dst, obj, timestampFromObject, 'previousSecretExpireTime');
+  return dst;
+}
+
+/**
  * @param {Partial<Account.AsObject>} obj
  * @return {undefined|Account}
  */
 function accountFromObject(obj) {
   if (!obj) return undefined;
   const dst = new Account();
-  setProperties(dst, obj, 'id', 'type', 'displayName', 'description', 'username');
+  setProperties(dst, obj, 'id', 'type', 'displayName', 'description');
   convertProperties(dst, obj, timestampFromObject, 'createTime');
+  dst.setUserDetails(userAccountFromObject(obj.userDetails));
+  dst.setServiceDetails(serviceAccountFromObject(obj.serviceDetails));
   return dst;
 }
 
 /**
- * @param {Partial<GetServiceCredentialRequest.AsObject>} obj
- * @return {undefined|GetServiceCredentialRequest}
+ * @param {Partial<UserAccount.AsObject>} obj
+ * @return {undefined|UserAccount}
  */
-function getServiceCredentialRequestFromObject(obj) {
+function userAccountFromObject(obj) {
   if (!obj) return undefined;
-  const dst = new GetServiceCredentialRequest();
-  setProperties(dst, obj, 'name', 'id');
+  const dst = new UserAccount();
+  setProperties(dst, obj, 'username', 'has_password');
   return dst;
 }
 
 /**
- * @param {Partial<ListServiceCredentialsRequest.AsObject>} obj
- * @return {undefined|ListServiceCredentialsRequest}
+ * @param {Partial<ServiceAccount.AsObject>} obj
+ * @return {undefined|ServiceAccount}
  */
-function listServiceCredentialsRequestFromObject(obj) {
+function serviceAccountFromObject(obj) {
   if (!obj) return undefined;
-  const dst = new ListServiceCredentialsRequest();
-  setProperties(dst, obj, 'name', 'accountId');
-  return dst;
-}
-
-/**
- * @param {Partial<CreateServiceCredentialRequest.AsObject>} obj
- * @return {undefined|CreateServiceCredentialRequest}
- */
-function createServiceCredentialRequestFromObject(obj) {
-  if (!obj) return undefined;
-  const dst = new CreateServiceCredentialRequest();
-  setProperties(dst, obj, 'name');
-  dst.setServiceCredential(serviceCredentialFromObject(obj.serviceCredential));
-  return dst;
-}
-
-/**
- * @param {Partial<DeleteServiceCredentialRequest.AsObject>} obj
- * @return {undefined|DeleteServiceCredentialRequest}
- */
-function deleteServiceCredentialRequestFromObject(obj) {
-  if (!obj) return undefined;
-  const dst = new DeleteServiceCredentialRequest();
-  setProperties(dst, obj, 'name', 'id', 'allowMissing');
-  return dst;
-}
-
-/**
- * @param {Partial<ServiceCredential.AsObject>} obj
- * @return {undefined|ServiceCredential}
- */
-function serviceCredentialFromObject(obj) {
-  if (!obj) return undefined;
-  const dst = new ServiceCredential();
-  setProperties(dst, obj, 'id', 'accountId', 'displayName', 'description', 'secret');
-  convertProperties(dst, obj, timestampFromObject, 'createTime', 'expireTime');
+  const dst = new ServiceAccount();
+  setProperties(dst, obj, 'clientId', 'clientSecret');
+  convertProperties(dst, obj, timestampFromObject, 'previousSecretExpireTime');
   return dst;
 }
 

--- a/ui/ops/src/components/CopyDiv.vue
+++ b/ui/ops/src/components/CopyDiv.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="d-flex align-center">
+    <span ref="container" class="mr-auto">
+      <slot>{{ props.text ?? '' }}</slot>
+    </span>
+    <v-btn :icon="copied ? 'mdi-check' : 'mdi-content-copy'" variant="text" @click="onCopy" v-bind="props.btnProps">
+      <v-icon :size="iconSize"/>
+      <v-menu activator="parent"
+              :open-on-click="false"
+              :model-value="copied"
+              location="bottom"
+              offset="6">
+        <v-card :text="copiedText" color="success"/>
+      </v-menu>
+    </v-btn>
+  </div>
+</template>
+
+<script setup>
+import {onScopeDispose, ref, watch} from 'vue';
+
+const props = defineProps({
+  text: {
+    type: String,
+    default: undefined
+  },
+  iconSize: {
+    type: [Number, String],
+    default: 24
+  },
+  btnProps: {
+    type: Object,
+    default: () => ({})
+  },
+  copiedText: {
+    type: String,
+    default: 'Copied to clipboard'
+  }
+});
+
+const container = ref(null);
+
+const copied = ref(false);
+const onCopy = () => {
+  let _text = props.text;
+  if (!_text) {
+    if (!container.value) return;
+    _text = container.value.innerText;
+  }
+  navigator.clipboard.writeText(_text);
+  copied.value = true;
+}
+
+let copiedTimeout = 0;
+watch(copied, (value) => {
+  clearTimeout(copiedTimeout);
+  if (!value) return;
+  copiedTimeout = setTimeout(() => {
+    copied.value = false;
+  }, 5000);
+});
+onScopeDispose(() => clearTimeout(copiedTimeout));
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/ops/src/components/SideBar.vue
+++ b/ui/ops/src/components/SideBar.vue
@@ -4,7 +4,7 @@
       {{ sidebar.title }}
     </span>
     <slot name="actions"/>
-    <v-btn icon="mdi-close" variant="plain" size="small" @click="sidebar.closeSidebar()">
+    <v-btn icon="mdi-close" variant="plain" size="small" @click="onCloseClick">
       <v-icon size="24">mdi-close</v-icon>
     </v-btn>
   </div>
@@ -16,8 +16,13 @@
 <script setup>
 import {useSidebarStore} from '@/stores/sidebar';
 
+const emit = defineEmits(['close']);
 const sidebar = useSidebarStore();
 
+const onCloseClick = () => {
+  emit('close');
+  sidebar.closeSidebar();
+};
 </script>
 
 <style scoped>

--- a/ui/ops/src/composables/time.js
+++ b/ui/ops/src/composables/time.js
@@ -12,7 +12,7 @@ import {
   startOfMinute,
   startOfMonth,
   startOfWeek,
-  startOfYear
+  startOfYear, toDate
 } from 'date-fns';
 import {computed, effectScope, onMounted, onScopeDispose, onUnmounted, reactive, ref, toValue, watch} from 'vue';
 import {setTimeout, clearTimeout} from 'safe-timers'
@@ -277,5 +277,34 @@ export function usePastDates(dates) {
       res.push(_dates[i]);
     }
     return res;
+  });
+}
+
+/**
+ * Returns a ref that says whether the given date is in the future.
+ * The ref will update as time changes.
+ *
+ * @param {import('vue').MaybeRefOrGetter<Date | number>} date
+ * @return {import('vue').ComputedRef<boolean>}
+ */
+export function useIsFutureDate(date) {
+  const _date = computed(() => toDate(toValue(date)))
+  const now = ref(new Date());
+  let nowHandle = 0;
+  onScopeDispose(() => clearTimeout(nowHandle));
+
+  watch(_date, (date) => {
+    const updateNow = () => {
+      clearTimeout(nowHandle);
+      const t = new Date();
+      now.value = t;
+      const delay = date.getTime() - t.getTime();
+      nowHandle = setTimeout(() => updateNow(), delay);
+    }
+    updateNow();
+  }, {immediate: true});
+
+  return computed(() => {
+    return now.value.getTime() < _date.value.getTime();
   });
 }

--- a/ui/ops/src/routes/auth/AuthNav.vue
+++ b/ui/ops/src/routes/auth/AuthNav.vue
@@ -33,7 +33,7 @@ const menuItems = [
   {
     title: 'Roles',
     icon: 'mdi-account-details',
-    link: {path: '/auth/roles'}
+    link: {path: '/auth/roles', name: 'roles'}
   },
   {
     title: 'Third-party Accounts',

--- a/ui/ops/src/routes/auth/AuthNav.vue
+++ b/ui/ops/src/routes/auth/AuthNav.vue
@@ -26,6 +26,11 @@ const menuItems = [
     link: {path: '/auth/users'}
   },
   {
+    title: 'Accounts',
+    icon: 'mdi-account-box-outline',
+    link: {path: '/auth/accounts'}
+  },
+  {
     title: 'Third-party Accounts',
     icon: 'mdi-key',
     link: {path: '/auth/third-party'}

--- a/ui/ops/src/routes/auth/AuthNav.vue
+++ b/ui/ops/src/routes/auth/AuthNav.vue
@@ -28,7 +28,7 @@ const menuItems = [
   {
     title: 'Accounts',
     icon: 'mdi-account-box-outline',
-    link: {path: '/auth/accounts'}
+    link: {path: '/auth/accounts', name: 'accounts'}
   },
   {
     title: 'Roles',

--- a/ui/ops/src/routes/auth/AuthNav.vue
+++ b/ui/ops/src/routes/auth/AuthNav.vue
@@ -31,6 +31,11 @@ const menuItems = [
     link: {path: '/auth/accounts'}
   },
   {
+    title: 'Roles',
+    icon: 'mdi-account-details',
+    link: {path: '/auth/roles'}
+  },
+  {
     title: 'Third-party Accounts',
     icon: 'mdi-key',
     link: {path: '/auth/third-party'}

--- a/ui/ops/src/routes/auth/accounts.js
+++ b/ui/ops/src/routes/auth/accounts.js
@@ -1,9 +1,4 @@
-import {getAccount, getRole, listAccounts, listRoles} from '@/api/ui/account.js';
-import {useAction} from '@/composables/action.js';
-import useCollection from '@/composables/collection.js';
 import {ChangeType} from '@smart-core-os/sc-api-grpc-web/types/change_pb';
-import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
-import {computed, toValue} from 'vue';
 
 /**
  * @typedef {UseCollectionOptions<T>} ListOnlyCollectionOptions
@@ -11,86 +6,6 @@ import {computed, toValue} from 'vue';
  * @template R
  * @template T
  */
-
-/**
- * @param {import('vue').MaybeRefOrGetter<Partial<ListAccountsRequest.AsObject>>} request
- * @param {import('vue').MaybeRefOrGetter<Partial<ListOnlyCollectionOptions<ListAccountsRequest.AsObject, Account.AsObject>>>?} options
- * @return {UseCollectionResponse<Account.AsObject>}
- */
-export function useAccountsCollection(request, options) {
-  const normOpts = computed(() => {
-    return {
-      cmp: (a, b) => a.id.localeCompare(b.id, undefined, {numeric: true}),
-      ...toValue(options)
-    };
-  });
-  const client = {
-    async listFn(req, tracker) {
-      const res = await listAccounts(req, tracker);
-      return {
-        items: res.accountsList,
-        nextPageToken: res.nextPageToken,
-        totalSize: res.totalSize
-      };
-    },
-    pullFn(req, resource) {
-      const opts = toValue(normOpts);
-      if (opts.pullFn) {
-        opts.pullFn(req, resource);
-      }
-    }
-  };
-
-  return useCollection(request, client, normOpts);
-}
-
-/**
- * @param {import('vue').MaybeRefOrGetter<Partial<ListRolesRequest.AsObject>>} request
- * @param {import('vue').MaybeRefOrGetter<Partial<ListOnlyCollectionOptions<ListRolesRequest.AsObject, Role.AsObject>>>?} options
- * @return {UseCollectionResponse<Role.AsObject>}
- */
-export function useRolesCollection(request, options) {
-  const normOpts = computed(() => {
-    return {
-      cmp: (a, b) => a.id.localeCompare(b.id, undefined, {numeric: true}),
-      ...toValue(options)
-    };
-  });
-  const client = {
-    async listFn(req, tracker) {
-      const res = await listRoles(req, tracker);
-      return {
-        items: res.rolesList,
-        nextPageToken: res.nextPageToken,
-        totalSize: res.totalSize
-      };
-    },
-    pullFn(req, resource) {
-      const opts = toValue(normOpts);
-      if (opts.pullFn) {
-        opts.pullFn(req, resource);
-      }
-    }
-  };
-
-  return useCollection(request, client, normOpts);
-}
-
-/**
- * @param {import('vue').MaybeRefOrGetter<Partial<GetAccountRequest.AsObject>>} request
- * @return {ToRefs<UnwrapNestedRefs<UseActionResponse<Account.AsObject>>>}
- */
-export function useGetAccount(request) {
-  return useAction(request, getAccount);
-}
-
-/**
- * @param {import('vue').MaybeRefOrGetter<Partial<GetRoleRequest.AsObject>>} request
- * @return {ToRefs<UnwrapNestedRefs<UseActionResponse<Role.AsObject>>>}
- */
-export function useGetRole(request) {
-  return useAction(request, getRole);
-}
 
 /**
  * Returns an object that looks like a Pull Change that adds the given val.
@@ -166,35 +81,5 @@ export function toUpdateChange(oldVal, newVal) {
     getChangesList() {
       return changes.changesList.map(change => ({toObject() { return change; }}));
     }
-  }
-}
-
-/**
- * @param {Account.Type} accountType
- * @return {string}
- */
-export function accountTypeIcon(accountType) {
-  switch (accountType) {
-    case Account.Type.USER_ACCOUNT:
-      return 'mdi-account';
-    case Account.Type.SERVICE_ACCOUNT:
-      return 'mdi-server';
-    default:
-      return 'mdi-account-question';
-  }
-}
-
-/**
- * @param {Account.Type} accountType
- * @return {string}
- */
-export function accountTypeStr(accountType) {
-  switch (accountType) {
-    case Account.Type.USER_ACCOUNT:
-      return 'User Account';
-    case Account.Type.SERVICE_ACCOUNT:
-      return 'Service Account';
-    default:
-      return `Unknown Account Type ${accountType}`;
   }
 }

--- a/ui/ops/src/routes/auth/accounts.js
+++ b/ui/ops/src/routes/auth/accounts.js
@@ -1,4 +1,5 @@
-import {listAccounts, listRoles} from '@/api/ui/account.js';
+import {getRole, listAccounts, listRoles} from '@/api/ui/account.js';
+import {useAction} from '@/composables/action.js';
 import useCollection from '@/composables/collection.js';
 import {ChangeType} from '@smart-core-os/sc-api-grpc-web/types/change_pb';
 import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
@@ -76,6 +77,14 @@ export function useRolesCollection(request, options) {
 }
 
 /**
+ * @param {import('vue').MaybeRefOrGetter<Partial<GetRoleRequest.AsObject>>} request
+ * @return {ToRefs<UnwrapNestedRefs<UseActionResponse<Role.AsObject>>>}
+ */
+export function useGetRole(request) {
+  return useAction(request, getRole);
+}
+
+/**
  * Returns an object that looks like a Pull Change that adds the given val.
  * Useful when an API doesn't support Pull but you want to reuse utilities that do.
  *
@@ -95,14 +104,14 @@ export function toAddChange(val) {
       return changes;
     },
     getChangesList() {
-      return changes.changesList.map(change => ({toObject() { return change; } }));
+      return changes.changesList.map(change => ({toObject() { return change; }}));
     }
   }
 }
 
 /**
  * Returns an object that looks like a Pull Change that deletes the given val.
- * Useful when an API doesn't support Pull but you want to reuse
+ * Useful when an API doesn't support Pull but you want to reuse utilities that do.
  *
  * @param {T} val
  * @return {Object}
@@ -120,7 +129,34 @@ export function toRemoveChange(val) {
       return changes;
     },
     getChangesList() {
-      return changes.changesList.map(change => ({toObject() { return change; } }));
+      return changes.changesList.map(change => ({toObject() { return change; }}));
+    }
+  }
+}
+
+/**
+ * Returns an object that looks like a Pull Change that updates the val.
+ * Useful when an API doesn't support Pull but you want to reuse utilities that do.
+ *
+ * @param {T} oldVal
+ * @param {T} newVal
+ * @return {Object}
+ * @template T
+ */
+export function toUpdateChange(oldVal, newVal) {
+  const changes = {
+    changesList: [{
+      type: ChangeType.UPDATE,
+      oldValue: oldVal,
+      newValue: newVal,
+    }]
+  };
+  return {
+    toObject() {
+      return changes;
+    },
+    getChangesList() {
+      return changes.changesList.map(change => ({toObject() { return change; }}));
     }
   }
 }

--- a/ui/ops/src/routes/auth/accounts.js
+++ b/ui/ops/src/routes/auth/accounts.js
@@ -1,4 +1,4 @@
-import {listAccounts} from '@/api/ui/account.js';
+import {listAccounts, listRoles} from '@/api/ui/account.js';
 import useCollection from '@/composables/collection.js';
 import {ChangeType} from '@smart-core-os/sc-api-grpc-web/types/change_pb';
 import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
@@ -28,6 +28,38 @@ export function useAccountsCollection(request, options) {
       const res = await listAccounts(req, tracker);
       return {
         items: res.accountsList,
+        nextPageToken: res.nextPageToken,
+        totalSize: res.totalSize
+      };
+    },
+    pullFn(req, resource) {
+      const opts = toValue(normOpts);
+      if (opts.pullFn) {
+        opts.pullFn(req, resource);
+      }
+    }
+  };
+
+  return useCollection(request, client, normOpts);
+}
+
+/**
+ * @param {import('vue').MaybeRefOrGetter<Partial<ListRolesRequest.AsObject>>} request
+ * @param {import('vue').MaybeRefOrGetter<Partial<ListOnlyCollectionOptions<ListRolesRequest.AsObject, Role.AsObject>>>?} options
+ * @return {UseCollectionResponse<Role.AsObject>}
+ */
+export function useRolesCollection(request, options) {
+  const normOpts = computed(() => {
+    return {
+      cmp: (a, b) => a.id.localeCompare(b.id, undefined, {numeric: true}),
+      ...toValue(options)
+    };
+  });
+  const client = {
+    async listFn(req, tracker) {
+      const res = await listRoles(req, tracker);
+      return {
+        items: res.rolesList,
         nextPageToken: res.nextPageToken,
         totalSize: res.totalSize
       };

--- a/ui/ops/src/routes/auth/accounts.js
+++ b/ui/ops/src/routes/auth/accounts.js
@@ -1,4 +1,4 @@
-import {getRole, listAccounts, listRoles} from '@/api/ui/account.js';
+import {getAccount, getRole, listAccounts, listRoles} from '@/api/ui/account.js';
 import {useAction} from '@/composables/action.js';
 import useCollection from '@/composables/collection.js';
 import {ChangeType} from '@smart-core-os/sc-api-grpc-web/types/change_pb';
@@ -74,6 +74,14 @@ export function useRolesCollection(request, options) {
   };
 
   return useCollection(request, client, normOpts);
+}
+
+/**
+ * @param {import('vue').MaybeRefOrGetter<Partial<GetAccountRequest.AsObject>>} request
+ * @return {ToRefs<UnwrapNestedRefs<UseActionResponse<Account.AsObject>>>}
+ */
+export function useGetAccount(request) {
+  return useAction(request, getAccount);
 }
 
 /**

--- a/ui/ops/src/routes/auth/accounts/AccountsPage.vue
+++ b/ui/ops/src/routes/auth/accounts/AccountsPage.vue
@@ -55,12 +55,12 @@
         <template #item.roles="{item}">
           <v-progress-circular indeterminate v-if="item.roles?.loading" size="small"/>
           <template v-else>
-            <span v-for="(role, i) in item.roles?.items.slice(0, 2)" :key="role.id">
+            <span v-for="(role, i) in item.roles?.items.slice(0, 1)" :key="role.id">
               <role-assignment-link :role-assignment="role" data-skip-row-select="true"/>
               <template v-if="i < item.roles?.items.length - 1">, </template>
             </span>
-            <template v-if="item.roles.items.length > 2">
-              and {{ item.roles.items.length - 2 }} more
+            <template v-if="item.roles.items.length > 1">
+              and {{ item.roles.items.length - 1 }} more
             </template>
           </template>
         </template>

--- a/ui/ops/src/routes/auth/accounts/AccountsPage.vue
+++ b/ui/ops/src/routes/auth/accounts/AccountsPage.vue
@@ -59,14 +59,13 @@
 import {timestampToDate} from '@/api/convpb.js';
 import {updateAccount} from '@/api/ui/account.js';
 import {useDataTableCollection} from '@/composables/table.js';
+import {toAddChange, toRemoveChange, toUpdateChange} from '@/routes/auth/accounts.js';
 import {
   accountTypeIcon,
   accountTypeStr,
-  toAddChange,
-  toRemoveChange, toUpdateChange,
   useAccountsCollection,
   useGetAccount
-} from '@/routes/auth/accounts.js';
+} from '@/routes/auth/accounts/accounts.js';
 import CopySecretAlert from '@/routes/auth/accounts/CopySecretAlert.vue';
 import DeleteAccountsBtn from '@/routes/auth/accounts/DeleteAccountsBtn.vue';
 import NewAccountBtn from '@/routes/auth/accounts/NewAccountBtn.vue';

--- a/ui/ops/src/routes/auth/accounts/AccountsPage.vue
+++ b/ui/ops/src/routes/auth/accounts/AccountsPage.vue
@@ -8,6 +8,7 @@
             variant="outlined"
             :accounts="selectedAccounts"
             @delete="onDelete"/>
+        <grant-role-btn v-if="showGrantBtn" variant="outlined" :accounts="allSelectedAccountIds"/>
         <new-account-btn variant="flat" color="primary" @save="onNewAccountSave"/>
       </template>
     </v-toolbar>
@@ -68,6 +69,7 @@ import {
 } from '@/routes/auth/accounts/accounts.js';
 import CopySecretAlert from '@/routes/auth/accounts/CopySecretAlert.vue';
 import DeleteAccountsBtn from '@/routes/auth/accounts/DeleteAccountsBtn.vue';
+import GrantRoleBtn from '@/routes/auth/accounts/GrantRoleBtn.vue';
 import NewAccountBtn from '@/routes/auth/accounts/NewAccountBtn.vue';
 import {useSidebarStore} from '@/stores/sidebar.js';
 import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
@@ -180,6 +182,18 @@ const onSecretClose = () => {
 };
 
 const selectedAccounts = ref([]);
+const allSelectedAccountIds = computed(() => {
+  const ids = {};
+  for (const account of selectedAccounts.value) {
+    ids[account.id] = true;
+  }
+  if (props.accountId) {
+    ids[props.accountId] = true;
+  }
+  return Object.keys(ids).sort();
+})
+
+const showGrantBtn = computed(() => allSelectedAccountIds.value.length > 0);
 
 const showDeleteAccountsBtn = computed(() => selectedAccounts.value.length > 0);
 const onDelete = () => {

--- a/ui/ops/src/routes/auth/accounts/AccountsPage.vue
+++ b/ui/ops/src/routes/auth/accounts/AccountsPage.vue
@@ -71,7 +71,7 @@
 
 <script setup>
 import {timestampToDate} from '@/api/convpb.js';
-import {deleteRoleAssignment, updateAccount} from '@/api/ui/account.js';
+import {deleteRoleAssignment, rotateAccountClientSecret, updateAccount} from '@/api/ui/account.js';
 import {useDevicesCollection} from '@/composables/devices.js';
 import {useDataTableCollection} from '@/composables/table.js';
 import {toAddChange, toRemoveChange, toUpdateChange} from '@/routes/auth/accounts.js';
@@ -237,6 +237,7 @@ watch(sidebarAccount, (item) => {
     account: item,
     roleAssignments: sidebarRoleAssignments,
     updateAccount: onAccountUpdate,
+    rotateServiceAccountSecret: onRotateServiceAccountSecret,
     removeRole: onGrantRemove
   };
   sidebar.visible = true;
@@ -277,6 +278,12 @@ const onAccountUpdate = async ({account}) => {
   return newAccount;
 }
 
+const onRotateServiceAccountSecret = async ({account, expireTime}) => {
+  const res = await rotateAccountClientSecret({id: account.id, previousSecretExpireTime: expireTime});
+  account.serviceDetails.clientSecret = res.clientSecret;
+  latestAccount.value = account;
+  refreshSidebarAccount();
+}
 const onSecretClose = () => {
   latestAccount.value = null;
 };

--- a/ui/ops/src/routes/auth/accounts/AccountsPage.vue
+++ b/ui/ops/src/routes/auth/accounts/AccountsPage.vue
@@ -1,0 +1,113 @@
+<template>
+  <v-card elevation="0" class="rounded-lg">
+    <v-toolbar title="Accounts" color="transparent" class="px-4 pt-2">
+      <template #append>
+        <v-btn>
+          New Account...
+          <v-menu v-model="newAccountMenu" activator="parent" :close-on-content-click="false">
+            <new-account-card @save="onNewAccountSave" @cancel="onNewAccountCancel"/>
+          </v-menu>
+        </v-btn>
+      </template>
+    </v-toolbar>
+    <v-expand-transition>
+      <div v-if="latestServiceCredential">
+        <copy-secret-alert :credential="latestServiceCredential.secret" @close="onSecretClose"/>
+      </div>
+    </v-expand-transition>
+    <v-card-text>
+      <v-data-table-server
+          v-bind="tableAttrs"
+          :headers="tableHeaders"
+          disable-sort>
+        <template #item.type="{item}">
+          <v-icon :icon="accountTypeIcon(item.type)" v-tooltip:bottom="accountTypeStr(item.type)"/>
+        </template>
+        <template #item.displayName="{item}">
+          <span>{{ item.displayName }}</span>
+          <span class="opacity-50 ml-2" v-if="item.description">{{ item.description }}</span>
+        </template>
+        <template #item.username="{item}">
+          {{ item.type === Account.Type.USER_ACCOUNT ? item.username : item.id }}
+        </template>
+        <template #item.createTime="{item}">
+          {{ timestampToDate(item.createTime).toLocaleDateString() }}
+        </template>
+      </v-data-table-server>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup>
+import {timestampToDate} from '@/api/convpb.js';
+import {useDataTableCollection} from '@/composables/table.js';
+import {
+  accountToChangeList,
+  accountTypeIcon,
+  accountTypeStr,
+  useAccountsCollection
+} from '@/routes/auth/accounts/accounts.js';
+import CopySecretAlert from '@/routes/auth/accounts/CopySecretAlert.vue';
+import NewAccountCard from '@/routes/auth/accounts/NewAccountCard.vue';
+import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
+import {computed, ref, watch} from 'vue';
+
+// used to fake PullAccounts when creating a new account.
+// the var isn't reactive, but the value will be whenever it's set
+let newAccountsResource = /** @type {ResourceCollection<Account.AsObject, *> | null} */ null;
+
+const wantCount = ref(20);
+const accountsCollectionOpts = computed(() => {
+  return {
+    wantCount: wantCount.value,
+    pullFn: (_, resource) => {
+      newAccountsResource = resource;
+    }
+  };
+})
+const accountsCollection = useAccountsCollection({}, accountsCollectionOpts);
+const tableAttrs = useDataTableCollection(wantCount, accountsCollection);
+const tableHeaders = computed(() => {
+  return [
+    {key: 'type', width: '1.5rem'},
+    {title: 'Name', key: 'displayName', maxWidth: '10em', cellProps: {class: 'text-overflow-ellipsis'}},
+    {title: 'Username / Client ID', key: 'username', maxWidth: '10em', cellProps: {class: 'text-overflow-ellipsis'}},
+    {title: 'Created', key: 'createTime', label: 'Created'},
+  ]
+});
+
+const latestAccount = ref(null);
+const latestServiceCredential = ref(null);
+
+const newAccountMenu = ref(false);
+
+const onNewAccountSave = ({account, serviceCredential}) => {
+  if (newAccountsResource) {
+    newAccountsResource.lastResponse = accountToChangeList(account);
+  }
+  latestAccount.value = account;
+  latestServiceCredential.value = serviceCredential;
+  newAccountMenu.value = false;
+};
+const onNewAccountCancel = () => {
+  newAccountMenu.value = false;
+}
+// reset the new account form once the menu is hidden
+const newAccountCardRef = ref(null);
+watch(newAccountMenu, (value) => {
+  if (value) {
+    setTimeout(() => {
+      const form = newAccountCardRef.value;
+      if (!form) return;
+      form.reset();
+    }, 250);
+  }
+});
+
+const onSecretClose = () => {
+  latestServiceCredential.value = null;
+};
+</script>
+
+<style scoped>
+</style>

--- a/ui/ops/src/routes/auth/accounts/AccountsPage.vue
+++ b/ui/ops/src/routes/auth/accounts/AccountsPage.vue
@@ -23,6 +23,13 @@
           disable-sort
           return-object
           v-model="selectedAccounts">
+        <template #top>
+          <v-expand-transition>
+            <div v-if="tableErrorStr">
+              <v-alert type="error" :text="tableErrorStr"/>
+            </div>
+          </v-expand-transition>
+        </template>
         <template #item.type="{item, internalItem, isSelected, toggleSelect}">
           <div class="select--container" :class="{selected: isSelected(internalItem)}">
             <v-checkbox-btn :model-value="isSelected(internalItem)"
@@ -84,6 +91,12 @@ const tableHeaders = computed(() => {
     {title: 'Username / Client ID', key: 'username', maxWidth: '10em', cellProps: {class: 'text-overflow-ellipsis'}},
     {title: 'Created', key: 'createTime', label: 'Created'},
   ]
+});
+
+const tableErrorStr = computed(() => {
+  const errors = accountsCollection.errors.value;
+  if (errors.length === 0) return null;
+  return 'Error fetching accounts: ' + errors.map((e) => (e.error ?? e).message ?? e).join(', ');
 });
 
 const latestAccount = ref(null);

--- a/ui/ops/src/routes/auth/accounts/AccountsPage.vue
+++ b/ui/ops/src/routes/auth/accounts/AccountsPage.vue
@@ -2,7 +2,13 @@
   <v-card elevation="0" class="rounded-lg">
     <v-toolbar title="Accounts" color="transparent" class="px-4 pt-2">
       <template #append>
-        <v-btn>
+        <delete-accounts-btn
+            v-if="showDeleteAccountsBtn"
+            color="error"
+            variant="outlined"
+            :accounts="selectedAccounts"
+            @delete="onDelete"/>
+        <v-btn variant="flat" color="primary">
           New Account...
           <v-menu v-model="newAccountMenu" activator="parent" :close-on-content-click="false">
             <new-account-card @save="onNewAccountSave" @cancel="onNewAccountCancel"/>
@@ -19,9 +25,14 @@
       <v-data-table-server
           v-bind="tableAttrs"
           :headers="tableHeaders"
-          disable-sort>
-        <template #item.type="{item}">
-          <v-icon :icon="accountTypeIcon(item.type)" v-tooltip:bottom="accountTypeStr(item.type)"/>
+          disable-sort
+          return-object
+          v-model="selectedAccounts">
+        <template #item.type="{item, internalItem, isSelected, toggleSelect}">
+          <div class="select--container" :class="{selected: isSelected(internalItem)}">
+            <v-checkbox-btn :model-value="isSelected(internalItem)" @click="toggleSelect(internalItem)" color="primary"/>
+            <v-icon :icon="accountTypeIcon(item.type)" v-tooltip:bottom="accountTypeStr(item.type)"/>
+          </div>
         </template>
         <template #item.displayName="{item}">
           <span>{{ item.displayName }}</span>
@@ -42,26 +53,28 @@
 import {timestampToDate} from '@/api/convpb.js';
 import {useDataTableCollection} from '@/composables/table.js';
 import {
-  accountToChangeList,
+  accountToAddChange,
+  accountToRemoveChange,
   accountTypeIcon,
   accountTypeStr,
   useAccountsCollection
 } from '@/routes/auth/accounts/accounts.js';
 import CopySecretAlert from '@/routes/auth/accounts/CopySecretAlert.vue';
+import DeleteAccountsBtn from '@/routes/auth/accounts/DeleteAccountsBtn.vue';
 import NewAccountCard from '@/routes/auth/accounts/NewAccountCard.vue';
 import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
 import {computed, ref, watch} from 'vue';
 
 // used to fake PullAccounts when creating a new account.
 // the var isn't reactive, but the value will be whenever it's set
-let newAccountsResource = /** @type {ResourceCollection<Account.AsObject, *> | null} */ null;
+let pullAccountsResource = /** @type {ResourceCollection<Account.AsObject, *> | null} */ null;
 
 const wantCount = ref(20);
 const accountsCollectionOpts = computed(() => {
   return {
     wantCount: wantCount.value,
     pullFn: (_, resource) => {
-      newAccountsResource = resource;
+      pullAccountsResource = resource;
     }
   };
 })
@@ -69,7 +82,7 @@ const accountsCollection = useAccountsCollection({}, accountsCollectionOpts);
 const tableAttrs = useDataTableCollection(wantCount, accountsCollection);
 const tableHeaders = computed(() => {
   return [
-    {key: 'type', width: '1.5rem'},
+    {key: 'type', width: '1.5rem', cellProps: {class: 'pr-0'}},
     {title: 'Name', key: 'displayName', maxWidth: '10em', cellProps: {class: 'text-overflow-ellipsis'}},
     {title: 'Username / Client ID', key: 'username', maxWidth: '10em', cellProps: {class: 'text-overflow-ellipsis'}},
     {title: 'Created', key: 'createTime', label: 'Created'},
@@ -82,8 +95,8 @@ const latestServiceCredential = ref(null);
 const newAccountMenu = ref(false);
 
 const onNewAccountSave = ({account, serviceCredential}) => {
-  if (newAccountsResource) {
-    newAccountsResource.lastResponse = accountToChangeList(account);
+  if (pullAccountsResource) {
+    pullAccountsResource.lastResponse = accountToAddChange(account);
   }
   latestAccount.value = account;
   latestServiceCredential.value = serviceCredential;
@@ -107,7 +120,57 @@ watch(newAccountMenu, (value) => {
 const onSecretClose = () => {
   latestServiceCredential.value = null;
 };
+
+const selectedAccounts = ref([]);
+
+const showDeleteAccountsBtn = computed(() => selectedAccounts.value.length > 0);
+const onDelete = () => {
+  if (pullAccountsResource) {
+    for (const account of selectedAccounts.value) {
+      pullAccountsResource.lastResponse = accountToRemoveChange(account);
+    }
+  }
+  const _latest = latestAccount.value;
+  for (const account of selectedAccounts.value) {
+    if (account.id === _latest.id) {
+      latestAccount.value = null;
+      latestServiceCredential.value = null;
+    }
+  }
+  selectedAccounts.value = [];
+}
 </script>
 
-<style scoped>
+<style scoped lang="scss">
+:deep(.v-toolbar__append) {
+  gap: 1rem;
+}
+
+.select--container {
+  display: grid;
+  justify-items: center;
+  align-items: center;
+
+  .v-checkbox-btn {
+    grid-column: 1 / -1;
+    grid-row: 1 / -1;
+  }
+
+  .v-icon {
+    grid-column: 1 / -1;
+    grid-row: 1 / -1;
+  }
+
+  &:not(:hover, .selected) {
+    .v-checkbox-btn {
+      visibility: hidden;
+    }
+  }
+
+  &:hover, &.selected {
+    .v-icon {
+      visibility: hidden;
+    }
+  }
+}
 </style>

--- a/ui/ops/src/routes/auth/accounts/AccountsSideBar.vue
+++ b/ui/ops/src/routes/auth/accounts/AccountsSideBar.vue
@@ -4,7 +4,19 @@
       <v-btn v-if="!editMode" @click="onEditClick" icon="mdi-pencil" variant="plain" size="small"/>
     </template>
     <template v-if="!editMode">
-      <p class="px-4 my-4" v-if="account?.description">{{ account.description }}</p>
+      <div class="px-4 my-4" v-if="account">
+        <p v-if="account.description">{{ account.description }}</p>
+        <template v-if="account.username">
+          <h4>Username</h4>
+          <p>{{ account.username }}</p>
+        </template>
+        <template v-if="account.type === Account.Type.SERVICE_ACCOUNT">
+          <h4>Client ID</h4>
+          <p><copy-div :text="account.id" icon-size="18" :btn-props="{size: 'x-small'}"/></p>
+        </template>
+        <h4>Account Created</h4>
+        <p>{{ timestampToDate(account.createTime).toLocaleString() }}</p>
+      </div>
     </template>
     <template v-else>
       <v-form @submit.prevent="onSaveClick" v-model="formValid">
@@ -36,10 +48,13 @@
 </template>
 
 <script setup>
+import CopyDiv from '@/components/CopyDiv.vue';
 import SideBar from '@/components/SideBar.vue';
 import {useSidebarStore} from '@/stores/sidebar.js';
+import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
 import {computed, ref} from 'vue';
 import {useRouter} from 'vue-router';
+import {timestampToDate} from '@/api/convpb.js';
 
 const sidebar = useSidebarStore();
 const account = computed(() => sidebar.data?.account);

--- a/ui/ops/src/routes/auth/accounts/AccountsSideBar.vue
+++ b/ui/ops/src/routes/auth/accounts/AccountsSideBar.vue
@@ -37,7 +37,8 @@
                   </v-card-actions>
                   <v-card-actions>
                     <v-btn text="cancel" @click="onRotateCancel"/>
-                    <v-btn type="submit" color="primary" variant="flat" @click="onRotateSave">Generate New Secret
+                    <v-btn type="submit" color="primary" variant="flat" @click="onRotateSave">
+                      Generate New Secret
                     </v-btn>
                   </v-card-actions>
                   <v-expand-transition>
@@ -52,9 +53,9 @@
               </v-dialog>
             </v-btn>
           </p>
-          <template v-if="account.serviceDetails.previousSecretExpireTime">
+          <template v-if="previousSecretExpireTime && previousSecretNotExpired">
             <v-list-subheader>Old Secret Expires</v-list-subheader>
-            <p class="px-4">{{ timestampToDate(account.serviceDetails.previousSecretExpireTime).toLocaleString() }}</p>
+            <p class="px-4">{{ previousSecretExpireTime.toLocaleString() }}</p>
           </template>
         </template>
         <v-list-subheader>Account Created</v-list-subheader>
@@ -117,6 +118,7 @@ import {timestampToDate} from '@/api/convpb.js';
 import CopyDiv from '@/components/CopyDiv.vue';
 import {DAY, HOUR, MINUTE} from '@/components/now.js';
 import SideBar from '@/components/SideBar.vue';
+import {useIsFutureDate} from '@/composables/time.js';
 import RoleAssignmentLink from '@/routes/auth/accounts/RoleAssignmentLink.vue';
 import {useSidebarStore} from '@/stores/sidebar.js';
 import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
@@ -128,6 +130,9 @@ const account = computed(() => sidebar.data?.account);
 const roleAssignmentsCollection = computed(() => sidebar.data?.roleAssignments);
 
 const roleAssignments = computed(() => roleAssignmentsCollection.value?.items ?? []);
+
+const previousSecretExpireTime = computed(() => timestampToDate(account.value?.serviceDetails?.previousSecretExpireTime));
+const previousSecretNotExpired = useIsFutureDate(previousSecretExpireTime);
 
 const editMode = ref(false);
 const formValid = ref(false);

--- a/ui/ops/src/routes/auth/accounts/AccountsSideBar.vue
+++ b/ui/ops/src/routes/auth/accounts/AccountsSideBar.vue
@@ -4,18 +4,18 @@
       <v-btn v-if="!editMode" @click="onEditClick" icon="mdi-pencil" variant="plain" size="small"/>
     </template>
     <template v-if="!editMode">
-      <div class="px-4 my-4" v-if="account">
-        <p v-if="account.description">{{ account.description }}</p>
+      <div v-if="account" class="details pt-4">
+        <p v-if="account.description" class="px-4">{{ account.description }}</p>
         <template v-if="account.username">
-          <h4>Username</h4>
-          <p>{{ account.username }}</p>
+          <v-list-subheader>Username</v-list-subheader>
+          <p class="px-4">{{ account.username }}</p>
         </template>
         <template v-if="account.type === Account.Type.SERVICE_ACCOUNT">
-          <h4>Client ID</h4>
-          <p><copy-div :text="account.id" icon-size="18" :btn-props="{size: 'x-small'}"/></p>
+          <v-list-subheader>Client ID</v-list-subheader>
+          <p class="px-4"><copy-div :text="account.id" icon-size="18" :btn-props="{size: 'small', class: 'ma-n2'}"/></p>
         </template>
-        <h4>Account Created</h4>
-        <p>{{ timestampToDate(account.createTime).toLocaleString() }}</p>
+        <v-list-subheader>Account Created</v-list-subheader>
+        <p class="px-4">{{ timestampToDate(account.createTime).toLocaleString() }}</p>
       </div>
     </template>
     <template v-else>
@@ -44,6 +44,9 @@
         </div>
       </v-expand-transition>
     </template>
+    <v-list>
+      <v-list-subheader>Roles</v-list-subheader>
+    </v-list>
   </side-bar>
 </template>
 
@@ -112,5 +115,7 @@ const editDescriptionModel = ref(null);
 </script>
 
 <style scoped>
-
+.details .v-list-subheader {
+  min-height: initial;
+}
 </style>

--- a/ui/ops/src/routes/auth/accounts/AccountsSideBar.vue
+++ b/ui/ops/src/routes/auth/accounts/AccountsSideBar.vue
@@ -1,0 +1,101 @@
+<template>
+  <side-bar @close="onCloseClick">
+    <template #actions>
+      <v-btn v-if="!editMode" @click="onEditClick" icon="mdi-pencil" variant="plain" size="small"/>
+    </template>
+    <template v-if="!editMode">
+      <p class="px-4 my-4" v-if="account?.description">{{ account.description }}</p>
+    </template>
+    <template v-else>
+      <v-form @submit.prevent="onSaveClick" v-model="formValid">
+        <v-text-field
+            class="ma-4"
+            v-model="editDisplayNameModel"
+            :rules="editDisplayNameRules"
+            :counter="100"
+            label="Name"
+            autocomplete="off"/>
+        <v-textarea
+            class="ma-4"
+            v-model="editDescriptionModel"
+            label="Description"
+            :counter="250"
+            autocomplete="off"/>
+        <div class="d-flex ga-2 ma-4">
+          <v-btn @click="onSaveClick" variant="flat" color="primary" type="submit" :disabled="!formValid">Save</v-btn>
+          <v-btn @click="onCancelClick" variant="flat">Cancel</v-btn>
+        </div>
+      </v-form>
+      <v-expand-transition>
+        <div v-if="saveError">
+          <v-alert type="error" tile :text="saveErrorStr"/>
+        </div>
+      </v-expand-transition>
+    </template>
+  </side-bar>
+</template>
+
+<script setup>
+import SideBar from '@/components/SideBar.vue';
+import {useSidebarStore} from '@/stores/sidebar.js';
+import {computed, ref} from 'vue';
+import {useRouter} from 'vue-router';
+
+const sidebar = useSidebarStore();
+const account = computed(() => sidebar.data?.account);
+
+const editMode = ref(false);
+const formValid = ref(false);
+const saving = ref(false);
+const saveError = ref(null);
+const saveErrorStr = computed(() => {
+  const err = saveError.value;
+  if (!err) return null;
+  const msg = `${err.error?.message ?? err.message ?? err}`;
+  return 'Error saving account: ' + msg;
+})
+
+const router = useRouter();
+const onCloseClick = () => {
+  router.push({name: 'accounts'});
+}
+const onEditClick = () => {
+  editDisplayNameModel.value = account.value?.displayName ?? '';
+  editDescriptionModel.value = account.value?.description ?? '';
+  editMode.value = true;
+};
+const onCancelClick = () => {
+  editMode.value = false;
+};
+const onSaveClick = async () => {
+  try {
+    saving.value = true;
+    const newAccount = {
+      ...account.value,
+      displayName: editDisplayNameModel.value,
+      description: editDescriptionModel.value,
+    }
+    await sidebar.data.updateAccount({account: newAccount});
+    saveError.value = null;
+    editMode.value = false;
+  } catch (e) {
+    saveError.value = e;
+  } finally {
+    saving.value = false;
+  }
+};
+
+const editDisplayNameModel = ref(null);
+const editDisplayNameRules = computed(() => {
+  return [
+    (v) => !!v || 'Name is required',
+    (v) => v.length >= 3 || 'Name must be at least 3 characters',
+    (v) => v.length <= 100 || 'Name must be less than 100 characters',
+  ];
+})
+const editDescriptionModel = ref(null);
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/ops/src/routes/auth/accounts/CopySecretAlert.vue
+++ b/ui/ops/src/routes/auth/accounts/CopySecretAlert.vue
@@ -1,0 +1,60 @@
+<template>
+  <v-alert type="info" tile icon="mdi-key" closable @click:close="emit('close')">
+    <template #title>
+      Service Account Created
+    </template>
+    <template #text>
+      <p class="mb-3">
+        Make sure to save your secret token somewhere private. You won't be able to see it again.
+      </p>
+      <div class="secret d-flex align-center">
+        <pre class="ml-4 my-2 mr-auto text-h6">{{ props.credential }}</pre>
+        <v-btn :icon="secretCopied ? 'mdi-check' : 'mdi-content-copy'" variant="text" @click="onCopySecret">
+          <v-icon size="24"/>
+          <v-menu activator="parent"
+                  :open-on-click="false"
+                  :model-value="secretCopied"
+                  location="bottom"
+                  offset="6">
+            <v-card text="Secret copied to clipboard" color="success"/>
+          </v-menu>
+        </v-btn>
+      </div>
+    </template>
+  </v-alert>
+</template>
+
+<script setup>
+import {onScopeDispose, ref, watch} from 'vue';
+
+const props = defineProps({
+  credential: {
+    type: String,
+    default: undefined,
+  }
+});
+const emit = defineEmits(["close"]);
+
+const secretCopied = ref(false);
+const onCopySecret = () => {
+  navigator.clipboard.writeText(props.credential);
+  secretCopied.value = true;
+}
+let secretCopiedTimeout = 0;
+watch(secretCopied, (value) => {
+  clearTimeout(secretCopiedTimeout);
+  if (!value) return;
+  secretCopiedTimeout = setTimeout(() => {
+    secretCopied.value = false;
+  }, 5000);
+});
+onScopeDispose(() => clearTimeout(secretCopiedTimeout));
+</script>
+
+<style scoped>
+.secret {
+  border-radius: 0.2rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background-color: rgba(0, 0, 0, 0.04);
+}
+</style>

--- a/ui/ops/src/routes/auth/accounts/CopySecretAlert.vue
+++ b/ui/ops/src/routes/auth/accounts/CopySecretAlert.vue
@@ -1,7 +1,7 @@
 <template>
   <v-alert type="info" tile icon="mdi-key" closable @click:close="emit('close')">
     <template #title>
-      Service Account Created
+      Service Account Secret Created
     </template>
     <template #text>
       <p class="mb-3">

--- a/ui/ops/src/routes/auth/accounts/CopySecretAlert.vue
+++ b/ui/ops/src/routes/auth/accounts/CopySecretAlert.vue
@@ -7,25 +7,16 @@
       <p class="mb-3">
         Make sure to save your secret token somewhere private. You won't be able to see it again.
       </p>
-      <div class="secret d-flex align-center">
-        <pre class="ml-4 my-2 mr-auto text-h6">{{ props.credential }}</pre>
-        <v-btn :icon="secretCopied ? 'mdi-check' : 'mdi-content-copy'" variant="text" @click="onCopySecret">
-          <v-icon size="24"/>
-          <v-menu activator="parent"
-                  :open-on-click="false"
-                  :model-value="secretCopied"
-                  location="bottom"
-                  offset="6">
-            <v-card text="Secret copied to clipboard" color="success"/>
-          </v-menu>
-        </v-btn>
-      </div>
+      <copy-div class="secret" copied-text="Secret copied to clipboard">
+        <pre class="ml-4 my-2 text-h6">{{ props.credential }}</pre>
+      </copy-div>
     </template>
   </v-alert>
 </template>
 
 <script setup>
-import {onScopeDispose, ref, watch} from 'vue';
+
+import CopyDiv from '@/components/CopyDiv.vue';
 
 const props = defineProps({
   credential: {
@@ -33,22 +24,7 @@ const props = defineProps({
     default: undefined,
   }
 });
-const emit = defineEmits(["close"]);
-
-const secretCopied = ref(false);
-const onCopySecret = () => {
-  navigator.clipboard.writeText(props.credential);
-  secretCopied.value = true;
-}
-let secretCopiedTimeout = 0;
-watch(secretCopied, (value) => {
-  clearTimeout(secretCopiedTimeout);
-  if (!value) return;
-  secretCopiedTimeout = setTimeout(() => {
-    secretCopied.value = false;
-  }, 5000);
-});
-onScopeDispose(() => clearTimeout(secretCopiedTimeout));
+const emit = defineEmits(['close']);
 </script>
 
 <style scoped>

--- a/ui/ops/src/routes/auth/accounts/DeleteAccountsBtn.vue
+++ b/ui/ops/src/routes/auth/accounts/DeleteAccountsBtn.vue
@@ -24,7 +24,7 @@ const props = defineProps({
   },
   accounts: {
     type: Array,
-    default: () => [],
+    default: () => [], // of Account.AsObject
   }
 });
 const emit = defineEmits(['cancel', 'delete']);

--- a/ui/ops/src/routes/auth/accounts/DeleteAccountsBtn.vue
+++ b/ui/ops/src/routes/auth/accounts/DeleteAccountsBtn.vue
@@ -1,0 +1,61 @@
+<template>
+  <v-btn>
+    Delete
+    <v-dialog activator="parent" max-width="440" v-model="dialogVisible">
+      <v-card :title="dialogTitle">
+        <v-card-text>Are you sure you want to delete these accounts? This cannot be undone!</v-card-text>
+        <v-card-actions>
+          <v-btn text="Cancel" @click="onCancel" :disabled="deleteLoading"/>
+          <v-btn text="Delete" @click="onDelete" type="submit" color="error" variant="flat" :loading="deleteLoading"/>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-btn>
+</template>
+
+<script setup>
+import {deleteAccount} from '@/api/ui/account.js';
+import {computed, ref} from 'vue';
+
+const props = defineProps({
+  name: {
+    type: String,
+    default: undefined,
+  },
+  accounts: {
+    type: Array,
+    default: () => [],
+  }
+});
+const emit = defineEmits(['cancel', 'delete']);
+
+const dialogVisible = ref(false);
+const dialogTitle = computed(() => {
+  if (props.accounts.length === 1) {
+    return `Delete Account ${props.accounts[0].displayName}`;
+  }
+  return `Delete ${props.accounts.length} Accounts`;
+});
+const deleteLoading = ref(false);
+const onCancel = () => {
+  emit('cancel');
+  dialogVisible.value = false;
+}
+const onDelete = async () => {
+  deleteLoading.value = true;
+  try {
+    const selected = props.accounts;
+    for (const account of selected) {
+      await deleteAccount({id: account.id, allowMissing: true});
+    }
+    emit('delete');
+    dialogVisible.value = false;
+  } finally {
+    deleteLoading.value = false;
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/ops/src/routes/auth/accounts/GrantChip.vue
+++ b/ui/ops/src/routes/auth/accounts/GrantChip.vue
@@ -1,0 +1,61 @@
+<template>
+  <v-chip v-tooltip:bottom="tooltipStr">
+    <template #prepend>{{ prependStr }}</template>
+    {{ valueStr }}
+  </v-chip>
+</template>
+
+<script setup>
+import {ResourceTypeById} from '@/api/ui/account.js';
+import {RoleAssignment} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
+import {computed} from 'vue';
+
+const props = defineProps({
+  title: {
+    type: String,
+    default: undefined
+  },
+  value: {
+    type: String,
+    default: undefined
+  },
+  type: {
+    type: Number,
+    default: RoleAssignment.ResourceType.RESOURCE_TYPE_UNSPECIFIED
+  }
+});
+
+const prependStr = computed(() => {
+  switch (props.type) {
+    case RoleAssignment.ResourceType.NAMED_RESOURCE:
+      return 'ID';
+    case RoleAssignment.ResourceType.NAMED_RESOURCE_PATH_PREFIX:
+      return 'ID+';
+    case RoleAssignment.ResourceType.NODE:
+      return 'On Node';
+    case RoleAssignment.ResourceType.SUBSYSTEM:
+      return 'System';
+    case RoleAssignment.ResourceType.ZONE:
+      return 'Zone';
+    default:
+      return ResourceTypeById[props.type] ?? 'Unknown';
+  }
+});
+const valueStr = computed(() => {
+  return props.title;
+});
+const tooltipStr = computed(() => {
+  return props.value ?? props.title;
+})
+</script>
+
+<style scoped>
+:deep(.v-chip__prepend) {
+  height: 100%;
+  margin-left: -10px;
+  padding-left: 10px;
+  margin-right: .5em;
+  padding-right: .5em;
+  background: rgba(var(--v-theme-primary), 0.4);
+}
+</style>

--- a/ui/ops/src/routes/auth/accounts/GrantChip.vue
+++ b/ui/ops/src/routes/auth/accounts/GrantChip.vue
@@ -28,9 +28,9 @@ const props = defineProps({
 const prependStr = computed(() => {
   switch (props.type) {
     case RoleAssignment.ResourceType.NAMED_RESOURCE:
-      return 'ID';
+      return 'Device';
     case RoleAssignment.ResourceType.NAMED_RESOURCE_PATH_PREFIX:
-      return 'ID+';
+      return 'Device+';
     case RoleAssignment.ResourceType.NODE:
       return 'On Node';
     case RoleAssignment.ResourceType.SUBSYSTEM:

--- a/ui/ops/src/routes/auth/accounts/GrantRoleBtn.vue
+++ b/ui/ops/src/routes/auth/accounts/GrantRoleBtn.vue
@@ -1,0 +1,126 @@
+<template>
+  <v-btn>
+    Grant Role...
+    <v-menu v-model="menuModel" activator="parent" :close-on-content-click="false">
+      <v-card title="Grant Role" width="440px">
+        <v-card-text>
+          <v-autocomplete
+              v-model="selectedRole"
+              :items="rolesCollection"
+              item-title="displayName"
+              item-value="id"
+              return-object
+              label="Role"
+              hide-details/>
+        </v-card-text>
+        <v-card-text>
+          <scope-autocomplete v-model="selectedScopes" :disabled="scopeDisabled"/>
+        </v-card-text>
+        <v-card-actions>
+          <v-btn @click="onGrantClick" color="primary" :disabled="!selectedRole || selectedScopes.length === 0">Grant</v-btn>
+          <v-btn @click="onCancelClick">Cancel</v-btn>
+        </v-card-actions>
+        <v-expand-transition>
+          <div v-if="grantError">
+            <v-alert type="error" :text="grantErrorStr" tile class="mt-2"/>
+          </div>
+        </v-expand-transition>
+      </v-card>
+    </v-menu>
+  </v-btn>
+</template>
+
+<script setup>
+import {createRoleAssignment} from '@/api/ui/account.js';
+import ScopeAutocomplete from '@/routes/auth/accounts/ScopeAutocomplete.vue';
+import {useRolesCollection} from '@/routes/auth/roles/roles.js';
+import {computed, onScopeDispose, ref} from 'vue';
+
+const props = defineProps({
+  name: {
+    type: String,
+    default: undefined
+  },
+  accounts: {
+    type: [String, Object, Array], // String is the id, Object is an account, Array is of string or object.
+    required: true,
+  }
+});
+const emit = defineEmits(['grant', 'cancel']);
+
+const selectedRole = ref(null);
+const selectedScopes = ref([]);
+
+const menuModel = ref(false);
+
+const grantLoading = ref(false);
+const grantError = ref(null);
+const grantErrorStr = computed(() => {
+  const err = grantError.value;
+  if (!err) return null;
+  return `Failed to grant roles: ${err.error?.message ?? err.message ?? err}`;
+});
+
+const _accountIds = computed(() => {
+  if (Array.isArray(props.accounts)) {
+    return props.accounts.map((a) => typeof a === 'string' ? a : a.id);
+  } else {
+    return [typeof props.accounts === 'string' ? props.accounts : props.accounts.id];
+  }
+})
+const onGrantClick = async () => {
+  grantLoading.value = true;
+  try {
+    for (const accountId of _accountIds.value) {
+      for (const scope of selectedScopes.value) {
+        await createRoleAssignment({
+          name: props.name,
+          roleAssignment: {
+            accountId: accountId,
+            roleId: selectedRole.value.id,
+            scope: {
+              resource: scope.value,
+              resourceType: scope.type,
+            }
+          }
+        });
+      }
+    }
+    grantError.value = null;
+    emit('grant', {role: selectedRole.value, scopes: selectedScopes.value});
+    hideAndClear();
+  } catch (e) {
+    grantError.value = e;
+  } finally {
+    grantLoading.value = false;
+  }
+}
+const onCancelClick = () => {
+  emit('cancel');
+  hideAndClear();
+}
+let hideAndClearHandle = 0;
+const hideAndClear = () => {
+  menuModel.value = false;
+  hideAndClearHandle = setTimeout(() => {
+    selectedRole.value = null;
+    selectedScopes.value = [];
+    grantError.value = null;
+  }, 250);
+}
+onScopeDispose(() => {
+  clearTimeout(hideAndClearHandle);
+});
+
+// role selection
+// todo: support pagination and/or filtering on the server
+const rolesWantCount = ref(100);
+const {items: rolesCollection} = useRolesCollection(() => ({name: props.name}), () => ({
+  wantCount: rolesWantCount.value
+}));
+
+const scopeDisabled = computed(() => !selectedRole.value);
+</script>
+
+<style scoped>
+</style>

--- a/ui/ops/src/routes/auth/accounts/GrantRoleBtn.vue
+++ b/ui/ops/src/routes/auth/accounts/GrantRoleBtn.vue
@@ -46,7 +46,7 @@ const props = defineProps({
     required: true,
   }
 });
-const emit = defineEmits(['grant', 'cancel']);
+const emit = defineEmits(['save', 'cancel']);
 
 const selectedRole = ref(null);
 const selectedScopes = ref([]);
@@ -70,10 +70,11 @@ const _accountIds = computed(() => {
 })
 const onGrantClick = async () => {
   grantLoading.value = true;
+  const ras = [];
   try {
     for (const accountId of _accountIds.value) {
       for (const scope of selectedScopes.value) {
-        await createRoleAssignment({
+        const res = await createRoleAssignment({
           name: props.name,
           roleAssignment: {
             accountId: accountId,
@@ -84,10 +85,11 @@ const onGrantClick = async () => {
             }
           }
         });
+        ras.push(res);
       }
     }
     grantError.value = null;
-    emit('grant', {role: selectedRole.value, scopes: selectedScopes.value});
+    emit('save', ras);
     hideAndClear();
   } catch (e) {
     grantError.value = e;

--- a/ui/ops/src/routes/auth/accounts/NewAccountBtn.vue
+++ b/ui/ops/src/routes/auth/accounts/NewAccountBtn.vue
@@ -1,0 +1,47 @@
+<template>
+  <v-btn>
+    New Account...
+    <v-menu v-model="menuVisible" activator="parent" :close-on-content-click="false">
+      <new-account-card :name="props.name" @save="onSave" @cancel="onCancel" ref="cardRef"/>
+    </v-menu>
+  </v-btn>
+</template>
+
+<script setup>
+import NewAccountCard from '@/routes/auth/accounts/NewAccountCard.vue';
+import {ref, watch} from 'vue';
+
+const props = defineProps({
+  name: {
+    type: String,
+    default: undefined
+  }
+});
+const emit = defineEmits(['save', 'cancel']);
+
+const menuVisible = ref(false);
+
+const onSave = (e) => {
+  emit('save', e);
+  menuVisible.value = false;
+};
+const onCancel = () => {
+  emit('cancel');
+  menuVisible.value = false;
+}
+// reset the new account form once the menu is hidden
+const cardRef = ref(null);
+watch(menuVisible, (value) => {
+  if (value) {
+    setTimeout(() => {
+      const form = cardRef.value;
+      if (!form) return;
+      form.reset();
+    }, 250);
+  }
+});
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/ops/src/routes/auth/accounts/NewAccountCard.vue
+++ b/ui/ops/src/routes/auth/accounts/NewAccountCard.vue
@@ -51,6 +51,7 @@
         <v-btn text="Create"
                color="primary"
                type="submit"
+               variant="flat"
                :disabled="!formValid"
                :loading="saveLoading"/>
         <v-btn text="Cancel" @click="onCancel"/>

--- a/ui/ops/src/routes/auth/accounts/NewAccountCard.vue
+++ b/ui/ops/src/routes/auth/accounts/NewAccountCard.vue
@@ -1,0 +1,186 @@
+<template>
+  <v-card min-width="440">
+    <v-form @submit.prevent="onSave"
+            v-model="formValid"
+            ref="formRef"
+            :disabled="formDisabled">
+      <v-card-title>New Account</v-card-title>
+      <v-card-text class="ga-2 d-flex flex-column">
+        <v-btn-toggle v-model="accountType"
+                      variant="outlined"
+                      divided
+                      mandatory
+                      density="comfortable"
+                      class="mb-2">
+          <v-btn :value="Account.Type.USER_ACCOUNT" text="User" v-tooltip:bottom="'User account'"/>
+          <v-btn :value="Account.Type.SERVICE_ACCOUNT" text="Service" v-tooltip:bottom="'Service account'"/>
+        </v-btn-toggle>
+        <template v-if="accountType === Account.Type.USER_ACCOUNT">
+          <v-text-field label="Full Name"
+                        v-model.trim="fullName"
+                        :rules="fullNameRules"
+                        required
+                        :counter="100"
+                        autocomplete="off"/>
+          <v-text-field label="Username"
+                        v-model.trim="username"
+                        :rules="usernameRules"
+                        required
+                        :counter="100"
+                        autocomplete="off"/>
+          <v-text-field label="Password"
+                        v-model.trim="password"
+                        required
+                        type="password"
+                        autocomplete="off"/>
+        </template>
+        <template v-if="accountType === Account.Type.SERVICE_ACCOUNT">
+          <v-text-field label="Account Name"
+                        v-model.trim="accountName"
+                        :rules="accountNameRules"
+                        required
+                        :counter="100"
+                        autocomplete="off"/>
+          <v-textarea label="Description"
+                      v-model.trim="description"
+                      :counter="500"
+                      autocomplete="off"/>
+        </template>
+      </v-card-text>
+      <v-card-actions>
+        <v-btn text="Create"
+               color="primary"
+               type="submit"
+               :disabled="!formValid"
+               :loading="saveLoading"/>
+        <v-btn text="Cancel" @click="onCancel"/>
+      </v-card-actions>
+    </v-form>
+  </v-card>
+</template>
+
+<script setup>
+import {createAccount, createServiceCredential} from '@/api/ui/account.js';
+import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
+import {computed, ref, watch} from 'vue';
+
+const props = defineProps({
+  name: {
+    type: String,
+    default: undefined,
+  }
+});
+
+const emit = defineEmits(['save', 'cancel', 'error']);
+
+const formRef = ref(null);
+const formValid = ref(false);
+const accountType = ref(Account.Type.USER_ACCOUNT);
+const fullName = ref('');
+const fullNameRules = computed(() => {
+  return [
+    (v) => !!v || 'Full Name is required',
+    (v) => v.length >= 3 || 'Full Name must be at least 3 characters',
+    (v) => v.length <= 100 || 'Full Name must be less than 100 characters',
+  ];
+})
+const username = ref('');
+const usernameRules = computed(() => {
+  return [
+    (v) => !!v || 'Username is required',
+    (v) => v.length >= 3 || 'Username must be at least 3 characters',
+    (v) => v.length <= 100 || 'Username must be less than 100 characters',
+    (v) => /^[a-zA-Z0-9.-_@]+$/.test(v) || 'Username must use only alphanumerics with .-_@',
+  ];
+})
+const password = ref('');
+// guess a suitable username based on the entered full name
+const nameToUsername = (name) => {
+  if (!name) return '';
+  return name.toLowerCase().replace(/[^a-zA-Z0-9.-_@]+/g, '.');
+};
+watch(fullName, (value, oldValue) => {
+  if (username.value && username.value !== nameToUsername(oldValue)) {
+    return; // manual username has been entered
+  }
+  username.value = nameToUsername(value);
+});
+
+const accountName = ref('');
+const accountNameRules = computed(() => {
+  return [
+    (v) => !!v || 'Account Name is required',
+    (v) => v.length >= 3 || 'Account Name must be at least 3 characters',
+    (v) => v.length <= 100 || 'Account Name must be less than 100 characters',
+  ];
+});
+const description = ref('');
+
+const formDisabled = ref(false);
+const saveLoading = ref(false);
+const reset = () => {
+  const form = formRef.value;
+  if (!form) return;
+  form.reset();
+  accountType.value = Account.Type.USER_ACCOUNT;
+}
+const onSave = async () => {
+  saveLoading.value = true;
+  formDisabled.value = true;
+  try {
+    switch (accountType.value) {
+      case Account.Type.USER_ACCOUNT: {
+        const createAccountReq = {
+          name: props.name,
+          account: {
+            type: Account.Type.USER_ACCOUNT,
+            displayName: fullName.value,
+            username: username.value,
+          },
+          password: password.value,
+        }
+        const account = await createAccount(createAccountReq);
+        emit('save', {account});
+        break;
+      }
+      case Account.Type.SERVICE_ACCOUNT: {
+        const createAccountReq = {
+          name: props.name,
+          account: {
+            type: Account.Type.SERVICE_ACCOUNT,
+            displayName: accountName.value,
+            description: description.value,
+          }
+        };
+        const account = await createAccount(createAccountReq);
+        const createServiceCredentialReq = {
+          name: props.name,
+          serviceCredential: {
+            accountId: account.id,
+            displayName: 'Credential 1',
+          }
+        };
+        const serviceCredential = await createServiceCredential(createServiceCredentialReq);
+        emit('save', {account, serviceCredential});
+        break;
+      }
+    }
+  } catch (e) {
+    console.warn(e);
+  } finally {
+    saveLoading.value = false;
+    formDisabled.value = false;
+  }
+};
+const onCancel = () => {
+  emit('cancel');
+}
+
+defineExpose({
+  reset,
+})
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/ops/src/routes/auth/accounts/NewAccountCard.vue
+++ b/ui/ops/src/routes/auth/accounts/NewAccountCard.vue
@@ -31,7 +31,9 @@
           <v-text-field label="Password"
                         v-model.trim="password"
                         required
-                        type="password"
+                        :type="showPassword ? 'text' : 'password'"
+                        :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+                        @click:append-inner="showPassword = !showPassword"
                         autocomplete="off"/>
         </template>
         <template v-if="accountType === Account.Type.SERVICE_ACCOUNT">
@@ -100,6 +102,7 @@ const usernameRules = computed(() => {
   ];
 })
 const password = ref('');
+const showPassword = ref(false);
 // guess a suitable username based on the entered full name
 const nameToUsername = (name) => {
   if (!name) return '';
@@ -136,6 +139,7 @@ const reset = () => {
   form.reset();
   accountType.value = Account.Type.USER_ACCOUNT;
   saveError.value = null;
+  showPassword.value = false;
 }
 
 const onSave = async () => {

--- a/ui/ops/src/routes/auth/accounts/NewAccountCard.vue
+++ b/ui/ops/src/routes/auth/accounts/NewAccountCard.vue
@@ -56,6 +56,11 @@
                :loading="saveLoading"/>
         <v-btn text="Cancel" @click="onCancel"/>
       </v-card-actions>
+      <v-expand-transition>
+        <div v-if="errorStr">
+          <v-alert type="error" :text="errorStr" tile class="mt-4"/>
+        </div>
+      </v-expand-transition>
     </v-form>
   </v-card>
 </template>
@@ -117,6 +122,12 @@ const accountNameRules = computed(() => {
 });
 const description = ref('');
 
+const saveError = ref(null);
+const errorStr = computed(() => {
+  if (!saveError.value) return null;
+  return saveError.value.message;
+});
+
 const formDisabled = ref(false);
 const saveLoading = ref(false);
 const reset = () => {
@@ -124,7 +135,9 @@ const reset = () => {
   if (!form) return;
   form.reset();
   accountType.value = Account.Type.USER_ACCOUNT;
+  saveError.value = null;
 }
+
 const onSave = async () => {
   saveLoading.value = true;
   formDisabled.value = true;
@@ -166,8 +179,9 @@ const onSave = async () => {
         break;
       }
     }
+    saveError.value = null;
   } catch (e) {
-    console.warn(e);
+    saveError.value = e;
   } finally {
     saveLoading.value = false;
     formDisabled.value = false;

--- a/ui/ops/src/routes/auth/accounts/NewAccountCard.vue
+++ b/ui/ops/src/routes/auth/accounts/NewAccountCard.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script setup>
-import {createAccount, createServiceCredential} from '@/api/ui/account.js';
+import {createAccount} from '@/api/ui/account.js';
 import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
 import {computed, ref, watch} from 'vue';
 
@@ -149,7 +149,9 @@ const onSave = async () => {
           account: {
             type: Account.Type.USER_ACCOUNT,
             displayName: fullName.value,
-            username: username.value,
+            userDetails: {
+              username: username.value,
+            }
           },
           password: password.value,
         }
@@ -167,15 +169,7 @@ const onSave = async () => {
           }
         };
         const account = await createAccount(createAccountReq);
-        const createServiceCredentialReq = {
-          name: props.name,
-          serviceCredential: {
-            accountId: account.id,
-            displayName: 'Credential 1',
-          }
-        };
-        const serviceCredential = await createServiceCredential(createServiceCredentialReq);
-        emit('save', {account, serviceCredential});
+        emit('save', {account});
         break;
       }
     }

--- a/ui/ops/src/routes/auth/accounts/RoleAssignmentLink.vue
+++ b/ui/ops/src/routes/auth/accounts/RoleAssignmentLink.vue
@@ -1,0 +1,44 @@
+<template>
+  <router-link :to="toAttr">{{ textStr }}</router-link>
+</template>
+
+<script setup>
+import {ResourceTypeById} from '@/api/ui/account.js';
+import {computed} from 'vue';
+
+const props = defineProps({
+  roleAssignment: {
+    type: Object, // type of RoleAssignment.AsObject & {role: Role.AsObject}
+    required: true,
+  }
+});
+
+const toAttr = computed(() => {
+  const roleAssignment = props.roleAssignment;
+  if (!roleAssignment) return null;
+  return {
+    name: 'roles',
+    params: {
+      roleId: roleAssignment.roleId,
+    }
+  };
+});
+const textStr = computed(() => {
+  let str = '';
+  if (!props.roleAssignment.scope) {
+    str += 'Global';
+  } else {
+    const typeStr = (() => {
+      const base = ResourceTypeById[props.roleAssignment.scope.resourceType];
+      return base[0] + base.slice(1).toLowerCase();
+    })();
+    str += `${typeStr} ${props.roleAssignment.scope.resource}`;
+  }
+  str += ` ${props.roleAssignment.role?.displayName ?? '...'}`;
+  return str;
+})
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/ops/src/routes/auth/accounts/ScopeAutocomplete.vue
+++ b/ui/ops/src/routes/auth/accounts/ScopeAutocomplete.vue
@@ -1,0 +1,160 @@
+<template>
+  <v-autocomplete
+      v-model="scopes"
+      :items="items"
+      v-model:search="searchModel"
+      no-filter
+      multiple chips closable-chips
+      return-object
+      label="Scope"
+      hide-details>
+    <template #chip="{props: chipProps, item}">
+      <grant-chip :title="item.raw.title" :value="item.raw.value" :type="item.raw.type" v-bind="chipProps"/>
+    </template>
+    <template #item="{props: itemProps, item, index}">
+      <v-list-subheader v-if="item.raw.header" :title="item.title" :class="{'mt-4': index !== 0}"/>
+      <v-list-item v-else-if="item.raw.onClick"
+                   v-bind="omit(itemProps, 'onClick')"
+                   @click="item.raw.onClick"
+                   base-color="info"/>
+      <v-list-item v-else-if="item.raw?.type === RoleAssignment.ResourceType.NAMED_RESOURCE" v-bind="itemProps">
+        <template #append>
+          <v-list-item-action>
+            <v-btn icon="mdi-file-tree" variant="plain" v-tooltip:bottom="'Also allow descendants'"
+                   @click="toggleNamedDescendants($event, item)"/>
+          </v-list-item-action>
+        </template>
+      </v-list-item>
+      <v-list-item v-else v-bind="itemProps" density="compact"/>
+    </template>
+  </v-autocomplete>
+</template>
+
+<script setup>
+import {useDevicesCollection, usePullDevicesMetadata} from '@/composables/devices.js';
+import GrantChip from '@/routes/auth/accounts/GrantChip.vue';
+import {useCohortStore} from '@/stores/cohort.js';
+import {RoleAssignment} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
+import {omit} from 'lodash';
+import {computed, ref, watch} from 'vue';
+
+const scopes = defineModel({
+  type: Array, // of string
+  default: () => [],
+});
+const searchModel = ref(null);
+const hasSearchText = computed(() => !!searchModel.value?.trim());
+
+const toggleNamedDescendants = (event, item) => {
+  event.stopPropagation();
+  const idx = scopes.value.findIndex((i) => i.value === item.value);
+  if (idx === -1) {
+    scopes.value.push({...item.raw, type: RoleAssignment.ResourceType.NAMED_RESOURCE_PATH_PREFIX});
+  } else {
+    scopes.value.splice(idx, 1);
+  }
+}
+
+// for selecting name and name-prefix items
+const listDevicesWantCount = ref(10);
+const onListDevicesShowMoreClick = () => {
+  listDevicesWantCount.value += 10;
+}
+watch(searchModel, () => listDevicesWantCount.value = 10);
+const listDevicesRequest = computed(() => {
+  if (!hasSearchText.value) return null; // don't search without text
+
+  const conditions = [];
+  const searchStr = searchModel.value;
+  const words = searchStr.split(/\s+/);
+  for (const word of words) {
+    conditions.push({stringContainsFold: word});
+  }
+  return {query: {conditionsList: conditions}};
+});
+const {
+  items: searchDevices,
+  loading: searchDevicesLoading,
+  hasMorePages: searchDevicesHasMorePages
+} = useDevicesCollection(listDevicesRequest, () => ({wantCount: listDevicesWantCount.value}));
+
+// for selecting zone and subsystem items
+const {
+  value: devicesMetadata,
+  loading: devicesMetadataLoading
+} = usePullDevicesMetadata(['metadata.location.zone', 'metadata.membership.subsystem']);
+
+// for selecting node items
+const cohortStore = useCohortStore();
+
+const items = computed(() => {
+  const items = [];
+
+  items.push({title: 'Device', header: true, loading: searchDevicesLoading.value});
+  if (!hasSearchText.value) {
+    items.push({title: 'Search to find specific devices', props: {disabled: true}});
+  } else {
+    const deviceToItem = (device) => {
+      const title = (() => {
+        return device.metadata?.appearance?.title || device.name;
+      })()
+      const subtitle = (() => {
+        if (title === device.name) return null;
+        return device.name;
+      })()
+      const props = {};
+      if (subtitle) {
+        props.subtitle = subtitle;
+        props.lines = '2';
+      }
+      return {title, type: RoleAssignment.ResourceType.NAMED_RESOURCE, value: device.name, props};
+    }
+    for (const device of searchDevices.value) {
+      items.push(deviceToItem(device));
+    }
+    if (!searchDevicesLoading.value && searchDevicesHasMorePages.value) {
+      items.push({
+        title: 'Load more...',
+        onClick: onListDevicesShowMoreClick,
+        props: {subtitle: 'Or refine your search'}
+      });
+    }
+  }
+
+  const addMdItems = (title, field, type) => {
+    items.push({title, header: true, loading: devicesMetadataLoading.value});
+    const counts = devicesMetadata.value?.fieldCountsList.find((i) => i.field === field);
+    if (!counts) return;
+    for (const name of counts.countsMap.map(([k]) => k).sort((a, b) => a.localeCompare(b))) {
+      items.push({title: name, type, value: name});
+    }
+  }
+  addMdItems('Zone', 'metadata.location.zone', RoleAssignment.ResourceType.ZONE);
+  addMdItems('Subsystem', 'metadata.membership.subsystem', RoleAssignment.ResourceType.SUBSYSTEM);
+
+  items.push({title: 'On Node', header: true, loading: cohortStore.loading.value});
+  for (const node of cohortStore.cohortNodes) {
+    items.push({title: node.name, type: RoleAssignment.ResourceType.NODE, value: node.name});
+  }
+
+  // filter based on search terms
+  const matcher = ((str) => {
+    if (!str) return () => true;
+    const words = str.split(/\s+/).map(word => word.toLowerCase());
+    return (item) => {
+      if (!item.value) return true;
+      if (item.type === RoleAssignment.ResourceType.NAMED_RESOURCE || item.type === RoleAssignment.ResourceType.NAMED_RESOURCE_PATH_PREFIX) {
+        return true;
+      }
+      return words.every((word) => item.title.toLowerCase().includes(word));
+    };
+  })(searchModel.value);
+  return items.filter(matcher);
+});
+</script>
+
+<style scoped>
+:deep(.v-menu .v-list-item + .v-list-subheader) {
+  margin-top: 16px;
+}
+</style>

--- a/ui/ops/src/routes/auth/accounts/accounts.js
+++ b/ui/ops/src/routes/auth/accounts/accounts.js
@@ -1,0 +1,98 @@
+import {listAccounts} from '@/api/ui/account.js';
+import useCollection from '@/composables/collection.js';
+import {ChangeType} from '@smart-core-os/sc-api-grpc-web/types/change_pb.js';
+import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
+import {computed, toValue} from 'vue';
+
+/**
+ * @typedef {UseCollectionOptions<T>} ListOnlyCollectionOptions
+ * @property {function(R, ResourceCollection<T, any>): void} pullFn
+ * @template R
+ * @template T
+ */
+
+/**
+ * @param {import('vue').MaybeRefOrGetter<Partial<ListAccountsRequest.AsObject>>} request
+ * @param {import('vue').MaybeRefOrGetter<Partial<ListOnlyCollectionOptions<ListAccountsRequest.AsObject, Account.AsObject>>>?} options
+ * @return {UseCollectionResponse<Account.AsObject>}
+ */
+export function useAccountsCollection(request, options) {
+  const normOpts = computed(() => {
+    return {
+      cmp: (a, b) => a.id.localeCompare(b.id, undefined, {numeric: true}),
+      ...toValue(options)
+    };
+  });
+  const client = {
+    async listFn(req, tracker) {
+      const res = await listAccounts(req, tracker);
+      return {
+        items: res.accountsList,
+        nextPageToken: res.nextPageToken,
+        totalSize: res.totalSize
+      };
+    },
+    pullFn(req, resource) {
+      const opts = toValue(normOpts);
+      if (opts.pullFn) {
+        opts.pullFn(req, resource);
+      }
+    }
+  };
+
+  return useCollection(request, client, normOpts);
+}
+
+/**
+ * Returns an object that looks like a Pull Change that adds the given account.
+ * Needed because Accounts doesn't support pull and we'd like to reuse our utilities that do.
+ *
+ * @param {Account.AsObject} account
+ * @return {Object}
+ */
+export function accountToChangeList(account) {
+  const changes = {
+    changesList: [{
+      type: ChangeType.ADD,
+      newValue: account,
+    }]
+  };
+  return {
+    toObject() {
+      return changes;
+    },
+    getChangesList() {
+      return changes.changesList.map(change => ({toObject() { return change; } }));
+    }
+  }
+}
+
+/**
+ * @param {Account.Type} accountType
+ * @return {string}
+ */
+export function accountTypeIcon(accountType) {
+  switch (accountType) {
+    case Account.Type.USER_ACCOUNT:
+      return 'mdi-account';
+    case Account.Type.SERVICE_ACCOUNT:
+      return 'mdi-server';
+    default:
+      return 'mdi-account-question';
+  }
+}
+
+/**
+ * @param {Account.Type} accountType
+ * @return {string}
+ */
+export function accountTypeStr(accountType) {
+  switch (accountType) {
+    case Account.Type.USER_ACCOUNT:
+      return 'User Account';
+    case Account.Type.SERVICE_ACCOUNT:
+      return 'Service Account';
+    default:
+      return `Unknown Account Type ${accountType}`;
+  }
+}

--- a/ui/ops/src/routes/auth/accounts/accounts.js
+++ b/ui/ops/src/routes/auth/accounts/accounts.js
@@ -1,6 +1,6 @@
 import {listAccounts} from '@/api/ui/account.js';
 import useCollection from '@/composables/collection.js';
-import {ChangeType} from '@smart-core-os/sc-api-grpc-web/types/change_pb.js';
+import {ChangeType} from '@smart-core-os/sc-api-grpc-web/types/change_pb';
 import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
 import {computed, toValue} from 'vue';
 
@@ -50,11 +50,35 @@ export function useAccountsCollection(request, options) {
  * @param {Account.AsObject} account
  * @return {Object}
  */
-export function accountToChangeList(account) {
+export function accountToAddChange(account) {
   const changes = {
     changesList: [{
       type: ChangeType.ADD,
       newValue: account,
+    }]
+  };
+  return {
+    toObject() {
+      return changes;
+    },
+    getChangesList() {
+      return changes.changesList.map(change => ({toObject() { return change; } }));
+    }
+  }
+}
+
+/**
+ * Returns an object that looks like a Pull Change that deletes the given account.
+ * Needed because Accounts doesn't support pull and we'd like to reuse our utilities that do.
+ *
+ * @param {Account.AsObject} account
+ * @return {Object}
+ */
+export function accountToRemoveChange(account) {
+  const changes = {
+    changesList: [{
+      type: ChangeType.REMOVE,
+      oldValue: account,
     }]
   };
   return {

--- a/ui/ops/src/routes/auth/accounts/accounts.js
+++ b/ui/ops/src/routes/auth/accounts/accounts.js
@@ -1,0 +1,75 @@
+import {getAccount, listAccounts} from '@/api/ui/account.js';
+import {useAction} from '@/composables/action.js';
+import useCollection from '@/composables/collection.js';
+import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
+import {computed, toValue} from 'vue';
+
+/**
+ * @param {import('vue').MaybeRefOrGetter<Partial<ListAccountsRequest.AsObject>>} request
+ * @param {import('vue').MaybeRefOrGetter<Partial<ListOnlyCollectionOptions<ListAccountsRequest.AsObject, Account.AsObject>>>?} options
+ * @return {UseCollectionResponse<Account.AsObject>}
+ */
+export function useAccountsCollection(request, options) {
+  const normOpts = computed(() => {
+    return {
+      cmp: (a, b) => a.id.localeCompare(b.id, undefined, {numeric: true}),
+      ...toValue(options)
+    };
+  });
+  const client = {
+    async listFn(req, tracker) {
+      const res = await listAccounts(req, tracker);
+      return {
+        items: res.accountsList,
+        nextPageToken: res.nextPageToken,
+        totalSize: res.totalSize
+      };
+    },
+    pullFn(req, resource) {
+      const opts = toValue(normOpts);
+      if (opts.pullFn) {
+        opts.pullFn(req, resource);
+      }
+    }
+  };
+
+  return useCollection(request, client, normOpts);
+}
+
+/**
+ * @param {import('vue').MaybeRefOrGetter<Partial<GetAccountRequest.AsObject>>} request
+ * @return {ToRefs<UnwrapNestedRefs<UseActionResponse<Account.AsObject>>>}
+ */
+export function useGetAccount(request) {
+  return useAction(request, getAccount);
+}
+
+/**
+ * @param {Account.Type} accountType
+ * @return {string}
+ */
+export function accountTypeIcon(accountType) {
+  switch (accountType) {
+    case Account.Type.USER_ACCOUNT:
+      return 'mdi-account';
+    case Account.Type.SERVICE_ACCOUNT:
+      return 'mdi-server';
+    default:
+      return 'mdi-account-question';
+  }
+}
+
+/**
+ * @param {Account.Type} accountType
+ * @return {string}
+ */
+export function accountTypeStr(accountType) {
+  switch (accountType) {
+    case Account.Type.USER_ACCOUNT:
+      return 'User Account';
+    case Account.Type.SERVICE_ACCOUNT:
+      return 'Service Account';
+    default:
+      return `Unknown Account Type ${accountType}`;
+  }
+}

--- a/ui/ops/src/routes/auth/accounts/accounts.js
+++ b/ui/ops/src/routes/auth/accounts/accounts.js
@@ -44,17 +44,18 @@ export function useAccountsCollection(request, options) {
 }
 
 /**
- * Returns an object that looks like a Pull Change that adds the given account.
- * Needed because Accounts doesn't support pull and we'd like to reuse our utilities that do.
+ * Returns an object that looks like a Pull Change that adds the given val.
+ * Useful when an API doesn't support Pull but you want to reuse utilities that do.
  *
- * @param {Account.AsObject} account
+ * @param {T} val
  * @return {Object}
+ * @template T
  */
-export function accountToAddChange(account) {
+export function toAddChange(val) {
   const changes = {
     changesList: [{
       type: ChangeType.ADD,
-      newValue: account,
+      newValue: val,
     }]
   };
   return {
@@ -68,17 +69,18 @@ export function accountToAddChange(account) {
 }
 
 /**
- * Returns an object that looks like a Pull Change that deletes the given account.
- * Needed because Accounts doesn't support pull and we'd like to reuse our utilities that do.
+ * Returns an object that looks like a Pull Change that deletes the given val.
+ * Useful when an API doesn't support Pull but you want to reuse
  *
- * @param {Account.AsObject} account
+ * @param {T} val
  * @return {Object}
+ * @template T
  */
-export function accountToRemoveChange(account) {
+export function toRemoveChange(val) {
   const changes = {
     changesList: [{
       type: ChangeType.REMOVE,
-      oldValue: account,
+      oldValue: val,
     }]
   };
   return {

--- a/ui/ops/src/routes/auth/accounts/accounts.js
+++ b/ui/ops/src/routes/auth/accounts/accounts.js
@@ -1,8 +1,9 @@
 import {getAccount, listAccounts} from '@/api/ui/account.js';
 import {useAction} from '@/composables/action.js';
 import useCollection from '@/composables/collection.js';
+import {toAddChange, toRemoveChange, useRoleAssignmentsCollection} from '@/routes/auth/accounts.js';
 import {Account} from '@vanti-dev/sc-bos-ui-gen/proto/account_pb';
-import {computed, toValue} from 'vue';
+import {computed, effectScope, reactive, toValue, watch} from 'vue';
 
 /**
  * @param {import('vue').MaybeRefOrGetter<Partial<ListAccountsRequest.AsObject>>} request
@@ -72,4 +73,80 @@ export function accountTypeStr(accountType) {
     default:
       return `Unknown Account Type ${accountType}`;
   }
+}
+
+/**
+ * @typedef {UseCollectionResponse<RoleAssignment.AsObject>} AccountRoleAssignmentsResponse
+ * @property {function((Array<RoleAssignment.AsObject> | RoleAssignment.AsObject)): void} applyCreate - call after a local change to update the collection
+ */
+
+/**
+ * Returns a reactive object containing a key for each account in accounts.
+ * The values associated with each account are like the return value of useRoleAssignmentsCollection.
+ * Each value also has an applyCreate method that can be called to update the collection with a local change,
+ * say after assigning new roles to the account.
+ *
+ * @param {import('vue').MaybeRefOrGetter<Array<string|Account.AsObject>>} accounts
+ * @param {import('vue').MaybeRefOrGetter<null | Partial<ListRoleAssignmentsRequest.AsObject>>} [baseRequest]
+ * @return {import('vue').Reactive<Record<string, AccountRoleAssignmentsResponse>>}
+ */
+export function useAccountsRoleAssignments(accounts, baseRequest) {
+  const dict = reactive(/** @type {Record<string, AccountRoleAssignmentsResponse>} */ {}); // key is accountId
+  const closers = /** @type {Record<string, function():void>} */ {}; // key is accountId
+
+  watch(() => toValue(accounts), (accounts) => {
+    const toDelete = new Set(Object.keys(closers));
+    const toAdd = new Set(); // of accountIds
+    for (const account of accounts) {
+      const accountId = (() => {
+        if (typeof account === 'string') return account;
+        return account.id;
+      })();
+      if (closers[accountId]) {
+        toDelete.delete(accountId);
+      } else {
+        toAdd.add(accountId);
+      }
+    }
+
+    for (const accountId of toDelete) {
+      closers[accountId]();
+      delete closers[accountId];
+      delete dict[accountId];
+    }
+
+    for (const accountId of toAdd) {
+      const scope = effectScope();
+      closers[accountId] = () => scope.stop();
+      scope.run(() => {
+        const _request = {...(toValue(baseRequest) || {})};
+        _request.filter = `account_id=${accountId}`;
+        /** @type {ResourceCollection<RoleAssignment.AsObject>} */
+        let pullResource = null; // filled by callback
+        dict[accountId] = {
+          ...useRoleAssignmentsCollection(_request, {
+            pullFn: (req, resource) => {
+              pullResource = resource;
+            }
+          }),
+          applyCreate(changes) {
+            if (!pullResource) return; // too early
+            if (!Array.isArray(changes)) changes = [changes];
+            for (const change of changes) {
+              pullResource.lastResponse = toAddChange(change);
+            }
+          },
+          applyRemove(changes) {
+            if (!pullResource) return; // too early
+            if (!Array.isArray(changes)) changes = [changes];
+            for (const change of changes) {
+              pullResource.lastResponse = toRemoveChange(change);
+            }
+          }
+        };
+      })
+    }
+  }, {deep: true, immediate: true});
+
+  return dict
 }

--- a/ui/ops/src/routes/auth/accounts/route.js
+++ b/ui/ops/src/routes/auth/accounts/route.js
@@ -1,0 +1,17 @@
+export default [
+  {
+    path: 'accounts/:accountId?',
+    components: {
+      default: () => import('./AccountsPage.vue')
+    },
+    props: {
+      default: false,
+      sidebar: true
+    },
+    meta: {
+      authentication: {
+        rolesRequired: ['superAdmin', 'admin', 'operator', 'viewer']
+      }
+    }
+  }
+];

--- a/ui/ops/src/routes/auth/accounts/route.js
+++ b/ui/ops/src/routes/auth/accounts/route.js
@@ -1,12 +1,14 @@
 export default [
   {
     path: 'accounts/:accountId?',
+    name: 'accounts',
     components: {
-      default: () => import('./AccountsPage.vue')
+      default: () => import('./AccountsPage.vue'),
+      sidebar: () => import('./AccountsSidebar.vue')
     },
     props: {
-      default: false,
-      sidebar: true
+      default: true,
+      sidebar: false
     },
     meta: {
       authentication: {

--- a/ui/ops/src/routes/auth/roles/DeleteRolesBtn.vue
+++ b/ui/ops/src/routes/auth/roles/DeleteRolesBtn.vue
@@ -1,0 +1,61 @@
+<template>
+  <v-btn>
+    Delete
+    <v-dialog activator="parent" max-width="440" v-model="dialogVisible">
+      <v-card :title="dialogTitle">
+        <v-card-text>Are you sure you want to delete these roles? This cannot be undone!</v-card-text>
+        <v-card-actions>
+          <v-btn text="Cancel" @click="onCancel" :disabled="deleteLoading"/>
+          <v-btn text="Delete" @click="onDelete" type="submit" color="error" variant="flat" :loading="deleteLoading"/>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-btn>
+</template>
+
+<script setup>
+import {deleteRole} from '@/api/ui/account.js';
+import {computed, ref} from 'vue';
+
+const props = defineProps({
+  name: {
+    type: String,
+    default: undefined,
+  },
+  roles: {
+    type: Array,
+    default: () => [], // of Role.AsObject
+  }
+});
+const emit = defineEmits(['cancel', 'delete']);
+
+const dialogVisible = ref(false);
+const dialogTitle = computed(() => {
+  if (props.roles.length === 1) {
+    return `Delete Role ${props.roles[0].displayName}`;
+  }
+  return `Delete ${props.roles.length} Roles`;
+});
+const deleteLoading = ref(false);
+const onCancel = () => {
+  emit('cancel');
+  dialogVisible.value = false;
+}
+const onDelete = async () => {
+  deleteLoading.value = true;
+  try {
+    const selected = props.roles;
+    for (const account of selected) {
+      await deleteRole({id: account.id, allowMissing: true});
+    }
+    emit('delete');
+    dialogVisible.value = false;
+  } finally {
+    deleteLoading.value = false;
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/ops/src/routes/auth/roles/NewRoleBtn.vue
+++ b/ui/ops/src/routes/auth/roles/NewRoleBtn.vue
@@ -1,0 +1,47 @@
+<template>
+  <v-btn>
+    New Role...
+    <v-menu v-model="menuVisible" activator="parent" :close-on-content-click="false">
+      <new-role-card :name="props.name" @save="onSave" @cancel="onCancel" ref="cardRef"/>
+    </v-menu>
+  </v-btn>
+</template>
+
+<script setup>
+import NewRoleCard from '@/routes/auth/roles/NewRoleCard.vue';
+import {ref, watch} from 'vue';
+
+const props = defineProps({
+  name: {
+    type: String,
+    default: undefined
+  }
+});
+const emit = defineEmits(['save', 'cancel']);
+
+const menuVisible = ref(false);
+
+const onSave = (e) => {
+  emit('save', e);
+  menuVisible.value = false;
+};
+const onCancel = () => {
+  emit('cancel');
+  menuVisible.value = false;
+}
+// reset the new account form once the menu is hidden
+const cardRef = ref(null);
+watch(menuVisible, (value) => {
+  if (value) {
+    setTimeout(() => {
+      const form = cardRef.value;
+      if (!form) return;
+      form.reset();
+    }, 250);
+  }
+});
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/ops/src/routes/auth/roles/NewRoleCard.vue
+++ b/ui/ops/src/routes/auth/roles/NewRoleCard.vue
@@ -1,0 +1,117 @@
+<template>
+  <v-card min-width="440">
+    <v-form @submit.prevent="onSave"
+            v-model="formValid"
+            ref="formRef"
+            :disabled="formDisabled">
+      <v-card-title>New Role</v-card-title>
+      <v-card-text class="ga-2 d-flex flex-column">
+        <v-text-field
+            label="Name"
+            v-model.trim="displayName"
+            :rules="displayNameRules"
+            required
+            :counter="100"
+            autocomplete="off"/>
+        <v-textarea
+            label="Description"
+            v-model.trim="description"
+            :rules="descriptionRules"
+            :counter="250"
+            autocomplete="off"/>
+      </v-card-text>
+      <v-card-actions>
+        <v-btn text="Create"
+               color="primary"
+               type="submit"
+               variant="flat"
+               :disabled="!formValid"
+               :loading="saveLoading"/>
+        <v-btn text="Cancel" @click="onCancel"/>
+      </v-card-actions>
+      <v-expand-transition>
+        <div v-if="errorStr">
+          <v-alert type="error" :text="errorStr" tile class="mt-4"/>
+        </div>
+      </v-expand-transition>
+    </v-form>
+  </v-card>
+</template>
+
+<script setup>
+import {createRole} from '@/api/ui/account.js';
+import {computed, ref} from 'vue';
+
+const props = defineProps({
+  name: {
+    type: String,
+    default: undefined,
+  }
+});
+
+const emit = defineEmits(['save', 'cancel', 'error']);
+
+const formRef = ref(null);
+const formValid = ref(false);
+const displayName = ref('');
+const displayNameRules = computed(() => {
+  return [
+    (v) => !!v || 'Name is required',
+    (v) => v.length >= 3 || 'Name must be at least 3 characters',
+    (v) => v.length <= 100 || 'Name must be less than 100 characters',
+    // todo: add validation to check for uniqueness of the name.
+    //   Blocked on an API to check this
+  ];
+})
+const description = ref('');
+const descriptionRules = computed(() => {
+  return [];
+});
+
+const saveError = ref(null);
+const errorStr = computed(() => {
+  if (!saveError.value) return null;
+  return saveError.value.message;
+})
+
+const formDisabled = ref(false);
+const saveLoading = ref(false);
+const reset = () => {
+  const form = formRef.value;
+  if (!form) return;
+  form.reset();
+  saveError.value = null;
+}
+const onSave = async () => {
+  saveLoading.value = true;
+  formDisabled.value = true;
+  try {
+    const createRoleReq = {
+      name: props.name,
+      role: {
+        displayName: displayName.value,
+        description: description.value,
+      }
+    }
+    const role = await createRole(createRoleReq);
+    emit('save', {role});
+    saveError.value = null;
+  } catch (e) {
+    saveError.value = e;
+  } finally {
+    saveLoading.value = false;
+    formDisabled.value = false;
+  }
+};
+const onCancel = () => {
+  emit('cancel');
+}
+
+defineExpose({
+  reset,
+})
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/ops/src/routes/auth/roles/RolesPage.vue
+++ b/ui/ops/src/routes/auth/roles/RolesPage.vue
@@ -114,11 +114,6 @@ watch(sidebarItem, (item) => {
   sidebar.data = {role: item, updateRole: onRoleUpdate};
   sidebar.visible = true;
 }, {immediate: true});
-watch(() => sidebar.visible, (visible) => {
-  if (!visible && props.roleId) {
-    router.push({name: 'roles'});
-  }
-});
 
 const latestRole = ref(null);
 

--- a/ui/ops/src/routes/auth/roles/RolesPage.vue
+++ b/ui/ops/src/routes/auth/roles/RolesPage.vue
@@ -18,7 +18,9 @@
           disable-sort
           return-object
           show-select
-          v-model="selectedRoles">
+          v-model="selectedRoles"
+          :row-props="tableRowProps"
+          @click:row="onRowClick">
         <template #top>
           <v-expand-transition>
             <div v-if="tableErrorStr">
@@ -41,11 +43,21 @@
 </template>
 
 <script setup>
+import {updateRole} from '@/api/ui/account.js';
 import {useDataTableCollection} from '@/composables/table.js';
-import {toAddChange, toRemoveChange, useRolesCollection} from '@/routes/auth/accounts.js';
+import {toAddChange, toRemoveChange, toUpdateChange, useGetRole, useRolesCollection} from '@/routes/auth/accounts.js';
 import DeleteRolesBtn from '@/routes/auth/roles/DeleteRolesBtn.vue';
 import NewRoleBtn from '@/routes/auth/roles/NewRoleBtn.vue';
-import {computed, ref} from 'vue';
+import {useSidebarStore} from '@/stores/sidebar.js';
+import {computed, ref, watch} from 'vue';
+import {useRouter} from 'vue-router';
+
+const props = defineProps({
+  roleId: {
+    type: String,
+    default: null,
+  }
+});
 
 // used to fake PullRoles when creating a new role.
 // the var isn't reactive, but the value will be whenever it's set
@@ -59,13 +71,13 @@ const rolesCollectionOpts = computed(() => {
       pullRolesResource = resource;
     }
   };
-})
+});
 const rolesCollection = useRolesCollection({}, rolesCollectionOpts);
 const tableAttrs = useDataTableCollection(wantCount, rolesCollection);
 const tableHeaders = computed(() => {
   return [
     {title: 'Name', key: 'displayName', maxWidth: '10em', cellProps: {class: 'text-overflow-ellipsis'}},
-    {title: 'Permissions', key: 'permissions', align: 'end', maxWidth: '10em', cellProps: {class: 'text-overflow-ellipsis'}},
+    {title: 'Permissions', key: 'permissions', align: 'end', maxWidth: '10em'},
   ]
 });
 
@@ -73,6 +85,39 @@ const tableErrorStr = computed(() => {
   const errors = rolesCollection.errors.value;
   if (errors.length === 0) return null;
   return 'Error fetching roles: ' + errors.map((e) => (e.error ?? e).message ?? e).join(', ');
+});
+const tableRowProps = ({item}) => {
+  return {
+    class: {
+      'row-selected': selectedRoles.value.includes(item),
+      'row-active': item.id === props.roleId,
+    }
+  };
+};
+
+const router = useRouter();
+const onRowClick = (_, {item}) => {
+  if (item.id === props.roleId) return; // don't click on the same item
+  router.push({name: 'roles', params: {roleId: item.id}});
+}
+const sidebar = useSidebarStore();
+const {response: sidebarItem, refresh: refreshSidebarItem} = useGetRole(() => {
+  if (!props.roleId) return null;
+  return {id: props.roleId};
+});
+watch(sidebarItem, (item) => {
+  if (!item) {
+    sidebar.closeSidebar();
+    return;
+  }
+  sidebar.title = item.displayName || `Role ${props.roleId}`;
+  sidebar.data = {role: item, updateRole: onRoleUpdate};
+  sidebar.visible = true;
+}, {immediate: true});
+watch(() => sidebar.visible, (visible) => {
+  if (!visible && props.roleId) {
+    router.push({name: 'roles'});
+  }
 });
 
 const latestRole = ref(null);
@@ -83,6 +128,32 @@ const onNewRoleSave = ({role}) => {
   }
   latestRole.value = role;
 };
+const onRoleUpdate = async ({role}) => {
+  const oldRole = (() => {
+    if (sidebarItem.value?.id === role.id) return sidebarItem.value;
+    return rolesCollection.items.value.find((r) => r.id === role.id);
+  })();
+
+  const newRole = await updateRole({role})
+
+  if (!oldRole) {
+    // we can't do a dynamic of the role, so just refresh the whole list
+    rolesCollection.refresh();
+  } else {
+    // this will update the role in the collection
+    pullRolesResource.lastResponse = toUpdateChange(oldRole, newRole);
+  }
+  if (latestRole.value?.id === role.id) {
+    latestRole.value = newRole;
+  }
+  selectedRoles.value = selectedRoles.value.map((r) => {
+    if (r.id === role.id) return newRole;
+    return r;
+  });
+  refreshSidebarItem();
+
+  return newRole;
+}
 
 const selectedRoles = ref([]);
 
@@ -98,13 +169,26 @@ const onDelete = () => {
     if (_latest && role.id === _latest.id) {
       latestRole.value = null;
     }
+    if (role.id === props.roleId) {
+      router.push({name: 'roles'});
+    }
   }
   selectedRoles.value = [];
 }
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 :deep(.v-toolbar__append) {
   gap: 1rem;
+}
+
+.v-data-table {
+  :deep(.row-selected) {
+    background-color: rgba(var(--v-theme-primary), 0.1);
+  }
+
+  :deep(.row-active) {
+    background-color: rgba(var(--v-theme-primary), 0.4);
+  }
 }
 </style>

--- a/ui/ops/src/routes/auth/roles/RolesPage.vue
+++ b/ui/ops/src/routes/auth/roles/RolesPage.vue
@@ -45,9 +45,10 @@
 <script setup>
 import {updateRole} from '@/api/ui/account.js';
 import {useDataTableCollection} from '@/composables/table.js';
-import {toAddChange, toRemoveChange, toUpdateChange, useGetRole, useRolesCollection} from '@/routes/auth/accounts.js';
+import {toAddChange, toRemoveChange, toUpdateChange} from '@/routes/auth/accounts.js';
 import DeleteRolesBtn from '@/routes/auth/roles/DeleteRolesBtn.vue';
 import NewRoleBtn from '@/routes/auth/roles/NewRoleBtn.vue';
+import {useGetRole, useRolesCollection} from '@/routes/auth/roles/roles.js';
 import {useSidebarStore} from '@/stores/sidebar.js';
 import {computed, ref, watch} from 'vue';
 import {useRouter} from 'vue-router';

--- a/ui/ops/src/routes/auth/roles/RolesPage.vue
+++ b/ui/ops/src/routes/auth/roles/RolesPage.vue
@@ -35,7 +35,7 @@
           <span class="opacity-50 ml-2" v-if="item.description">{{ item.description }}</span>
         </template>
         <template #item.permissions="{item}">
-          {{ (item.permissionsList ?? []).length.toLocaleString() }}
+          {{ (item.permissionIdsList ?? []).length.toLocaleString() }}
         </template>
       </v-data-table-server>
     </v-card-text>
@@ -123,13 +123,14 @@ const onNewRoleSave = ({role}) => {
   }
   latestRole.value = role;
 };
-const onRoleUpdate = async ({role}) => {
+const onRoleUpdate = async ({role, updateMask}) => {
   const oldRole = (() => {
     if (sidebarItem.value?.id === role.id) return sidebarItem.value;
     return rolesCollection.items.value.find((r) => r.id === role.id);
   })();
 
-  const newRole = await updateRole({role})
+  const mask = updateMask && updateMask.length > 0 && {pathsList: updateMask} || undefined;
+  const newRole = await updateRole({role, updateMask: mask});
 
   if (!oldRole) {
     // we can't do a dynamic of the role, so just refresh the whole list

--- a/ui/ops/src/routes/auth/roles/RolesPage.vue
+++ b/ui/ops/src/routes/auth/roles/RolesPage.vue
@@ -1,0 +1,97 @@
+<template>
+  <v-card elevation="0" class="rounded-lg">
+    <v-toolbar title="Roles" color="transparent" class="px-4 pt-2">
+      <template #append>
+        <delete-roles-btn
+            v-if="showDeleteRolesBtn"
+            color="error"
+            variant="outlined"
+            :roles="selectedRoles"
+            @delete="onDelete"/>
+        <new-role-btn variant="flat" color="primary" @save="onNewRoleSave"/>
+      </template>
+    </v-toolbar>
+    <v-card-text>
+      <v-data-table-server
+          v-bind="tableAttrs"
+          :headers="tableHeaders"
+          disable-sort
+          return-object
+          show-select
+          v-model="selectedRoles">
+        <!-- no header select item -->
+        <template #header.data-table-select/>
+        <template #item.displayName="{item}">
+          <span>{{ item.displayName }}</span>
+          <span class="opacity-50 ml-2" v-if="item.description">{{ item.description }}</span>
+        </template>
+        <template #item.permissions="{item}">
+          {{ (item.permissionsList ?? []).length.toLocaleString() }}
+        </template>
+      </v-data-table-server>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup>
+import {useDataTableCollection} from '@/composables/table.js';
+import {toAddChange, toRemoveChange, useRolesCollection} from '@/routes/auth/accounts.js';
+import DeleteRolesBtn from '@/routes/auth/roles/DeleteRolesBtn.vue';
+import NewRoleBtn from '@/routes/auth/roles/NewRoleBtn.vue';
+import {computed, ref} from 'vue';
+
+// used to fake PullRoles when creating a new role.
+// the var isn't reactive, but the value will be whenever it's set
+let pullRolesResource = /** @type {ResourceCollection<Role.AsObject, *> | null} */ null;
+
+const wantCount = ref(20);
+const rolesCollectionOpts = computed(() => {
+  return {
+    wantCount: wantCount.value,
+    pullFn: (_, resource) => {
+      pullRolesResource = resource;
+    }
+  };
+})
+const rolesCollection = useRolesCollection({}, rolesCollectionOpts);
+const tableAttrs = useDataTableCollection(wantCount, rolesCollection);
+const tableHeaders = computed(() => {
+  return [
+    {title: 'Name', key: 'displayName', maxWidth: '10em', cellProps: {class: 'text-overflow-ellipsis'}},
+    {title: 'Permissions', key: 'permissions', align: 'end', maxWidth: '10em', cellProps: {class: 'text-overflow-ellipsis'}},
+  ]
+});
+
+const latestRole = ref(null);
+
+const onNewRoleSave = ({role}) => {
+  if (pullRolesResource) {
+    pullRolesResource.lastResponse = toAddChange(role);
+  }
+  latestRole.value = role;
+};
+
+const selectedRoles = ref([]);
+
+const showDeleteRolesBtn = computed(() => selectedRoles.value.length > 0);
+const onDelete = () => {
+  if (pullRolesResource) {
+    for (const role of selectedRoles.value) {
+      pullRolesResource.lastResponse = toRemoveChange(role);
+    }
+  }
+  const _latest = latestRole.value;
+  for (const role of selectedRoles.value) {
+    if (_latest && role.id === _latest.id) {
+      latestRole.value = null;
+    }
+  }
+  selectedRoles.value = [];
+}
+</script>
+
+<style scoped>
+:deep(.v-toolbar__append) {
+  gap: 1rem;
+}
+</style>

--- a/ui/ops/src/routes/auth/roles/RolesPage.vue
+++ b/ui/ops/src/routes/auth/roles/RolesPage.vue
@@ -19,6 +19,13 @@
           return-object
           show-select
           v-model="selectedRoles">
+        <template #top>
+          <v-expand-transition>
+            <div v-if="tableErrorStr">
+              <v-alert type="error" :text="tableErrorStr"/>
+            </div>
+          </v-expand-transition>
+        </template>
         <!-- no header select item -->
         <template #header.data-table-select/>
         <template #item.displayName="{item}">
@@ -60,6 +67,12 @@ const tableHeaders = computed(() => {
     {title: 'Name', key: 'displayName', maxWidth: '10em', cellProps: {class: 'text-overflow-ellipsis'}},
     {title: 'Permissions', key: 'permissions', align: 'end', maxWidth: '10em', cellProps: {class: 'text-overflow-ellipsis'}},
   ]
+});
+
+const tableErrorStr = computed(() => {
+  const errors = rolesCollection.errors.value;
+  if (errors.length === 0) return null;
+  return 'Error fetching roles: ' + errors.map((e) => (e.error ?? e).message ?? e).join(', ');
 });
 
 const latestRole = ref(null);

--- a/ui/ops/src/routes/auth/roles/RolesSideBar.vue
+++ b/ui/ops/src/routes/auth/roles/RolesSideBar.vue
@@ -20,15 +20,39 @@
     </template>
     <v-list density="compact">
       <v-list-subheader>{{ permissionsListTitle }}</v-list-subheader>
-      <v-list-item v-for="perm in permissionsList" :key="perm">
-        <v-list-item-title>{{ perm }}</v-list-item-title>
-      </v-list-item>
+      <v-expand-transition group>
+        <v-list-item
+            v-for="perm in permissionsToggleList" :key="perm.id"
+            density="compact"
+            @click="onPermissionClick(perm)">
+          <template #prepend>
+            <v-checkbox-btn :model-value="perm.assigned" color="primary" density="compact" class="mr-2"/>
+          </template>
+          <v-list-item-title>{{ perm.displayName }}</v-list-item-title>
+          <v-menu activator="parent" location="left" open-on-hover>
+            <v-card width="20em">
+              <v-card-title class="pb-0">{{ perm.displayName }}</v-card-title>
+              <v-card-subtitle>{{ perm.id }}</v-card-subtitle>
+              <v-card-text>{{ perm.description }}</v-card-text>
+              <template v-if="perm.implies.length > 0">
+                <v-card-subtitle class="pt-2">Implies</v-card-subtitle>
+                <v-card-text class="pt-0">{{ perm.implies.join(', ') }}</v-card-text>
+              </template>
+              <template v-if="perm.dependsOn.length > 0">
+                <v-card-subtitle class="pt-2">Depends On</v-card-subtitle>
+                <v-card-text class="pt-0">{{ perm.dependsOn.join(', ') }}</v-card-text>
+              </template>
+            </v-card>
+          </v-menu>
+        </v-list-item>
+      </v-expand-transition>
     </v-list>
   </side-bar>
 </template>
 
 <script setup>
 import SideBar from '@/components/SideBar.vue';
+import {useAssignedPermissions} from '@/routes/auth/roles/roles.js';
 import {useSidebarStore} from '@/stores/sidebar.js';
 import {computed, ref} from 'vue';
 import {useRouter} from 'vue-router';
@@ -48,13 +72,29 @@ const permissionsListTitle = computed(() => {
   }
 });
 
+const {
+  toggleList: permissionsToggleList,
+  addPermission, removePermission
+} = useAssignedPermissions(permissionsList);
+const onPermissionClick = async (perm) => {
+  const newRole = {
+    ...role.value
+  }
+  if (perm.assigned) {
+    newRole.permissionIdsList = removePermission(perm);
+  } else {
+    newRole.permissionIdsList = addPermission(perm);
+  }
+  await sidebar.data.updateRole({role: newRole, updateMask: ['permission_ids']});
+}
+
 const editMode = ref(false);
 const saving = ref(false);
 const saveError = ref(null);
 
 const router = useRouter();
 const onCloseClick = () => {
-  router.push({name: 'accounts'});
+  router.push({name: 'roles'});
 }
 const onEditClick = () => {
   editDescriptionModel.value = role.value?.description ?? '';
@@ -70,7 +110,7 @@ const onSaveClick = async () => {
       ...role.value,
       description: editDescriptionModel.value
     }
-    await sidebar.data.updateRole({role: newRole});
+    await sidebar.data.updateRole({role: newRole, updateMask: ['description']});
     saveError.value = null;
   } catch (e) {
     saveError.value = e;

--- a/ui/ops/src/routes/auth/roles/RolesSideBar.vue
+++ b/ui/ops/src/routes/auth/roles/RolesSideBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <side-bar>
+  <side-bar @close="onCloseClick">
     <template #actions>
       <v-btn v-if="!editMode" @click="onEditClick" icon="mdi-pencil" variant="plain" size="small"/>
     </template>
@@ -31,6 +31,7 @@
 import SideBar from '@/components/SideBar.vue';
 import {useSidebarStore} from '@/stores/sidebar.js';
 import {computed, ref} from 'vue';
+import {useRouter} from 'vue-router';
 
 const sidebar = useSidebarStore();
 const role = computed(() => sidebar.data?.role);
@@ -50,6 +51,11 @@ const permissionsListTitle = computed(() => {
 const editMode = ref(false);
 const saving = ref(false);
 const saveError = ref(null);
+
+const router = useRouter();
+const onCloseClick = () => {
+  router.push({name: 'accounts'});
+}
 const onEditClick = () => {
   editDescriptionModel.value = role.value?.description ?? '';
   editMode.value = true;

--- a/ui/ops/src/routes/auth/roles/RolesSideBar.vue
+++ b/ui/ops/src/routes/auth/roles/RolesSideBar.vue
@@ -31,16 +31,20 @@
           <v-list-item-title>{{ perm.displayName }}</v-list-item-title>
           <v-menu activator="parent" location="left" open-on-hover>
             <v-card width="20em">
-              <v-card-title class="pb-0">{{ perm.displayName }}</v-card-title>
+              <v-card-title class="pb-0 text-wrap">{{ perm.displayName }}</v-card-title>
               <v-card-subtitle>{{ perm.id }}</v-card-subtitle>
               <v-card-text>{{ perm.description }}</v-card-text>
               <template v-if="perm.implies.length > 0">
                 <v-card-subtitle class="pt-2">Implies</v-card-subtitle>
-                <v-card-text class="pt-0">{{ perm.implies.join(', ') }}</v-card-text>
+                <v-card-text class="pt-0">
+                  <div v-for="p of perm.implies" :key="p.id">{{ p.displayName }}</div>
+                </v-card-text>
               </template>
               <template v-if="perm.dependsOn.length > 0">
                 <v-card-subtitle class="pt-2">Depends On</v-card-subtitle>
-                <v-card-text class="pt-0">{{ perm.dependsOn.join(', ') }}</v-card-text>
+                <v-card-text class="pt-0">
+                  <div v-for="p of perm.dependsOn" :key="p.id">{{ p.displayName }}</div>
+                </v-card-text>
               </template>
             </v-card>
           </v-menu>

--- a/ui/ops/src/routes/auth/roles/RolesSideBar.vue
+++ b/ui/ops/src/routes/auth/roles/RolesSideBar.vue
@@ -1,0 +1,82 @@
+<template>
+  <side-bar>
+    <template #actions>
+      <v-btn v-if="!editMode" @click="onEditClick" icon="mdi-pencil" variant="plain" size="small"/>
+    </template>
+    <template v-if="!editMode">
+      <p class="px-4 my-4" v-if="role?.description">{{ role.description }}</p>
+    </template>
+    <template v-else>
+      <v-textarea
+          class="ma-4"
+          v-model="editDescriptionModel"
+          label="Description"
+          :counter="250"
+          autocomplete="off"/>
+      <div class="d-flex ga-2 ma-4">
+        <v-btn @click="onSaveClick" variant="flat" color="primary">Save</v-btn>
+        <v-btn @click="onCancelClick" variant="flat">Cancel</v-btn>
+      </div>
+    </template>
+    <v-list density="compact">
+      <v-list-subheader>{{ permissionsListTitle }}</v-list-subheader>
+      <v-list-item v-for="perm in permissionsList" :key="perm">
+        <v-list-item-title>{{ perm }}</v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </side-bar>
+</template>
+
+<script setup>
+import SideBar from '@/components/SideBar.vue';
+import {useSidebarStore} from '@/stores/sidebar.js';
+import {computed, ref} from 'vue';
+
+const sidebar = useSidebarStore();
+const role = computed(() => sidebar.data?.role);
+const permissionsList = computed(() => role.value?.permissionIdsList ?? []);
+const permissionsListTitle = computed(() => {
+  const len = permissionsList.value.length;
+  switch (len) {
+    case 0:
+      return 'No Permissions';
+    case 1:
+      return '1 Permission';
+    default:
+      return `${len} Permissions`;
+  }
+});
+
+const editMode = ref(false);
+const saving = ref(false);
+const saveError = ref(null);
+const onEditClick = () => {
+  editDescriptionModel.value = role.value?.description ?? '';
+  editMode.value = true;
+};
+const onCancelClick = () => {
+  editMode.value = false;
+};
+const onSaveClick = async () => {
+  try {
+    saving.value = true;
+    const newRole = {
+      ...role.value,
+      description: editDescriptionModel.value
+    }
+    await sidebar.data.updateRole({role: newRole});
+    saveError.value = null;
+  } catch (e) {
+    saveError.value = e;
+  } finally {
+    saving.value = false;
+  }
+  editMode.value = false;
+};
+
+const editDescriptionModel = ref(null);
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/ops/src/routes/auth/roles/roles.js
+++ b/ui/ops/src/routes/auth/roles/roles.js
@@ -23,8 +23,8 @@ export function useAssignedPermissions(perms) {
     return {
       ...perm,
       assigned: permIndex.value[perm.id] ?? false,
-      implies: permissionsStore.impliedPermissions(perm.id),
-      dependsOn: permissionsStore.dependentPermissions(perm.id),
+      implies: permissionsStore.impliedPermissions(perm.id).map((id) => permissionsStore.permissionsById(id)),
+      dependsOn: permissionsStore.dependentPermissions(perm.id).map((id) => permissionsStore.permissionsById(id)),
     };
   }));
   const assignedList = computed(() => toggleList.value.filter((perm) => perm.assigned));

--- a/ui/ops/src/routes/auth/roles/roles.js
+++ b/ui/ops/src/routes/auth/roles/roles.js
@@ -1,0 +1,66 @@
+import {usePermissionsStore} from '@/stores/permissions.js';
+import {computed, toValue} from 'vue';
+
+/**
+ * @typedef {Permission.AsObject} AssignedPermission
+ * @property {boolean} assigned
+ */
+
+/**
+ * @param {import('vue').MaybeRefOrGetter<string[]>} perms
+ * @return {{
+ *   toggleList: ComputedRef<AssignedPermission[]>,
+ *   assignedList: ComputedRef<AssignedPermission[]>
+ * }}
+ */
+export function useAssignedPermissions(perms) {
+  const permIndex = computed(() => toValue(perms).reduce((acc, perm) => {
+    acc[perm] = true;
+    return acc;
+  }, {}));
+  const permissionsStore = usePermissionsStore();
+  const toggleList = computed(() => permissionsStore.permissionsList.map((perm) => {
+    return {
+      ...perm,
+      assigned: permIndex.value[perm.id] ?? false,
+      implies: permissionsStore.impliedPermissions(perm.id),
+      dependsOn: permissionsStore.dependentPermissions(perm.id),
+    };
+  }));
+  const assignedList = computed(() => toggleList.value.filter((perm) => perm.assigned));
+
+  /**
+   * @param {string | AssignedPermission} idOrPerm
+   * @return {string[]}
+   */
+  const addPermission = (idOrPerm) => {
+    const perm = typeof idOrPerm === 'string' ? permissionsStore.permissionsById(idOrPerm) : idOrPerm;
+    if (!perm) {
+      return toValue(perms);
+    }
+    const idx = {...permIndex.value};
+    idx[perm.id] = true;
+    for (const impliedPermission of permissionsStore.impliedPermissions(perm.id)) {
+      idx[impliedPermission] = true;
+    }
+    return Object.keys(idx).sort();
+  }
+  const removePermission = (idOrPerm) => {
+    const perm = typeof idOrPerm === 'string' ? permissionsStore.permissionsById(idOrPerm) : idOrPerm;
+    if (!perm) {
+      return toValue(perms);
+    }
+    const idx = {...permIndex.value};
+    delete idx[perm.id];
+    for (const dependentPermission of permissionsStore.dependentPermissions(perm.id)) {
+      delete idx[dependentPermission];
+    }
+    return Object.keys(idx).sort();
+  }
+  return {
+    toggleList,
+    assignedList,
+    addPermission,
+    removePermission
+  };
+}

--- a/ui/ops/src/routes/auth/roles/route.js
+++ b/ui/ops/src/routes/auth/roles/route.js
@@ -1,12 +1,14 @@
 export default [
   {
     path: 'roles/:roleId?',
+    name: 'roles',
     components: {
-      default: () => import('./RolesPage.vue')
+      default: () => import('./RolesPage.vue'),
+      sidebar: () => import('./RolesSideBar.vue')
     },
     props: {
-      default: false,
-      sidebar: true
+      default: true,
+      sidebar: false
     },
     meta: {
       authentication: {

--- a/ui/ops/src/routes/auth/roles/route.js
+++ b/ui/ops/src/routes/auth/roles/route.js
@@ -1,0 +1,17 @@
+export default [
+  {
+    path: 'roles/:roleId?',
+    components: {
+      default: () => import('./RolesPage.vue')
+    },
+    props: {
+      default: false,
+      sidebar: true
+    },
+    meta: {
+      authentication: {
+        rolesRequired: ['superAdmin', 'admin', 'operator', 'viewer']
+      }
+    }
+  }
+];

--- a/ui/ops/src/routes/auth/route.js
+++ b/ui/ops/src/routes/auth/route.js
@@ -1,5 +1,6 @@
 import SidebarPage from '@/components/pages/SidebarPage.vue';
 import accounts from '@/routes/auth/accounts/route.js';
+import roles from '@/routes/auth/roles/route.js';
 import thirdParty from '@/routes/auth/third-party/route.js';
 import {useUiConfigStore} from '@/stores/uiConfig.js';
 import {route} from '@/util/router.js';
@@ -25,6 +26,7 @@ export default [
       },
       ...route(thirdParty),
       ...route(accounts),
+      ...route(roles),
     ],
     meta: {
       authentication: {

--- a/ui/ops/src/routes/auth/route.js
+++ b/ui/ops/src/routes/auth/route.js
@@ -1,4 +1,5 @@
 import SidebarPage from '@/components/pages/SidebarPage.vue';
+import accounts from '@/routes/auth/accounts/route.js';
 import thirdParty from '@/routes/auth/third-party/route.js';
 import {useUiConfigStore} from '@/stores/uiConfig.js';
 import {route} from '@/util/router.js';
@@ -22,13 +23,14 @@ export default [
           title: 'Users'
         }
       },
-      ...route(thirdParty)
+      ...route(thirdParty),
+      ...route(accounts),
     ],
     meta: {
       authentication: {
         rolesRequired: ['superAdmin', 'admin', 'operator', 'viewer']
       },
-      title: 'Auth'
+      title: 'Access Management'
     },
     beforeEnter: async (to, from, next) => {
       const uiConfig = useUiConfigStore();

--- a/ui/ops/src/routes/router.js
+++ b/ui/ops/src/routes/router.js
@@ -46,8 +46,9 @@ if (window) {
 
     const sidebar = useSidebarStore();
 
-    // Reset the sidebar to defaults if the path has changed
-    if (to.path !== from.path) {
+    // Reset the sidebar to defaults if the active route changes
+    if ((to.name && to.name !== from.name) ||
+        (!to.name && to.path !== from.path)) {
       sidebar.resetSidebarToDefaults();
     }
 

--- a/ui/ops/src/stores/permissions.js
+++ b/ui/ops/src/stores/permissions.js
@@ -1,0 +1,132 @@
+import {acceptHMRUpdate, defineStore} from 'pinia';
+import {computed, ref} from 'vue';
+
+// todo: stop using a fixed permissions list
+/**
+ * @type {import('@vanti-dev/sc-bos-ui-gen/proto/account_pb').Permission.AsObject[]}
+ * @private
+ */
+const _permissions = [
+  {
+    'id': 'account:read',
+    'displayName': 'Account - Read All',
+    'description': 'Read-only access to all account details',
+    'impliesIdsList': [
+      'account:self:read'
+    ]
+  },
+  {
+    'id': 'account:self:read',
+    'displayName': 'Account - Read Own Account',
+    'description': 'Read details of your own account',
+    'impliesIdsList': []
+  },
+  {
+    'id': 'account:self:write',
+    'displayName': 'Account - Write Own Account',
+    'description': 'Update your own account details, including credentials',
+    'impliesIdsList': [
+      'account:self:read'
+    ]
+  },
+  {
+    'id': 'account:write',
+    'displayName': 'Account - Write All',
+    'description': 'Manage all accounts; Create and assign roles',
+    'impliesIdsList': [
+      'account:read'
+    ]
+  },
+  {
+    'id': 'traits:history:read',
+    'displayName': 'Traits - Read History',
+    'description': 'Read all historical data from devices',
+    'impliesIdsList': []
+  },
+  {
+    'id': 'traits:read',
+    'displayName': 'Traits - Read',
+    'description': 'Read all live data from devices',
+    'impliesIdsList': []
+  },
+  {
+    'id': 'traits:write',
+    'displayName': 'Traits - Write',
+    'description': 'Send commands to devices and update device state',
+    'impliesIdsList': [
+      'traits:read'
+    ]
+  }
+]
+
+export const usePermissionsStore = defineStore('permissions', () => {
+  const permissionsList = ref(_permissions);
+  const permissionsById = computed(() => permissionsList.value.reduce((acc, curr) => {
+    acc[curr.id] = curr
+    return acc
+  }, {}));
+
+  /**
+   * A map from permission id to a array of all transitively implied permissions.
+   *
+   * @type {ComputedRef<Record<string,string[]>>}
+   */
+  const impliedPermissions = computed(() => {
+    const implied = {};
+    const permById = permissionsById.value;
+    for (const perm of permissionsList.value) {
+      const idx = {};
+      const toAdd = [perm];
+      while (toAdd.length) {
+        const p = toAdd.pop();
+        if (idx[p.id]) {
+          continue;
+        }
+        idx[p.id] = true;
+        toAdd.push(...p.impliesIdsList.map((id) => permById[id]).filter((p) => p));
+      }
+      delete idx[perm.id];
+      implied[perm.id] = Object.keys(idx).sort();
+    }
+    return implied;
+  });
+  /**
+   * A map from permission id to a array of all permissions that imply it.
+   *
+   * @type {ComputedRef<Record<string, string[]>>}
+   */
+  const dependentPermissions = computed(() => {
+    const dependent = {};
+    for (const [dep, implies] of Object.entries(impliedPermissions.value)) {
+      if (!dependent[dep]) {
+        dependent[dep] = [];
+      }
+      for (const imply of implies) {
+        if (!dependent[imply]) {
+          dependent[imply] = [];
+        }
+        dependent[imply].push(dep);
+      }
+    }
+    return dependent;
+  })
+
+  return {
+    loading: ref(false),
+    loaded: ref(true),
+    permissionsList,
+    permissionsById(id) {
+      return permissionsById.value[id];
+    },
+    impliedPermissions(id) {
+      return impliedPermissions.value[id];
+    },
+    dependentPermissions(id) {
+      return dependentPermissions.value[id];
+    }
+  }
+});
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(usePermissionsStore, import.meta.hot));
+}

--- a/ui/ops/src/style.scss
+++ b/ui/ops/src/style.scss
@@ -16,6 +16,12 @@ p {
   pointer-events: none !important;
 }
 
+.text-overflow-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .v-text-field--outlined {
   background: var(--v-neutral-lighten1);
   border-color: var(--v-neutral-lighten2);


### PR DESCRIPTION
Add new role and account management pages to the Ops UI. These pages allow the creation, modification, and deletion of roles and their associated permissions, and accounts and their assigned roles.

![image](https://github.com/user-attachments/assets/19ef07af-4b6b-4ea9-92dd-59ec8fbf43b6)

The account management feature set isn't 100% complete, here is the feature set included in this PR:

1. [x] View existing roles
2. [x] Create new roles
3. [x] Edit the description of a role
4. [x] Edit the permissions a role has
5. [x] See details about a permission
6. [x] Delete a role
7. [x] View existing accounts
8. [x] See service accounts and user accounts
9. [x] Create new accounts of both types
10. [x] Edit the username of user accounts
11. [x] Edit the description for service accounts
12. [x] Assign new roles to accounts - both individually and in bulk
13. [x] Remove roles from accounts
14. [x] See more details about roles an account has assigned
15. [x] Delete accounts
16. [x] Rotate service account secrets
17. [x] Specify an expiry for old service account secrets
18. [ ] Change a users password
19. [ ] Change your own users password
20. [ ] Edit your own users display name
21. [ ] Hide pages/elements based on the current users permissions