### PR TITLE
auto/history: refactor to allow pollOnSchedule lifecycle defined by a cron schedule in config

### DIFF
--- a/pkg/auto/history/airtemperature.go
+++ b/pkg/auto/history/airtemperature.go
@@ -2,14 +2,13 @@ package history
 
 import (
 	"context"
-	"errors"
 
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/cmp"
 	"github.com/vanti-dev/sc-bos/pkg/auto/history/config"
-	"github.com/vanti-dev/sc-bos/pkg/util/pull"
 )
 
 func (a *automation) collectAirTemperatureChanges(ctx context.Context, source config.Source, payloads chan<- []byte) {
@@ -18,6 +17,8 @@ func (a *automation) collectAirTemperatureChanges(ctx context.Context, source co
 		a.logger.Error("collection aborted", zap.Error(err))
 		return
 	}
+
+	last := newDeduper[*traits.AirTemperature](cmp.Equal(cmp.FloatValueApprox(0, 0.0001)))
 
 	pullFn := func(ctx context.Context, changes chan<- []byte) error {
 		stream, err := client.PullAirTemperature(ctx, &traits.PullAirTemperatureRequest{Name: source.Name, ReadMask: source.ReadMask.PB()})
@@ -30,7 +31,10 @@ func (a *automation) collectAirTemperatureChanges(ctx context.Context, source co
 				return err
 			}
 			for _, change := range msg.Changes {
-				payload, err := proto.Marshal(change.AirTemperature)
+				if !last.Changed(change.GetAirTemperature()) {
+					continue
+				}
+				payload, err := proto.Marshal(change.GetAirTemperature())
 				if err != nil {
 					return err
 				}
@@ -43,14 +47,20 @@ func (a *automation) collectAirTemperatureChanges(ctx context.Context, source co
 		}
 	}
 	pollFn := func(ctx context.Context, changes chan<- []byte) error {
-		demand, err := client.GetAirTemperature(ctx, &traits.GetAirTemperatureRequest{Name: source.Name, ReadMask: source.ReadMask.PB()})
+		resp, err := client.GetAirTemperature(ctx, &traits.GetAirTemperatureRequest{Name: source.Name, ReadMask: source.ReadMask.PB()})
 		if err != nil {
 			return err
 		}
-		payload, err := proto.Marshal(demand)
+
+		if !last.Changed(resp) {
+			return nil
+		}
+
+		payload, err := proto.Marshal(resp)
 		if err != nil {
 			return err
 		}
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -59,11 +69,7 @@ func (a *automation) collectAirTemperatureChanges(ctx context.Context, source co
 		return nil
 	}
 
-	err := pull.Changes(ctx, pull.NewFetcher(pullFn, pollFn), payloads, pull.WithLogger(a.logger))
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return
-	}
-	if err != nil {
+	if err := collectChanges(ctx, source, pullFn, pollFn, payloads, a.logger); err != nil {
 		a.logger.Warn("collection aborted", zap.Error(err))
 	}
 }

--- a/pkg/auto/history/collect.go
+++ b/pkg/auto/history/collect.go
@@ -1,0 +1,44 @@
+package history
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/vanti-dev/sc-bos/pkg/auto/history/config"
+	"github.com/vanti-dev/sc-bos/pkg/util/pull"
+)
+
+type collector func(ctx context.Context, source config.Source, payloads chan<- []byte)
+type getter func(context.Context, chan<- []byte) error
+
+func collectChanges(ctx context.Context, cfg config.Source, pullFn, pollFn getter, changes chan<- []byte, logger *zap.Logger) error {
+	if cfg.PollingSchedule != nil {
+		var t time.Time
+
+		for {
+			t = time.Now()
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(time.Until(cfg.PollingSchedule.Schedule.Next(t))):
+				err := pollFn(ctx, changes)
+				if err != nil {
+					logger.Warn("poll aborted", zap.Error(err))
+				}
+			}
+		}
+	}
+
+	err := pull.Changes(ctx, pull.NewFetcher[[]byte](pullFn, pollFn), changes, pull.WithLogger(logger))
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/auto/history/config/root.go
+++ b/pkg/auto/history/config/root.go
@@ -23,6 +23,11 @@ type Source struct {
 	Trait trait.Name `json:"trait,omitempty"`
 	// ReadMask instructs the history service to only read the specified fields
 	ReadMask *FieldMask `json:"readMask,omitempty"`
+	// PollingSchedule, when present, configures the auto to poll the source updates even if the source supports pull.
+	// A new poll will be executed each time the given schedule triggers, but only changes will be recorded.
+	// Polling is useful when it is not critical to collect every change to a device,
+	// and excessive storage of historical records is a concern.
+	PollingSchedule *jsontypes.Schedule `json:"pollingSchedule,omitempty"`
 }
 
 func (s Source) SourceName() string {

--- a/pkg/auto/history/dedupe.go
+++ b/pkg/auto/history/dedupe.go
@@ -12,6 +12,9 @@ type deduper[T proto.Message] struct {
 }
 
 func newDeduper[T proto.Message](message cmp.Message) *deduper[T] {
+	if message == nil {
+		message = cmp.Equal()
+	}
 	return &deduper[T]{equal: message}
 }
 
@@ -20,11 +23,6 @@ func newDeduper[T proto.Message](message cmp.Message) *deduper[T] {
 // If the messages are not equal, it returns true and updates the last message.
 // It uses the provided equal comparator to determine equality, or a default one if not provided.
 func (d *deduper[T]) Changed(m T) bool {
-	// set a default equal comparator if not provided
-	if d.equal == nil {
-		d.equal = cmp.Equal()
-	}
-
 	if d.equal(d.last, m) {
 		return false
 	}

--- a/pkg/auto/history/dedupe.go
+++ b/pkg/auto/history/dedupe.go
@@ -1,0 +1,35 @@
+package history
+
+import (
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smart-core-os/sc-golang/pkg/cmp"
+)
+
+type deduper[T proto.Message] struct {
+	last  T
+	equal cmp.Message
+}
+
+func newDeduper[T proto.Message](message cmp.Message) *deduper[T] {
+	return &deduper[T]{equal: message}
+}
+
+// Changed checks if the message has changed compared to the last one.
+// If the messages are equal, it returns false.
+// If the messages are not equal, it returns true and updates the last message.
+// It uses the provided equal comparator to determine equality, or a default one if not provided.
+func (d *deduper[T]) Changed(m T) bool {
+	// set a default equal comparator if not provided
+	if d.equal == nil {
+		d.equal = cmp.Equal()
+	}
+
+	if d.equal(d.last, m) {
+		return false
+	}
+
+	d.last = m
+
+	return true
+}

--- a/pkg/auto/history/electric.go
+++ b/pkg/auto/history/electric.go
@@ -2,14 +2,13 @@ package history
 
 import (
 	"context"
-	"errors"
 
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/cmp"
 	"github.com/vanti-dev/sc-bos/pkg/auto/history/config"
-	"github.com/vanti-dev/sc-bos/pkg/util/pull"
 )
 
 func (a *automation) collectElectricDemandChanges(ctx context.Context, source config.Source, payloads chan<- []byte) {
@@ -18,6 +17,8 @@ func (a *automation) collectElectricDemandChanges(ctx context.Context, source co
 		a.logger.Error("collection aborted", zap.Error(err))
 		return
 	}
+
+	last := newDeduper[*traits.ElectricDemand](cmp.Equal(cmp.FloatValueApprox(0, 0.0001)))
 
 	pullFn := func(ctx context.Context, changes chan<- []byte) error {
 		stream, err := client.PullDemand(ctx, &traits.PullDemandRequest{Name: source.Name, UpdatesOnly: true, ReadMask: source.ReadMask.PB()})
@@ -30,10 +31,15 @@ func (a *automation) collectElectricDemandChanges(ctx context.Context, source co
 				return err
 			}
 			for _, change := range msg.Changes {
-				payload, err := proto.Marshal(change.Demand)
+				if !last.Changed(change.GetDemand()) {
+					continue
+				}
+
+				payload, err := proto.Marshal(change.GetDemand())
 				if err != nil {
 					return err
 				}
+
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
@@ -43,14 +49,20 @@ func (a *automation) collectElectricDemandChanges(ctx context.Context, source co
 		}
 	}
 	pollFn := func(ctx context.Context, changes chan<- []byte) error {
-		demand, err := client.GetDemand(ctx, &traits.GetDemandRequest{Name: source.Name, ReadMask: source.ReadMask.PB()})
+		resp, err := client.GetDemand(ctx, &traits.GetDemandRequest{Name: source.Name, ReadMask: source.ReadMask.PB()})
 		if err != nil {
 			return err
 		}
-		payload, err := proto.Marshal(demand)
+
+		if !last.Changed(resp) {
+			return nil
+		}
+
+		payload, err := proto.Marshal(resp)
 		if err != nil {
 			return err
 		}
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -59,11 +71,7 @@ func (a *automation) collectElectricDemandChanges(ctx context.Context, source co
 		return nil
 	}
 
-	err := pull.Changes(ctx, pull.NewFetcher(pullFn, pollFn), payloads, pull.WithLogger(a.logger))
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return
-	}
-	if err != nil {
+	if err := collectChanges(ctx, source, pullFn, pollFn, payloads, a.logger); err != nil {
 		a.logger.Warn("collection aborted", zap.Error(err))
 	}
 }

--- a/pkg/auto/history/factory.go
+++ b/pkg/auto/history/factory.go
@@ -157,7 +157,7 @@ func (a *automation) applyConfig(ctx context.Context, cfg config.Root) error {
 	// work out where we're getting the records from
 	var serverClient wrap.ServiceUnwrapper
 	payloads := make(chan []byte)
-	var collect func(context.Context, config.Source, chan<- []byte)
+	var collect collector
 	switch cfg.Source.Trait {
 	case trait.AirQualitySensor:
 		serverClient = gen.WrapAirQualitySensorHistory(historypb.NewAirQualitySensorServer(store))
@@ -184,6 +184,7 @@ func (a *automation) applyConfig(ctx context.Context, cfg config.Root) error {
 	// each time the source emits, we append it to the store
 	go func() {
 		defer close(payloads)
+
 		for {
 			select {
 			case <-ctx.Done():

--- a/pkg/auto/history/factory_test.go
+++ b/pkg/auto/history/factory_test.go
@@ -1,0 +1,323 @@
+package history
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap"
+	"golang.org/x/exp/rand"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
+	"github.com/smart-core-os/sc-golang/pkg/trait"
+	"github.com/smart-core-os/sc-golang/pkg/trait/airqualitysensorpb"
+	"github.com/smart-core-os/sc-golang/pkg/trait/airtemperaturepb"
+	"github.com/smart-core-os/sc-golang/pkg/trait/electricpb"
+	"github.com/smart-core-os/sc-golang/pkg/trait/occupancysensorpb"
+	"github.com/vanti-dev/sc-bos/pkg/auto/history/config"
+	"github.com/vanti-dev/sc-bos/pkg/gen"
+	meterpb "github.com/vanti-dev/sc-bos/pkg/gentrait/meter"
+	"github.com/vanti-dev/sc-bos/pkg/gentrait/statuspb"
+	"github.com/vanti-dev/sc-bos/pkg/node"
+	"github.com/vanti-dev/sc-bos/pkg/util/jsontypes"
+)
+
+func Test_automation_applyConfig(t *testing.T) {
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	t.Cleanup(cancel)
+
+	logger := zap.NewNop()
+	occupancy := occupancysensorpb.NewModel()
+	airQuality := airqualitysensorpb.NewModel()
+	airTemperature := airtemperaturepb.NewModel()
+	electric := electricpb.NewModel()
+	meter := meterpb.NewModel()
+	status := statuspb.NewModel()
+
+	announcer := node.New("test")
+
+	announcer.Logger = logger
+
+	announcer.Announce("occupancy",
+		node.HasTrait(trait.OccupancySensor),
+		node.HasServer(
+			traits.RegisterOccupancySensorApiServer,
+			traits.OccupancySensorApiServer(occupancysensorpb.NewModelServer(occupancy)),
+		),
+	)
+
+	announcer.Announce("airquality",
+		node.HasTrait(trait.AirQualitySensor),
+		node.HasServer(
+			traits.RegisterAirQualitySensorApiServer,
+			traits.AirQualitySensorApiServer(airqualitysensorpb.NewModelServer(airQuality)),
+		),
+	)
+
+	announcer.Announce("airtemperature",
+		node.HasTrait(trait.AirTemperature),
+		node.HasServer(
+			traits.RegisterAirTemperatureApiServer,
+			traits.AirTemperatureApiServer(airtemperaturepb.NewModelServer(airTemperature)),
+		),
+	)
+
+	announcer.Announce("electric",
+		node.HasTrait(trait.Electric),
+		node.HasServer(
+			traits.RegisterElectricApiServer,
+			traits.ElectricApiServer(electricpb.NewModelServer(electric)),
+		),
+	)
+
+	announcer.Announce("meter",
+		node.HasTrait(meterpb.TraitName),
+		node.HasServer(
+			gen.RegisterMeterApiServer,
+			gen.MeterApiServer(meterpb.NewModelServer(meter)),
+		),
+	)
+
+	announcer.Announce("status",
+		node.HasTrait(statuspb.TraitName),
+		node.HasServer(
+			gen.RegisterStatusApiServer,
+			gen.StatusApiServer(statuspb.NewModelServer(status)),
+		),
+	)
+
+	for _, cfg := range cfgs {
+		a := &automation{
+			clients:   announcer,
+			announcer: node.NewReplaceAnnouncer(announcer),
+			logger:    logger,
+		}
+
+		err := a.applyConfig(ctx, cfg)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// many events to each model server
+	for i := 0; i < 10; i++ {
+		if _, err := occupancy.SetOccupancy(&traits.Occupancy{
+			State:       traits.Occupancy_OCCUPIED,
+			PeopleCount: int32(rand.Intn(10)),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := airQuality.UpdateAirQuality(&traits.AirQuality{
+			CarbonDioxideLevel:       ptr(rand.Float32()),
+			VolatileOrganicCompounds: ptr(rand.Float32()),
+			AirPressure:              ptr(rand.Float32()),
+			InfectionRisk:            ptr(rand.Float32()),
+			Score:                    ptr(rand.Float32()),
+			ParticulateMatter_1:      ptr(rand.Float32()),
+			ParticulateMatter_25:     ptr(rand.Float32()),
+			ParticulateMatter_10:     ptr(rand.Float32()),
+			AirChangePerHour:         ptr(rand.Float32()),
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := airTemperature.UpdateAirTemperature(&traits.AirTemperature{
+			AmbientTemperature: &types.Temperature{ValueCelsius: rand.Float64()},
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := electric.UpdateDemand(&traits.ElectricDemand{
+			Voltage:       ptr(rand.Float32()),
+			Current:       rand.Float32(),
+			ReactivePower: ptr(rand.Float32()),
+			ApparentPower: ptr(rand.Float32()),
+			PowerFactor:   ptr(rand.Float32()),
+			RealPower:     ptr(rand.Float32()),
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := meter.UpdateMeterReading(&gen.MeterReading{
+			Usage:    rand.Float32(),
+			Produced: rand.Float32(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := status.UpdateProblem(&gen.StatusLog_Problem{
+			Name: randString(16),
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(time.Second)
+	}
+
+	aqCli := gen.NewAirQualitySensorHistoryClient(announcer.ClientConn())
+	occupancyCli := gen.NewOccupancySensorHistoryClient(announcer.ClientConn())
+	airTempCli := gen.NewAirTemperatureHistoryClient(announcer.ClientConn())
+	electricCli := gen.NewElectricHistoryClient(announcer.ClientConn())
+	meterCli := gen.NewMeterHistoryClient(announcer.ClientConn())
+	statusCli := gen.NewStatusHistoryClient(announcer.ClientConn())
+
+	aqHist, err := aqCli.ListAirQualityHistory(ctx, &gen.ListAirQualityHistoryRequest{Name: "airquality", PageSize: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(int32(2), aqHist.GetTotalSize()); diff != "" {
+		t.Fatal(diff, "airquality")
+	}
+
+	occHist, err := occupancyCli.ListOccupancyHistory(ctx, &gen.ListOccupancyHistoryRequest{Name: "occupancy", PageSize: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(int32(2), occHist.GetTotalSize()); diff != "" {
+		t.Fatal(diff, "occupancy")
+	}
+
+	airTempHist, err := airTempCli.ListAirTemperatureHistory(ctx, &gen.ListAirTemperatureHistoryRequest{Name: "airtemperature", PageSize: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(int32(2), airTempHist.GetTotalSize()); diff != "" {
+		t.Fatal(diff, "airtemperature")
+	}
+
+	electricHist, err := electricCli.ListElectricDemandHistory(ctx, &gen.ListElectricDemandHistoryRequest{Name: "electric", PageSize: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(int32(2), electricHist.GetTotalSize()); diff != "" {
+		t.Fatal(diff, "electric")
+	}
+
+	meterHist, err := meterCli.ListMeterReadingHistory(ctx, &gen.ListMeterReadingHistoryRequest{Name: "meter", PageSize: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(int32(2), meterHist.GetTotalSize()); diff != "" {
+		t.Fatal(diff, "meter")
+	}
+
+	statusHist, err := statusCli.ListCurrentStatusHistory(ctx, &gen.ListCurrentStatusHistoryRequest{Name: "status", PageSize: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(int32(2), statusHist.GetTotalSize()); diff != "" {
+		t.Fatal(diff, "status")
+	}
+
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+var cfgs = []config.Root{
+	{
+		Source: &config.Source{
+			Name:            "occupancy",
+			Trait:           trait.OccupancySensor,
+			PollingSchedule: jsontypes.MustParseExtendedSchedule("*/5 * * * * *"),
+		},
+		Storage: &config.Storage{
+			Type: "memory",
+			TTL: &config.TTL{
+				MaxAge:   jsontypes.Duration{Duration: time.Minute * 3},
+				MaxCount: 10,
+			},
+		},
+	},
+	{
+		Source: &config.Source{
+			Name:            "airquality",
+			Trait:           trait.AirQualitySensor,
+			PollingSchedule: jsontypes.MustParseExtendedSchedule("*/5 * * * * *"),
+		},
+		Storage: &config.Storage{
+			Type: "memory",
+			TTL: &config.TTL{
+				MaxAge:   jsontypes.Duration{Duration: time.Minute * 3},
+				MaxCount: 10,
+			},
+		},
+	},
+	{
+		Source: &config.Source{
+			Name:            "airtemperature",
+			Trait:           trait.AirTemperature,
+			PollingSchedule: jsontypes.MustParseExtendedSchedule("*/5 * * * * *"),
+		},
+		Storage: &config.Storage{
+			Type: "memory",
+			TTL: &config.TTL{
+				MaxAge:   jsontypes.Duration{Duration: time.Minute * 3},
+				MaxCount: 10,
+			},
+		},
+	},
+	{
+		Source: &config.Source{
+			Name:            "electric",
+			Trait:           trait.Electric,
+			PollingSchedule: jsontypes.MustParseExtendedSchedule("*/5 * * * * *"),
+		},
+		Storage: &config.Storage{
+			Type: "memory",
+			TTL: &config.TTL{
+				MaxAge:   jsontypes.Duration{Duration: time.Minute * 3},
+				MaxCount: 10,
+			},
+		},
+	},
+	{
+		Source: &config.Source{
+			Name:            "meter",
+			Trait:           meterpb.TraitName,
+			PollingSchedule: jsontypes.MustParseExtendedSchedule("*/5 * * * * *"),
+		},
+		Storage: &config.Storage{
+			Type: "memory",
+			TTL: &config.TTL{
+				MaxAge:   jsontypes.Duration{Duration: time.Minute * 3},
+				MaxCount: 10,
+			},
+		},
+	},
+	{
+		Source: &config.Source{
+			Name:            "status",
+			Trait:           statuspb.TraitName,
+			PollingSchedule: jsontypes.MustParseExtendedSchedule("*/5 * * * * *"),
+		},
+		Storage: &config.Storage{
+			Type: "memory",
+			TTL: &config.TTL{
+				MaxAge:   jsontypes.Duration{Duration: time.Minute * 3},
+				MaxCount: 10,
+			},
+		},
+	},
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}

--- a/pkg/auto/history/occupancysensor.go
+++ b/pkg/auto/history/occupancysensor.go
@@ -2,14 +2,13 @@ package history
 
 import (
 	"context"
-	"errors"
 
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/cmp"
 	"github.com/vanti-dev/sc-bos/pkg/auto/history/config"
-	"github.com/vanti-dev/sc-bos/pkg/util/pull"
 )
 
 func (a *automation) collectOccupancyChanges(ctx context.Context, source config.Source, payloads chan<- []byte) {
@@ -18,6 +17,8 @@ func (a *automation) collectOccupancyChanges(ctx context.Context, source config.
 		a.logger.Error("collection aborted", zap.Error(err))
 		return
 	}
+
+	last := newDeduper[*traits.Occupancy](cmp.Equal(cmp.FloatValueApprox(0, 0.0001)))
 
 	pullFn := func(ctx context.Context, changes chan<- []byte) error {
 		stream, err := client.PullOccupancy(ctx, &traits.PullOccupancyRequest{Name: source.Name, UpdatesOnly: true, ReadMask: source.ReadMask.PB()})
@@ -30,10 +31,15 @@ func (a *automation) collectOccupancyChanges(ctx context.Context, source config.
 				return err
 			}
 			for _, change := range msg.Changes {
-				payload, err := proto.Marshal(change.Occupancy)
+				if !last.Changed(change.GetOccupancy()) {
+					continue
+				}
+
+				payload, err := proto.Marshal(change.GetOccupancy())
 				if err != nil {
 					return err
 				}
+
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
@@ -43,14 +49,20 @@ func (a *automation) collectOccupancyChanges(ctx context.Context, source config.
 		}
 	}
 	pollFn := func(ctx context.Context, changes chan<- []byte) error {
-		demand, err := client.GetOccupancy(ctx, &traits.GetOccupancyRequest{Name: source.Name, ReadMask: source.ReadMask.PB()})
+		resp, err := client.GetOccupancy(ctx, &traits.GetOccupancyRequest{Name: source.Name, ReadMask: source.ReadMask.PB()})
 		if err != nil {
 			return err
 		}
-		payload, err := proto.Marshal(demand)
+
+		if !last.Changed(resp) {
+			return nil
+		}
+
+		payload, err := proto.Marshal(resp)
 		if err != nil {
 			return err
 		}
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -59,11 +71,7 @@ func (a *automation) collectOccupancyChanges(ctx context.Context, source config.
 		return nil
 	}
 
-	err := pull.Changes(ctx, pull.NewFetcher(pullFn, pollFn), payloads, pull.WithLogger(a.logger))
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return
-	}
-	if err != nil {
+	if err := collectChanges(ctx, source, pullFn, pollFn, payloads, a.logger); err != nil {
 		a.logger.Warn("collection aborted", zap.Error(err))
 	}
 }

--- a/pkg/util/jsontypes/schedule.go
+++ b/pkg/util/jsontypes/schedule.go
@@ -21,6 +21,14 @@ func MustParseSchedule(raw string) *Schedule {
 	return &Schedule{Schedule: schedule, Raw: raw}
 }
 
+func MustParseExtendedSchedule(raw string) *Schedule {
+	schedule, err := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow).Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+	return &Schedule{Schedule: schedule, Raw: raw}
+}
+
 func (s *Schedule) String() string {
 	return s.Raw
 }


### PR DESCRIPTION
The default behaviour will be as before: without a cron schedule for the history automation, the pull.Fetcher will determine whether polling or pull operations are used to fetch changes from a device trait.

However, if a cron schedule is provided, the history automation will use a poll cycle to fetch values on a given schedule, and will ignore duplicate consecutive changes to device traits.

This is effort taken to reduce the storage required for a history automation.