### PR TITLE
history: remove unused pgx index

### DIFF
--- a/pkg/history/pgxstore/schema.sql
+++ b/pkg/history/pgxstore/schema.sql
@@ -8,5 +8,5 @@ CREATE TABLE IF NOT EXISTS history
 
 DROP INDEX IF EXISTS history_create_time_idx; -- replaced by history_id_source_idx;
 DROP INDEX IF EXISTS history_source_idx; -- replaced by history_source_create_time_idx
-CREATE INDEX IF NOT EXISTS history_id_source_idx ON history (id, source);
+DROP INDEX IF EXISTS history_id_source_idx; -- wasn't used, used excessive space
 CREATE INDEX IF NOT EXISTS history_source_create_time_idx ON history (source, create_time);


### PR DESCRIPTION
The index was never used and consumed a large amount of disk space.