### PR TITLE
feat/high low airtemp setpoints in bacnet

### DIFF
--- a/pkg/driver/bacnet/merge/air_temperature.go
+++ b/pkg/driver/bacnet/merge/air_temperature.go
@@ -36,7 +36,7 @@ type airTemperatureConfig struct {
 
 func readAirTemperatureConfig(raw []byte) (cfg airTemperatureConfig, err error) {
 	err = json.Unmarshal(raw, &cfg)
-	if err != nil {
+	if err == nil {
 		if cfg.SetPointDeadBand == nil || *cfg.SetPointDeadBand == 0 {
 			cfg.SetPointDeadBand = new(float32)
 			*cfg.SetPointDeadBand = 1


### PR DESCRIPTION
Improve the support for high and low setpoints in the bacnet driver; add a configurable deadband and infer the target set point from the high/low setpoints if regular set point is not available 