### PR TITLE
build: use configs to remove external init.sql requirement

### DIFF
--- a/demo/vanti-ugs/docker-compose-ugs.yml
+++ b/demo/vanti-ugs/docker-compose-ugs.yml
@@ -8,8 +8,9 @@ services:
       POSTGRES_DB: smart_core
     ports:
       - "5432:5432"
-    volumes:
-      - "./scripts/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d"
+    configs:
+      - source: postgres-init
+        target: /docker-entrypoint-initdb.d/init.sql
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres -d smart_core" ]
       interval: 10s
@@ -43,6 +44,12 @@ services:
       db:
         condition: service_healthy
         restart: true
+
+configs:
+  postgres-init:
+    content: |
+      CREATE EXTENSION "uuid-ossp";
+      CREATE DATABASE keycloak;
 
 #  keycloak:
 #    image: quay.io/keycloak/keycloak:21.0.1

--- a/demo/vanti-ugs/scripts/docker-entrypoint-initdb.d/init.sql
+++ b/demo/vanti-ugs/scripts/docker-entrypoint-initdb.d/init.sql
@@ -1,3 +1,0 @@
-CREATE EXTENSION "uuid-ossp";
-
-CREATE DATABASE keycloak;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   db:
     image: docker.io/library/postgres:14
@@ -11,7 +10,9 @@ services:
       - "5432:5432"
     volumes:
       - postgres-storage:/var/lib/postgresql/data
-      - "./scripts/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d"
+    configs:
+      - source: postgres-init
+        target: /docker-entrypoint-initdb.d/init.sql
 
   pgadmin:
     image: docker.io/dpage/pgadmin4:6
@@ -59,3 +60,9 @@ services:
 
 volumes:
   postgres-storage:
+configs:
+  postgres-init:
+    content: |
+      CREATE EXTENSION "uuid-ossp";
+      CREATE DATABASE keycloak;
+

--- a/scripts/docker-entrypoint-initdb.d/init.sql
+++ b/scripts/docker-entrypoint-initdb.d/init.sql
@@ -1,3 +1,0 @@
-CREATE EXTENSION "uuid-ossp";
-
-CREATE DATABASE keycloak;


### PR DESCRIPTION
In docker-compose v2.23.1 the ability to specify config inline was introduced. We can use this to simplify our compose deployments to a single file for the demo and local dev env.

I tested the root compose file locally with a clean env (no saved containers, no saved volumes).