### PR TITLE
Feat/default meter exporthttp

### DIFF
--- a/pkg/auto/exporthttp/job/energy.go
+++ b/pkg/auto/exporthttp/job/energy.go
@@ -38,8 +38,6 @@ func (e *EnergyJob) Do(ctx context.Context, sendFn sender) error {
 
 		if err != nil {
 			e.Logger.Error("getting unit multiplier", zap.String("meter", meter), zap.Error(err))
-			cancel()
-			continue
 		}
 
 		earliest, latest, err := getRecordsByTime(cctx, e.client.ListMeterReadingHistory, meter, now, filterTime)

--- a/pkg/auto/exporthttp/job/water.go
+++ b/pkg/auto/exporthttp/job/water.go
@@ -36,8 +36,6 @@ func (w *WaterJob) Do(ctx context.Context, sendFn sender) error {
 
 		if err != nil {
 			w.Logger.Error("getting unit multiplier", zap.String("meter", meter), zap.Error(err))
-			cancel()
-			continue
 		}
 
 		earliest, latest, err := getRecordsByTime(cctx, w.client.ListMeterReadingHistory, meter, now, filterTime)


### PR DESCRIPTION
Default the meter readings unit multiplier to 1 if there is an error attempting to fetch the meter unit from the meter info server.