### PR TITLE
auto/exporthttp: get ctx timeout from config

### DIFF
--- a/cmd/tools/test-exporthttp/main.go
+++ b/cmd/tools/test-exporthttp/main.go
@@ -102,26 +102,31 @@ const (
 	"occupancy":    {
 	  "path": "occupancy",
 	  "schedule": "0/1 * * * *",
+	  "timeout": "15s",
 	  "sensors":  ["pir/01","pir/02","pir/03"]
 	},
 	"temperature": {
 	  "path": "temperature",
 	  "schedule": "0/2 * * * *",
+	  "timeout": "15s",
 	  "sensors": ["FCU/01","FCU/02"]
 	},
 	"energy":       {
 	  "path": "energy",
 	  "schedule": "0/1 * * * *",
+	  "timeout": "15s",
 	  "meters": ["smart-core/meters/01"]
 	},
 	"airQuality":  {
 	  "path": "air_quality",
 	  "schedule": "0/1 * * * *",
+	  "timeout": "15s",
 	  "sensors": ["smart-core/iaq/01"]
 	},
 	"water": {
 	  "path": "water",
 	  "schedule": "0/1 * * * *",
+	  "timeout": "15s",
 	  "meters" : ["smart-core/meters/03"]
 	}
   }

--- a/pkg/auto/exporthttp/config/root.go
+++ b/pkg/auto/exporthttp/config/root.go
@@ -36,6 +36,7 @@ type Authentication struct {
 type Source struct {
 	Path     string              `json:"path"`
 	Schedule *jsontypes.Schedule `json:"schedule"`
+	Timeout  *jsontypes.Duration `json:"timeout,omitempty"`
 }
 
 type Occupancy struct {

--- a/pkg/auto/exporthttp/job/air_quality.go
+++ b/pkg/auto/exporthttp/job/air_quality.go
@@ -29,7 +29,7 @@ func (a *AirQualityJob) Do(ctx context.Context, sendFn sender) error {
 	count := 0
 
 	for _, sensor := range a.Sensors {
-		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		cctx, cancel := context.WithTimeout(ctx, a.Timeout.Or(defaultTimeout))
 
 		resp, err := a.client.GetAirQuality(cctx, &traits.GetAirQualityRequest{Name: sensor})
 

--- a/pkg/auto/exporthttp/job/energy.go
+++ b/pkg/auto/exporthttp/job/energy.go
@@ -32,7 +32,7 @@ func (e *EnergyJob) Do(ctx context.Context, sendFn sender) error {
 	filterTime := now.Sub(e.PreviousExecution)
 
 	for _, meter := range e.Meters {
-		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		cctx, cancel := context.WithTimeout(ctx, e.Timeout.Or(defaultTimeout))
 
 		multiplier, err := e.getUnitMultiplier(cctx, meter)
 

--- a/pkg/auto/exporthttp/job/job.go
+++ b/pkg/auto/exporthttp/job/job.go
@@ -28,6 +28,8 @@ var (
 	errNoSensorsRetrieved = errors.New("no sensors retrieved")
 )
 
+const defaultTimeout = time.Second * 5
+
 // Job represents an exporthttp automation task that executes Do to send a POST request
 type Job interface {
 	GetName() string
@@ -86,6 +88,7 @@ func Multiplex(ctx context.Context, jobs ...Job) *Mulpx {
 type BaseJob struct {
 	Url               string
 	Schedule          *jsontypes.Schedule
+	Timeout           *jsontypes.Duration
 	PreviousExecution time.Time
 	Site              string
 	Logger            *zap.Logger
@@ -120,6 +123,7 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 				Schedule:          cfg.Sources.Occupancy.Schedule,
 				Logger:            logger,
 				PreviousExecution: now,
+				Timeout:           cfg.Sources.Occupancy.Timeout,
 			},
 			Sensors: cfg.Sources.Occupancy.Sensors,
 			client:  traits.NewOccupancySensorApiClient(node.ClientConn()),
@@ -135,6 +139,7 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 				Schedule:          cfg.Sources.Temperature.Schedule,
 				PreviousExecution: now,
 				Logger:            logger,
+				Timeout:           cfg.Sources.Temperature.Timeout,
 			},
 			Sensors: cfg.Sources.Temperature.Sensors,
 			client:  traits.NewAirTemperatureApiClient(node.ClientConn()),
@@ -150,6 +155,7 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 				Schedule:          cfg.Sources.Energy.Schedule,
 				PreviousExecution: now,
 				Logger:            logger,
+				Timeout:           cfg.Sources.Energy.Timeout,
 			},
 			Meters:     cfg.Sources.Energy.Meters,
 			client:     gen.NewMeterHistoryClient(node.ClientConn()),
@@ -166,6 +172,7 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 				Schedule:          cfg.Sources.AirQuality.Schedule,
 				PreviousExecution: now,
 				Logger:            logger,
+				Timeout:           cfg.Sources.AirQuality.Timeout,
 			},
 			Sensors: cfg.Sources.AirQuality.Sensors,
 			client:  traits.NewAirQualitySensorApiClient(node.ClientConn()),
@@ -181,6 +188,7 @@ func FromConfig(cfg config.Root, logger *zap.Logger, node *node.Node) []Job {
 				Schedule:          cfg.Sources.Water.Schedule,
 				PreviousExecution: now,
 				Logger:            logger,
+				Timeout:           cfg.Sources.Water.Timeout,
 			},
 			Meters:     cfg.Sources.Water.Meters,
 			client:     gen.NewMeterHistoryClient(node.ClientConn()),

--- a/pkg/auto/exporthttp/job/occupancy.go
+++ b/pkg/auto/exporthttp/job/occupancy.go
@@ -27,7 +27,7 @@ func (o *OccupancyJob) Do(ctx context.Context, sendFn sender) error {
 	hasCounted := false
 
 	for _, sensor := range o.Sensors {
-		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		cctx, cancel := context.WithTimeout(ctx, o.Timeout.Or(defaultTimeout))
 
 		resp, err := o.client.GetOccupancy(cctx, &traits.GetOccupancyRequest{Name: sensor})
 		cancel()

--- a/pkg/auto/exporthttp/job/temperature.go
+++ b/pkg/auto/exporthttp/job/temperature.go
@@ -29,7 +29,7 @@ func (t *TemperatureJob) Do(ctx context.Context, sendFn sender) error {
 	count := 0
 
 	for _, sensor := range t.Sensors {
-		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		cctx, cancel := context.WithTimeout(ctx, t.Timeout.Or(defaultTimeout))
 
 		resp, err := t.client.GetAirTemperature(cctx, &traits.GetAirTemperatureRequest{Name: sensor})
 		cancel()

--- a/pkg/auto/exporthttp/job/water.go
+++ b/pkg/auto/exporthttp/job/water.go
@@ -30,7 +30,7 @@ func (w *WaterJob) Do(ctx context.Context, sendFn sender) error {
 	filterTime := now.Sub(w.PreviousExecution)
 
 	for _, meter := range w.Meters {
-		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		cctx, cancel := context.WithTimeout(ctx, w.Timeout.Or(defaultTimeout))
 
 		multiplier, err := w.getUnitMultiplier(cctx, meter)
 
@@ -47,7 +47,6 @@ func (w *WaterJob) Do(ctx context.Context, sendFn sender) error {
 		}
 
 		consumption += processMeterRecords(multiplier, earliest, latest)
-
 	}
 
 	body := &types.WaterConsumption{


### PR DESCRIPTION
Since 5s timeout per sensor / meter device is too short in production deployments, I have made this configurable from the JSON configuration.