### PR TITLE
all: replace grpc.Dial/Context calls with grpc.NewClient

### DIFF
--- a/cmd/tools/dbadd-alerts/main.go
+++ b/cmd/tools/dbadd-alerts/main.go
@@ -44,9 +44,9 @@ func main() {
 
 func run(ctx context.Context) error {
 	host := "localhost:23557"
-	conn, err := grpc.Dial(host, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})))
+	conn, err := grpc.NewClient(host, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})))
 	if err != nil {
-		return fmt.Errorf("grpc.Dial: %w", err)
+		return fmt.Errorf("grpc.NewClient: %w", err)
 	}
 
 	devicesClient := gen.NewDevicesApiClient(conn)

--- a/cmd/tools/list-occupancy-history/main.go
+++ b/cmd/tools/list-occupancy-history/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 func main() {
-	conn, err := grpc.DialContext(context.Background(), "10.1.104.3:23557", grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+	conn, err := grpc.NewClient("10.1.104.3:23557", grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 		InsecureSkipVerify: true,
 	})))
 	if err != nil {

--- a/cmd/tools/proxy-test/main.go
+++ b/cmd/tools/proxy-test/main.go
@@ -27,7 +27,7 @@ func main() {
 	defer realServer.Stop()
 
 	log.Printf("Real server hosted on %v", realLis.Addr())
-	realConn, err := grpc.Dial(realLis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	realConn, err := grpc.NewClient(realLis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -48,7 +48,7 @@ func main() {
 	defer proxyServer.Stop()
 
 	log.Printf("Proxy server hosted on %v", proxyLis.Addr())
-	proxyConn, err := grpc.Dial(proxyLis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	proxyConn, err := grpc.NewClient(proxyLis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	client := traits.NewOnOffApiClient(proxyConn)
 	test, err := client.GetOnOff(context.Background(), &traits.GetOnOffRequest{})
 	if err != nil {

--- a/cmd/tools/pull-enter-leave/main.go
+++ b/cmd/tools/pull-enter-leave/main.go
@@ -24,7 +24,7 @@ func main() {
 		tlsConfig := &tls.Config{
 			InsecureSkipVerify: true,
 		}
-		conn, err := grpc.Dial("localhost:23557", grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+		conn, err := grpc.NewClient("localhost:23557", grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 		if err != nil {
 			return 0, err
 		}

--- a/cmd/tools/sample-tenant/main.go
+++ b/cmd/tools/sample-tenant/main.go
@@ -62,7 +62,7 @@ func main() {
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
 
 	name := "light-1"
-	conn, err := grpc.Dial(flagGRPCAddr,
+	conn, err := grpc.NewClient(flagGRPCAddr,
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 		grpc.WithPerRPCCredentials(oauth.TokenSource{TokenSource: ccConfig.TokenSource(ctx)}),
 	)

--- a/internal/router/stream_test.go
+++ b/internal/router/stream_test.go
@@ -28,11 +28,11 @@ func TestStreamHandler(t *testing.T) {
 	defer stop()
 
 	// downstream nodes
-	n1Client, err := newNode(t, ctx, "n1")
+	n1Client, err := newNode(t, "n1")
 	if err != nil {
 		t.Fatalf("newNode(n1) = %v", err)
 	}
-	n2Client, err := newNode(t, ctx, "n2")
+	n2Client, err := newNode(t, "n2")
 	if err != nil {
 		t.Fatalf("newNode(n2) = %v", err)
 	}
@@ -49,7 +49,7 @@ func TestStreamHandler(t *testing.T) {
 		}
 	}()
 
-	proxyConn, err := bufConn(ctx, proxyLis)
+	proxyConn, err := bufConn(proxyLis)
 	if err != nil {
 		t.Fatalf("bufConn(proxyLis) = %v", err)
 	}
@@ -137,7 +137,7 @@ func TestStreamHandler_Interceptors(t *testing.T) {
 			t.Errorf("server.Serve() = %v", err)
 		}
 	}()
-	conn, err := bufConn(context.Background(), lis)
+	conn, err := bufConn(lis)
 	if err != nil {
 		t.Fatalf("bufConn error %v", err)
 	}
@@ -254,10 +254,10 @@ func supportService(reg *Router, service string) {
 	_ = reg.AddService(s)
 }
 
-func newNode(t *testing.T, ctx context.Context, name string) (*grpc.ClientConn, error) {
+func newNode(t *testing.T, name string) (*grpc.ClientConn, error) {
 	lis := bufconn.Listen(1024 * 1024)
 	s := nodeServer(name)
-	c, err := bufConn(ctx, lis)
+	c, err := bufConn(lis)
 
 	t.Cleanup(func() { c.Close() })
 	t.Cleanup(func() { s.Stop() })
@@ -282,8 +282,8 @@ func nodeServer(name string) *grpc.Server {
 	return grpc.NewServer(grpc.UnknownServiceHandler(StreamHandler(r)))
 }
 
-func bufConn(ctx context.Context, buf *bufconn.Listener) (*grpc.ClientConn, error) {
-	return grpc.DialContext(ctx, "",
+func bufConn(buf *bufconn.Listener) (*grpc.ClientConn, error) {
+	return grpc.NewClient("localhost:0",
 		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 			return buf.Dial()
 		}),

--- a/pkg/app/servers_test.go
+++ b/pkg/app/servers_test.go
@@ -116,8 +116,7 @@ func TestServeGRPC(t *testing.T) {
 		serveErr <- err
 	}()
 
-	conn, err := grpc.DialContext(clientCtx, addr,
-		grpc.WithBlock(),
+	conn, err := grpc.NewClient(addr,
 		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 			InsecureSkipVerify: true,
 		})),

--- a/pkg/auth/policy/interceptor_test.go
+++ b/pkg/auth/policy/interceptor_test.go
@@ -45,7 +45,7 @@ func TestInterceptor_GRPC(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	conn, err := grpc.DialContext(ctx, "",
+	conn, err := grpc.NewClient("localhost:0",
 		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
 			return lis.DialContext(ctx)
 		}),

--- a/pkg/auto/azureiot/traits.go
+++ b/pkg/auto/azureiot/traits.go
@@ -366,7 +366,7 @@ func grpcClient[T any](a *Auto, c *T, f func(connInterface grpc.ClientConnInterf
 	if tlsConfig != nil {
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	}
-	conn, err := grpc.Dial(rn.Host, opts...)
+	conn, err := grpc.NewClient(rn.Host, opts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/driver/proxy/config/root.go
+++ b/pkg/driver/proxy/config/root.go
@@ -16,7 +16,7 @@ type Root struct {
 
 // Node is a networked Smart Core node, identified by its host.
 type Node struct {
-	Host string `json:"host,omitempty"` // for accepted values see grpc.Dial
+	Host string `json:"host,omitempty"` // for accepted values see grpc.NewClient
 
 	// TLS allows us to override the default enrollment managed TLS configuration.
 	TLS TLS `json:"tls,omitempty"`

--- a/pkg/driver/proxy/driver.go
+++ b/pkg/driver/proxy/driver.go
@@ -86,7 +86,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 			}
 			dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(creds))
 		}
-		conn, err := grpc.DialContext(ctx, n.Host, dialOpts...)
+		conn, err := grpc.NewClient(n.Host, dialOpts...)
 		if err != nil {
 			// dial shouldn't fail, connections are lazy. If we do see an error here make sure we surface it!
 			allErrs = multierr.Append(allErrs, fmt.Errorf("dial %v %w", n.Host, err))

--- a/pkg/hub/pull.go
+++ b/pkg/hub/pull.go
@@ -63,7 +63,7 @@ func PullNodes(ctx context.Context, conn *grpc.ClientConn) <-chan Change[Node] {
 
 // PullChildren returns a channel of changes to the children of all nodes enrolled in the hub conn.
 // The conn argument should be a connection to the hub.
-// For each node a new connection (via grpc.Dial) will be made using the nodes address and the given dialOpts.
+// For each node a new connection (via grpc.NewClient) will be made using the nodes address and the given dialOpts.
 // Children sent via the returned channel will have their Conn field set to the new connection which can be used so long
 // as that child is still a member of the hub cohort.
 func PullChildren(ctx context.Context, conn *grpc.ClientConn, dialOpts ...grpc.DialOption) <-chan Change[Child] {

--- a/pkg/manage/enrollment/server.go
+++ b/pkg/manage/enrollment/server.go
@@ -255,7 +255,7 @@ func (es *Server) TestEnrollment(ctx context.Context, _ *gen.TestEnrollmentReque
 	tlsConfig := pki.TLSClientConfig(pki.FuncSource(func() (*tls.Certificate, []*x509.Certificate, error) {
 		return &e.Cert, []*x509.Certificate{e.RootCA}, nil
 	}))
-	conn, err := grpc.DialContext(ctx, e.ManagerAddress, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	conn, err := grpc.NewClient(e.ManagerAddress, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +341,7 @@ func (es *Server) RequestRenew(ctx context.Context) error {
 		return clientCert, roots, err
 	})
 	tlsConfig := pki.TLSClientConfig(source)
-	conn, err := grpc.DialContext(ctx, hubAddress, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	conn, err := grpc.NewClient(hubAddress, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	if err != nil {
 		return err
 	}

--- a/pkg/node/remote_test.go
+++ b/pkg/node/remote_test.go
@@ -10,6 +10,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/vanti-dev/sc-bos/pkg/util/client"
 )
 
 func TestDialChan(t *testing.T) {
@@ -78,12 +80,12 @@ func TestDialChan(t *testing.T) {
 func awaitServing(ctx context.Context, addr string) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, addr, grpc.WithBlock(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return err
 	}
-	conn.Close()
-	return nil
+	defer conn.Close()
+	return client.WaitForReady(ctx, conn)
 }
 
 func awaitSend[T any](ctx context.Context, ch chan<- T, v T) error {

--- a/pkg/system/gateway/internal/test/gateway_test.go
+++ b/pkg/system/gateway/internal/test/gateway_test.go
@@ -170,7 +170,7 @@ func waitForNodes(t *testing.T, ctx context.Context) {
 func waitForNode(t *testing.T, ctx context.Context, addr string) {
 	t.Helper()
 
-	conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 		InsecureSkipVerify: true,
 	})))
 	if err != nil {
@@ -196,7 +196,7 @@ func configureCohort(t *testing.T, ctx context.Context) {
 
 	// todo: use the hubs ca (should be in dir, after the first request) for our client cert checks
 
-	hubConn, err := grpc.DialContext(ctx, shared.HubGRPCAddr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+	hubConn, err := grpc.NewClient(shared.HubGRPCAddr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 		InsecureSkipVerify: true,
 	})))
 	if err != nil {
@@ -228,7 +228,7 @@ func configureCohort(t *testing.T, ctx context.Context) {
 func testGW(t *testing.T, ctx context.Context, addr string) {
 	t.Helper()
 
-	conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 		InsecureSkipVerify: true,
 	})))
 	if err != nil {

--- a/pkg/system/gateway/scan.go
+++ b/pkg/system/gateway/scan.go
@@ -233,9 +233,9 @@ func (s *System) pullEnrolledNodes(ctx context.Context, hubClient gen.HubApiClie
 			nodeCtx, stop := context.WithCancel(ctx)
 			stops = append(stops, stop)
 
-			conn, err := grpc.DialContext(nodeCtx, node.Address, grpc.WithTransportCredentials(credentials.NewTLS(s.tlsConfig)))
+			conn, err := grpc.NewClient(node.Address, grpc.WithTransportCredentials(credentials.NewTLS(s.tlsConfig)))
 			if err != nil {
-				// An error here means there's something wrong with the params we passed to grpc.DialContext.
+				// An error here means there's something wrong with the params we passed to grpc.NewClient.
 				// It's unlikely that retrying will help, so skip this node and log an error.
 				s.logger.Error("failed to dial remote node", zap.String("address", node.Address), zap.Error(err))
 				stopAll()

--- a/pkg/system/hub/bolthub/server.go
+++ b/pkg/system/hub/bolthub/server.go
@@ -256,7 +256,7 @@ func (s *Server) TestHubNode(ctx context.Context, request *gen.TestHubNodeReques
 
 	logger := s.logger.With(zap.String("node_address", reg.Address))
 
-	conn, err := grpc.DialContext(ctx, reg.Address, grpc.WithTransportCredentials(credentials.NewTLS(s.TestTLSConfig)))
+	conn, err := grpc.NewClient(reg.Address, grpc.WithTransportCredentials(credentials.NewTLS(s.TestTLSConfig)))
 	if err != nil {
 		logger.Debug("failed connection", zap.Error(err))
 		return nil, status.Error(codes.Unavailable, "failed connection")

--- a/pkg/system/hub/pgxhub/server.go
+++ b/pkg/system/hub/pgxhub/server.go
@@ -284,7 +284,7 @@ func (n *Server) TestHubNode(ctx context.Context, request *gen.TestHubNodeReques
 
 	logger := n.logger.With(zap.String("node_address", reg.Address))
 
-	conn, err := grpc.DialContext(ctx, reg.Address, grpc.WithTransportCredentials(credentials.NewTLS(n.TestTLSConfig)))
+	conn, err := grpc.NewClient(reg.Address, grpc.WithTransportCredentials(credentials.NewTLS(n.TestTLSConfig)))
 	if err != nil {
 		logger.Debug("failed connection", zap.Error(err))
 		return nil, status.Error(codes.Unavailable, "failed connection")

--- a/pkg/system/hub/remote/enroll.go
+++ b/pkg/system/hub/remote/enroll.go
@@ -59,7 +59,8 @@ func Enroll(ctx context.Context, enrollment *gen.Enrollment, authority pki.Sourc
 	client := gen.NewEnrollmentApiClient(conn)
 	// any api call will do to force the connection to be established (or fail)
 	_, err = client.GetEnrollment(ctx, &gen.GetEnrollmentRequest{})
-	if err != nil {
+	if err != nil && status.Code(err) != codes.NotFound {
+		// NotFound is expected if the remote node is not enrolled yet, ignore that error
 		return nil, err
 	}
 

--- a/pkg/system/hub/remote/enroll.go
+++ b/pkg/system/hub/remote/enroll.go
@@ -40,7 +40,7 @@ func Enroll(ctx context.Context, enrollment *gen.Enrollment, authority pki.Sourc
 		}
 
 		// Make sure there's a timeout to avoid infinite (or 120s) connection loops in the case when tls fails.
-		// There's no way to actually get the grpc.Dial func to return on first tls error, it will continue to retry
+		// There's no way to actually get the ClientConn to return on first tls error, it will continue to retry
 		// until ctx expires.
 		var cleanUp context.CancelFunc
 		ctx, cleanUp = context.WithTimeout(ctx, 30*time.Second)
@@ -49,12 +49,16 @@ func Enroll(ctx context.Context, enrollment *gen.Enrollment, authority pki.Sourc
 
 	// the certInterceptor captures and saves the certificate presented by the server when the connection is opened
 	creds := &certInterceptor{TransportCredentials: credentials.NewTLS(tlsConfig)}
-	conn, err := grpc.DialContext(ctx, enrollment.TargetAddress,
+	conn, err := grpc.NewClient(enrollment.TargetAddress,
 		grpc.WithTransportCredentials(creds),
-		grpc.WithBlock(),
-		grpc.FailOnNonTempDialError(true),
-		grpc.WithReturnConnectionError(),
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	client := gen.NewEnrollmentApiClient(conn)
+	// any api call will do to force the connection to be established (or fail)
+	_, err = client.GetEnrollment(ctx, &gen.GetEnrollmentRequest{})
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +87,6 @@ func Enroll(ctx context.Context, enrollment *gen.Enrollment, authority pki.Sourc
 		return nil, err
 	}
 
-	client := gen.NewEnrollmentApiClient(conn)
 	_, err = client.CreateEnrollment(ctx, &gen.CreateEnrollmentRequest{
 		Enrollment: enrollment,
 	})
@@ -113,7 +116,7 @@ func Forget(ctx context.Context, enrollment *gen.Enrollment, tlsConfig *tls.Conf
 	//    - get the current enrollment and compare it with the one we would have used
 	//    - if it matches, ask the remote node to forget about us
 
-	conn, err := grpc.DialContext(ctx, enrollment.TargetAddress,
+	conn, err := grpc.NewClient(enrollment.TargetAddress,
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 	)
 	if err != nil {
@@ -138,7 +141,7 @@ func Forget(ctx context.Context, enrollment *gen.Enrollment, tlsConfig *tls.Conf
 		return fmt.Errorf("trusted: %w", err)
 	}
 
-	conn, err = grpc.DialContext(ctx, enrollment.TargetAddress,
+	conn, err = grpc.NewClient(enrollment.TargetAddress,
 		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 			InsecureSkipVerify: true,
 		})),
@@ -187,12 +190,16 @@ func Renew(ctx context.Context, enrollment *gen.Enrollment, authority pki.Source
 
 	// the certInterceptor captures and saves the certificate presented by the server when the connection is opened
 	creds := &certInterceptor{TransportCredentials: credentials.NewTLS(tlsConfig)}
-	conn, err := grpc.DialContext(ctx, enrollment.TargetAddress,
+	conn, err := grpc.NewClient(enrollment.TargetAddress,
 		grpc.WithTransportCredentials(creds),
-		grpc.WithBlock(),
-		grpc.FailOnNonTempDialError(true),
-		grpc.WithReturnConnectionError(),
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	client := gen.NewEnrollmentApiClient(conn)
+	// any api call will do to force the connection to be established (or fail)
+	_, err = client.GetEnrollment(ctx, &gen.GetEnrollmentRequest{})
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +225,6 @@ func Renew(ctx context.Context, enrollment *gen.Enrollment, authority pki.Source
 		return nil, err
 	}
 
-	client := gen.NewEnrollmentApiClient(conn)
 	_, err = client.UpdateEnrollment(ctx, &gen.UpdateEnrollmentRequest{
 		Enrollment: enrollment,
 	})

--- a/pkg/util/client/client.go
+++ b/pkg/util/client/client.go
@@ -20,5 +20,5 @@ func NewConnection(conf Config) (*grpc.ClientConn, error) {
 		}
 	}
 
-	return grpc.Dial(conf.Endpoint, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	return grpc.NewClient(conf.Endpoint, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 }

--- a/pkg/util/client/wait.go
+++ b/pkg/util/client/wait.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+var ErrTransientFailure = errors.New("transient failure")
+
+// WaitForReady waits for the grpc.ClientConn to be in a ready (connected) state or for the connection to fail.
+// Transient failures will return ErrTransientFailure, if cc is shutdown it will return grpc.ErrServerStopped,
+// otherwise it will block until the connection is ready or the context is done.
+func WaitForReady(ctx context.Context, cc *grpc.ClientConn) error {
+	// Similar to using grpc.WithBlock during dial
+	for {
+		s := cc.GetState()
+		switch s {
+		case connectivity.Idle:
+			cc.Connect()
+		case connectivity.Ready:
+			return nil
+		case connectivity.Shutdown:
+			return grpc.ErrServerStopped
+		case connectivity.Connecting:
+		case connectivity.TransientFailure:
+			return ErrTransientFailure
+		}
+
+		if !cc.WaitForStateChange(ctx, s) {
+			return ctx.Err()
+		}
+	}
+}


### PR DESCRIPTION
grpc.Dial/Context has been deprecated, as have options grpc.WithBlock and friends.

Most of the work here is about also removing the grpc.WithBlock and related options which aren't usable with NewClient.

There were some logic changes needed in the hub packages, but I don't think they'll have any noticeable effects on our deployments. Mostly making sure we perform at least one RPC before assuming we have the server cert captured.

The surprising thing was in node/remote.go which required a Connect call to build the resolver before the address could be updated. Without this the code would panic.

Finally, it appears that NewClient doesn't accept an empty target string, where Dial and DialContext did, at least in the case where the Dialler was replaced. In these cases I've used a localhost address just to satisfy, with minimal overhead, the requirements of the resolver. This code is only present in tests.