### PR TITLE
feat/device monitor auto

### DIFF
--- a/pkg/auto/allautos/factory.go
+++ b/pkg/auto/allautos/factory.go
@@ -4,6 +4,7 @@ import (
 	"github.com/vanti-dev/sc-bos/pkg/auto"
 	"github.com/vanti-dev/sc-bos/pkg/auto/azureiot"
 	"github.com/vanti-dev/sc-bos/pkg/auto/bms"
+	"github.com/vanti-dev/sc-bos/pkg/auto/devicemonitor"
 	"github.com/vanti-dev/sc-bos/pkg/auto/export"
 	"github.com/vanti-dev/sc-bos/pkg/auto/exporthttp"
 	"github.com/vanti-dev/sc-bos/pkg/auto/history"
@@ -23,6 +24,7 @@ func Factories() map[string]auto.Factory {
 	return map[string]auto.Factory{
 		azureiot.FactoryName:        azureiot.Factory,
 		bms.AutoType:                bms.Factory,
+		devicemonitor.AutoName:      devicemonitor.Factory,
 		"export-mqtt":               export.MQTTFactory,
 		"history":                   history.Factory,
 		lights.AutoType:             lights.Factory,

--- a/pkg/auto/devicemonitor/airtemperature.go
+++ b/pkg/auto/devicemonitor/airtemperature.go
@@ -1,0 +1,191 @@
+package devicemonitor
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/vanti-dev/sc-bos/pkg/auto/devicemonitor/config"
+	"github.com/vanti-dev/sc-bos/pkg/gen"
+)
+
+// abnormalTemperatureCheck checks if the return air temperatures are within the normal range defined in the config.
+// It generates alerts for abnormal temperatures and resolves them when temperatures return to normal.
+func (a *deviceMonitorAuto) abnormalTemperatureCheck(ctx context.Context, client traits.AirTemperatureApiClient, config *config.AirTempConfig) {
+	for _, device := range config.Devices {
+		resp, err := client.GetAirTemperature(ctx, &traits.GetAirTemperatureRequest{
+			Name: device.Name,
+		})
+		if err != nil {
+			a.Logger.Error("failed to get air temperature", zap.Error(err))
+			return
+		}
+		if resp.AmbientTemperature != nil {
+			if resp.AmbientTemperature.ValueCelsius < *config.OkRtLowerBound {
+				if device.AbnormalLowId == "" { // don't re-raise the alert if it is already there
+					alert, err := a.alertAdminClient.CreateAlert(ctx, &gen.CreateAlertRequest{
+						Alert: &gen.Alert{
+							Id:          uuid.New().String(),
+							CreateTime:  timestamppb.Now(),
+							Description: "Ambient temperature is abnormally low",
+							Severity:    gen.Alert_WARNING,
+							Source:      device.Name,
+						},
+					})
+					if err != nil {
+						a.Logger.Error("failed to create alert", zap.Error(err))
+					} else {
+						device.AbnormalLowId = alert.Id
+					}
+				}
+			} else {
+				if device.AbnormalLowId != "" {
+					_, err := a.alertAdminClient.ResolveAlert(ctx, &gen.ResolveAlertRequest{
+						Alert: &gen.Alert{
+							Id:          device.AbnormalLowId,
+							ResolveTime: timestamppb.Now(),
+						},
+					})
+					if err != nil {
+						a.Logger.Error("failed to resolve alert", zap.Error(err))
+					} else {
+						device.AbnormalLowId = ""
+					}
+				}
+			}
+			if resp.AmbientTemperature.ValueCelsius > *config.OkRtUpperBound {
+				if device.AbnormalHighId == "" {
+					alert, err := a.alertAdminClient.CreateAlert(ctx, &gen.CreateAlertRequest{
+						Alert: &gen.Alert{
+							Id:          uuid.New().String(),
+							CreateTime:  timestamppb.Now(),
+							Description: "Ambient temperature is abnormally high",
+							Severity:    gen.Alert_WARNING,
+							Source:      device.Name,
+						},
+					})
+					if err != nil {
+						a.Logger.Error("failed to create alert", zap.Error(err))
+					} else {
+						device.AbnormalHighId = alert.Id
+					}
+				}
+			} else {
+				if device.AbnormalHighId != "" {
+					_, err := a.alertAdminClient.ResolveAlert(ctx, &gen.ResolveAlertRequest{
+						Alert: &gen.Alert{
+							Id:          device.AbnormalHighId,
+							ResolveTime: timestamppb.Now(),
+						},
+					})
+					if err != nil {
+						a.Logger.Error("failed to resolve alert", zap.Error(err))
+					} else {
+						device.AbnormalHighId = ""
+					}
+				}
+			}
+		}
+	}
+}
+
+// hasReachedSetPoint checks if the measured temperature is within the acceptable tolerance range of the setPoint value.
+// It also respects the okSettlingTime by allowing a grace period after a set point change before evaluating.
+func (a *deviceMonitorAuto) hasReachedSetPoint(measured, setPoint float64, cfg *config.AirTempConfig, spChangedTime time.Time) bool {
+
+	if spChangedTime.Add(cfg.OkSettlingTime.Duration).After(a.Now()) {
+		// if we aren't expecting the set point to be reached until after Now, just return true
+		return true
+	}
+
+	tolerance := *cfg.Tolerance
+	if measured >= setPoint-tolerance && measured <= setPoint+tolerance {
+		return true
+	}
+	return false
+}
+
+// returnAirReachesSetPointCheck verifies if the return air temperature of each device aligns with its set point within tolerance.
+// It generates alerts if the set point is not reached within the allowed time and resolves them when conditions normalize.
+// If the set point is changed, the timer is reset and the okSettlingTime begins again from Now.
+func (a *deviceMonitorAuto) returnAirReachesSetPointCheck(ctx context.Context, client traits.AirTemperatureApiClient, config *config.AirTempConfig) {
+	for _, device := range config.Devices {
+		resp, err := client.GetAirTemperature(ctx, &traits.GetAirTemperatureRequest{
+			Name: device.Name,
+		})
+		if err != nil {
+			a.Logger.Error("failed to get air temperature", zap.Error(err))
+			return
+		}
+		setPoint := resp.GetTemperatureSetPoint()
+		if resp.AmbientTemperature != nil && setPoint != nil {
+			if device.PreviousSetPoint == nil {
+				// we need to be able to detect when the set point has been changed and reset the timer
+				// when the auto first runs, initialise the previous set point to the current set point
+				device.PreviousSetPoint = proto.Float64(setPoint.ValueCelsius)
+				device.SetPointChangedTime = a.Now()
+			}
+			if *device.PreviousSetPoint != setPoint.ValueCelsius {
+				// if the set point has been changed, we need to reset the timer
+				device.SetPointChangedTime = a.Now()
+			}
+			if !a.hasReachedSetPoint(resp.AmbientTemperature.ValueCelsius, setPoint.ValueCelsius, config, device.SetPointChangedTime) {
+				// make sure we aren't re-raising the alert if it is already there
+				if device.SetPointNotReachedId == "" {
+					alert, err := a.alertAdminClient.CreateAlert(ctx, &gen.CreateAlertRequest{
+						Alert: &gen.Alert{
+							Id:          uuid.New().String(),
+							CreateTime:  timestamppb.Now(),
+							Description: "Measured temperature is not reaching set point within expected time",
+							Severity:    gen.Alert_WARNING,
+							Source:      device.Name,
+						},
+					})
+					if err != nil {
+						a.Logger.Error("failed to create alert", zap.Error(err))
+					} else {
+						device.SetPointNotReachedId = alert.Id
+					}
+				}
+			} else {
+				// this case ideally should not happen:
+				// the idea of the auto is that it catches devices which don't reach the set point within a
+				// generous time period, meaning something is likely wrong with the device and requires a manual check.
+				// However, if we see that many alerts are being created and auto resolved here,
+				// the parameters might be too strict.
+				if device.SetPointNotReachedId != "" {
+					_, err := a.alertAdminClient.ResolveAlert(ctx, &gen.ResolveAlertRequest{
+						Alert: &gen.Alert{
+							Id:          device.SetPointNotReachedId,
+							ResolveTime: timestamppb.Now(),
+						},
+					})
+					if err != nil {
+						a.Logger.Error("failed to resolve alert", zap.Error(err))
+					} else {
+						device.SetPointNotReachedId = ""
+					}
+				}
+			}
+			device.PreviousSetPoint = proto.Float64(setPoint.ValueCelsius)
+		} else {
+			a.Logger.Error("failed to get air temperature or set point", zap.Error(err))
+		}
+	}
+}
+
+func (a *deviceMonitorAuto) runAirTemperatureMonitor(ctx context.Context, cfg config.Root, client traits.AirTemperatureApiClient) {
+
+	if cfg.AirTempConfig.OkRtUpperBound != nil && cfg.AirTempConfig.OkRtLowerBound != nil {
+		a.abnormalTemperatureCheck(ctx, client, cfg.AirTempConfig)
+	}
+
+	if cfg.AirTempConfig.Tolerance != nil && cfg.AirTempConfig.OkSettlingTime != nil {
+		a.returnAirReachesSetPointCheck(ctx, client, cfg.AirTempConfig)
+	}
+}

--- a/pkg/auto/devicemonitor/auto.go
+++ b/pkg/auto/devicemonitor/auto.go
@@ -1,0 +1,74 @@
+// Package devicemonitor is used to monitor the measurements and statuses of devices and look for any abnormal behaviour.
+// If abnormal behaviour is detected, it will raise a status notification.
+package devicemonitor
+
+import (
+	"context"
+	"time"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/vanti-dev/sc-bos/internal/util/pgxutil"
+	"github.com/vanti-dev/sc-bos/pkg/auto"
+	"github.com/vanti-dev/sc-bos/pkg/auto/devicemonitor/config"
+	"github.com/vanti-dev/sc-bos/pkg/gen"
+	"github.com/vanti-dev/sc-bos/pkg/node"
+	"github.com/vanti-dev/sc-bos/pkg/task/service"
+)
+
+const AutoName = "devicemonitor"
+
+var Factory auto.Factory = factory{}
+
+type factory struct{}
+
+type Storage struct {
+	Type string `json:"type,omitempty"`
+	pgxutil.ConnectConfig
+	Name string `json:"name,omitempty"`
+}
+
+type deviceMonitorAuto struct {
+	*service.Service[config.Root]
+	auto.Services
+
+	alertAdminClient gen.AlertAdminApiClient
+	announcer        *node.ReplaceAnnouncer
+}
+
+func (f factory) New(services auto.Services) service.Lifecycle {
+	a := &deviceMonitorAuto{Services: services}
+	a.Service = service.New(service.MonoApply(a.applyConfig), service.WithParser(config.ReadBytes))
+	a.Logger = a.Logger.Named(AutoName)
+	return a
+}
+
+func (a *deviceMonitorAuto) applyConfig(ctx context.Context, cfg config.Root) error {
+
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	a.announcer = node.NewReplaceAnnouncer(a.Node)
+	a.alertAdminClient = gen.NewAlertAdminApiClient(a.Node.ClientConn())
+	if cfg.AirTempConfig != nil && len(cfg.AirTempConfig.Devices) > 0 {
+		fcuClient := traits.NewAirTemperatureApiClient(a.Node.ClientConn())
+
+		atConfig := cfg.AirTempConfig
+		go func() {
+			t := now()
+			for {
+				next := atConfig.MonitorSchedule.Next(t)
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(time.Until(next)):
+					t = next
+					a.runAirTemperatureMonitor(ctx, cfg, fcuClient)
+				}
+			}
+		}()
+	}
+
+	return nil
+}

--- a/pkg/auto/devicemonitor/config/root.go
+++ b/pkg/auto/devicemonitor/config/root.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/vanti-dev/sc-bos/pkg/auto"
+	"github.com/vanti-dev/sc-bos/pkg/util/jsontypes"
+)
+
+type Device struct {
+	Name                 string `json:"name,omitempty"` // the name of the device
+	AbnormalHighId       string
+	AbnormalLowId        string
+	SetPointNotReachedId string
+
+	PreviousSetPoint    *float64
+	SetPointChangedTime time.Time
+}
+
+type AirTempConfig struct {
+	// if the return air temperature is equal to or greater than this value, it is ok.
+	// This MUST be configured to run abnormalTemperatureCheck
+	OkRtLowerBound *float64 `json:"okRtLowerBound,omitempty,omitzero"`
+	// This MUST be configured to run abnormalTemperatureCheck
+	OkRtUpperBound *float64 `json:"okRtUpperBound,omitempty,omitzero"` // if the return air temperature is equal to or less than this value, it is ok.
+
+	// if the return air temperature settles within the fcu set point tolerance within this time,
+	// then it is considered ok. If not, a status is raised indicating the fcu might not be OK.
+	// This duration should be in hours not minutes, as gets reset whenever the set point is adjusted
+	// This MUST be configured to run the set point reached check
+	OkSettlingTime *jsontypes.Duration `json:"okSettlingTime,omitempty,omitzero"`
+	// The tolerance (+-) we have for monitoring whether the temperature settled at its target.
+	// e.g. if the set point is 22°C and the tolerance is 2°C, then the temperature is considered settled
+	// when it is between 20°C and 24°C.
+	// This MUST be configured to run the set point reached check
+	Tolerance *float64 `json:"tolerance,omitempty,omitzero"`
+
+	MonitorSchedule *jsontypes.Schedule `json:"monitorSchedule,omitempty"`
+	Devices         []*Device           `json:"devices,omitempty"`
+}
+
+type Root struct {
+	auto.Config
+
+	AirTempConfig *AirTempConfig `json:"airTempConfig,omitempty"`
+
+	// Now returns the current time. It's configurable for testing purposes, typically for testing the logic.
+	Now func() time.Time `json:"-"`
+}
+
+func ReadBytes(data []byte) (cfg Root, err error) {
+	err = json.Unmarshal(data, &cfg)
+	if err != nil {
+		return
+	}
+
+	if cfg.AirTempConfig != nil && cfg.AirTempConfig.MonitorSchedule == nil {
+		cfg.AirTempConfig.MonitorSchedule = &jsontypes.Schedule{
+			Schedule: jsontypes.MustParseSchedule("0 * * * *"),
+		}
+	}
+
+	return cfg, nil
+}

--- a/pkg/auto/devicemonitor/devicemonitor_test.go
+++ b/pkg/auto/devicemonitor/devicemonitor_test.go
@@ -1,0 +1,341 @@
+package devicemonitor
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
+	"github.com/smart-core-os/sc-golang/pkg/trait"
+	"github.com/smart-core-os/sc-golang/pkg/trait/airtemperaturepb"
+	"github.com/vanti-dev/sc-bos/pkg/auto/devicemonitor/config"
+	"github.com/vanti-dev/sc-bos/pkg/gen"
+	"github.com/vanti-dev/sc-bos/pkg/node"
+	"github.com/vanti-dev/sc-bos/pkg/util/jsontypes"
+)
+
+func TestCheckReturnTemperaturesAreOk(t *testing.T) {
+	fcuName := "fcu1"
+	devices := []*config.Device{{
+		Name: fcuName,
+	}}
+	nodeName := "node1"
+	model := airtemperaturepb.NewModel()
+	n := node.New(nodeName)
+
+	n.Announce(fcuName,
+		node.HasTrait(trait.AirTemperature),
+		node.HasServer(traits.RegisterAirTemperatureApiServer, traits.AirTemperatureApiServer(airtemperaturepb.NewModelServer(model))),
+	)
+	ctx, stop := context.WithCancel(context.Background())
+	t.Cleanup(stop)
+
+	alertClient := &memalert{}
+	alertClient.alerts = make(map[string]*gen.Alert)
+	auto := &deviceMonitorAuto{
+		alertAdminClient: alertClient,
+	}
+	auto.Logger, _ = zap.NewDevelopment()
+
+	tempClient := traits.NewAirTemperatureApiClient(n.ClientConn())
+
+	tests := []struct {
+		name       string
+		okLower    float64
+		okUpper    float64
+		temp       float64
+		isResolved bool
+		want       *gen.Alert
+	}{
+		{"Test with normal temperature", 10, 30, 20, false, nil},
+		{"Test with low temperature", 10, 30, 5, false, &gen.Alert{
+			Id:          "low",
+			Source:      fcuName,
+			Severity:    gen.Alert_WARNING,
+			Description: "Ambient temperature is abnormally low",
+		}},
+		{"Test with temperature returning within bounds", 10, 30, 15, true, &gen.Alert{
+			Id:          "low",
+			Source:      fcuName,
+			Severity:    gen.Alert_WARNING,
+			Description: "Ambient temperature is abnormally low",
+		}},
+		{"Test with high temperature", 10, 30, 35, false, &gen.Alert{
+			Id:          "high",
+			Source:      fcuName,
+			Severity:    gen.Alert_WARNING,
+			Description: "Ambient temperature is abnormally high",
+		}},
+		{"Test with temperature returning within bounds", 10, 30, 25, true, &gen.Alert{
+			Id:          "high",
+			Source:      fcuName,
+			Severity:    gen.Alert_WARNING,
+			Description: "Ambient temperature is abnormally high",
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			model.UpdateAirTemperature(&traits.AirTemperature{
+				AmbientTemperature: &types.Temperature{
+					ValueCelsius: tt.temp,
+				},
+			})
+			// we need to make sure the model updates before we run our test
+			i := 5
+			for i > 0 {
+				i--
+				time.Sleep(1 * time.Second)
+				check, _ := tempClient.GetAirTemperature(ctx, &traits.GetAirTemperatureRequest{
+					Name: fcuName,
+				})
+				if check.AmbientTemperature.ValueCelsius == tt.temp {
+					break
+				}
+			}
+			if i == 0 {
+				t.Fatal("failed to update")
+			}
+			auto.abnormalTemperatureCheck(ctx, tempClient, &config.AirTempConfig{
+				Devices:        devices,
+				OkRtLowerBound: proto.Float64(tt.okLower),
+				OkRtUpperBound: proto.Float64(tt.okUpper),
+			})
+
+			s, err := alertClient.ListAlerts(ctx, &gen.ListAlertsRequest{
+				Name: fcuName,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.want == nil {
+				if len(s.Alerts) != 0 {
+					t.Fatalf("expected no problems, got %d", len(s.Alerts))
+				}
+			} else {
+				if len(s.Alerts) == 0 {
+					t.Fatalf("expected problems got 0")
+				}
+				last := len(s.Alerts) - 1
+				if s.Alerts[last].Source != tt.want.Source {
+					t.Fatalf("expected problem source %s, got %s", tt.want.Source, s.Alerts[last].Source)
+				}
+				if s.Alerts[last].Severity != tt.want.Severity {
+					t.Fatalf("expected problem severity %s, got %s", tt.want.Severity, s.Alerts[last].Severity)
+				}
+				if s.Alerts[last].Description != tt.want.Description {
+					t.Fatalf("expected problem description %s, got %s", tt.want.Description, s.Alerts[last].Description)
+				}
+				if tt.isResolved {
+					if s.Alerts[last].ResolveTime == nil {
+						t.Fatalf("expected problem to be resolved")
+					}
+				} else {
+					if s.Alerts[last].ResolveTime != nil {
+						t.Fatalf("expected problem to not be resolved")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCheckMeasuredReachesSetPoint(t *testing.T) {
+	fcuName := "fcu1"
+	devices := []*config.Device{{
+		Name: fcuName,
+	}}
+	nodeName := "node1"
+	model := airtemperaturepb.NewModel()
+	n := node.New(nodeName)
+
+	n.Announce(fcuName,
+		node.HasTrait(trait.AirTemperature),
+		node.HasServer(traits.RegisterAirTemperatureApiServer, traits.AirTemperatureApiServer(airtemperaturepb.NewModelServer(model))),
+	)
+	ctx, stop := context.WithCancel(context.Background())
+	t.Cleanup(stop)
+
+	alertClient := &memalert{}
+	alertClient.alerts = make(map[string]*gen.Alert)
+	auto := &deviceMonitorAuto{
+		alertAdminClient: alertClient,
+	}
+	auto.Logger, _ = zap.NewDevelopment()
+	auto.Now = func() time.Time {
+		return time.Now()
+	}
+
+	tempClient := traits.NewAirTemperatureApiClient(n.ClientConn())
+
+	// initialise our dummy fcu and auto before the tests
+	model.UpdateAirTemperature(&traits.AirTemperature{
+		AmbientTemperature: &types.Temperature{
+			ValueCelsius: 0,
+		},
+		TemperatureGoal: &traits.AirTemperature_TemperatureSetPoint{TemperatureSetPoint: &types.Temperature{ValueCelsius: 0}},
+	})
+	auto.returnAirReachesSetPointCheck(ctx, tempClient, &config.AirTempConfig{
+		Devices:        devices,
+		OkSettlingTime: &jsontypes.Duration{Duration: 500 * time.Millisecond},
+		Tolerance:      proto.Float64(2),
+	})
+
+	tests := []struct {
+		name            string
+		updatedSetPoint float64
+		measured        float64
+		okSettlingTime  time.Duration
+		tolerance       float64
+		isResolved      bool
+		want            *gen.Alert
+	}{
+		{"Measured reaches set point within ok time", 22, 20, 500 * time.Millisecond, 2, false, nil},
+		{"Measured doesn't reach but has more time to do so", 22, 0, 500 * time.Minute, 2, false, nil},
+		{"Measured doesn't reach set point within ok time", 22, 19.9, 500 * time.Millisecond, 2, false, &gen.Alert{
+			Id:          "notReached",
+			Source:      fcuName,
+			Severity:    gen.Alert_WARNING,
+			Description: "Measured temperature is not reaching set point within expected time",
+		}},
+		{"Measured reaches set point and resolves", 22, 20.0, 500 * time.Millisecond, 2, true, &gen.Alert{
+			Id:          "notReached",
+			Source:      fcuName,
+			Severity:    gen.Alert_WARNING,
+			Description: "Measured temperature is not reaching set point within expected time",
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model.UpdateAirTemperature(&traits.AirTemperature{
+				AmbientTemperature: &types.Temperature{
+					ValueCelsius: tt.measured,
+				},
+				TemperatureGoal: &traits.AirTemperature_TemperatureSetPoint{TemperatureSetPoint: &types.Temperature{ValueCelsius: tt.updatedSetPoint}},
+			})
+			// we need to make sure the model updates before we run our test
+			i := 5
+			for i > 0 {
+				i--
+				time.Sleep(1 * time.Second)
+				check, _ := tempClient.GetAirTemperature(ctx, &traits.GetAirTemperatureRequest{
+					Name: fcuName,
+				})
+				if check.AmbientTemperature.ValueCelsius == tt.measured {
+					break
+				}
+			}
+			if i == 0 {
+				t.Fatal("failed to update")
+			}
+			auto.returnAirReachesSetPointCheck(ctx, tempClient, &config.AirTempConfig{
+				Devices:        devices,
+				OkSettlingTime: &jsontypes.Duration{Duration: tt.okSettlingTime},
+				Tolerance:      proto.Float64(tt.tolerance),
+			})
+			s, err := alertClient.ListAlerts(ctx, &gen.ListAlertsRequest{
+				Name: fcuName,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.want == nil {
+				if len(s.Alerts) != 0 {
+					t.Fatalf("expected no problems, got %d", len(s.Alerts))
+				}
+			} else {
+				if len(s.Alerts) == 0 {
+					t.Fatalf("expected problems got 0")
+				}
+				last := len(s.Alerts) - 1
+				if s.Alerts[last].Source != tt.want.Source {
+					t.Fatalf("expected problem source %s, got %s", tt.want.Source, s.Alerts[last].Source)
+				}
+				if s.Alerts[last].Severity != tt.want.Severity {
+					t.Fatalf("expected problem severity %s, got %s", tt.want.Severity, s.Alerts[last].Severity)
+				}
+				if s.Alerts[last].Description != tt.want.Description {
+					t.Fatalf("expected problem description %s, got %s", tt.want.Description, s.Alerts[last].Description)
+				}
+				if tt.isResolved {
+					if s.Alerts[last].ResolveTime == nil {
+						t.Fatalf("expected problem to be resolved")
+					}
+				} else {
+					if s.Alerts[last].ResolveTime != nil {
+						t.Fatalf("expected problem to not be resolved")
+					}
+				}
+			}
+		})
+	}
+}
+
+type memalert struct {
+	gen.AlertApiClient
+
+	alerts map[string]*gen.Alert
+}
+
+func (m *memalert) CreateAlert(_ context.Context, req *gen.CreateAlertRequest, _ ...grpc.CallOption) (*gen.Alert, error) {
+
+	if req.Alert == nil {
+		return nil, errors.New("alert is nil")
+	}
+
+	if m.alerts[req.Alert.Id] != nil {
+		return nil, errors.New("alert already exists")
+	} else {
+		m.alerts[req.Alert.Id] = req.Alert
+	}
+	return req.Alert, nil
+}
+
+func (m *memalert) UpdateAlert(_ context.Context, req *gen.UpdateAlertRequest, _ ...grpc.CallOption) (*gen.Alert, error) {
+	if m.alerts[req.Alert.Id] == nil {
+		return nil, errors.New("alert doesn't exists")
+	} else {
+		m.alerts[req.Alert.Id] = req.Alert
+	}
+	return req.Alert, nil
+}
+
+func (m *memalert) ResolveAlert(_ context.Context, req *gen.ResolveAlertRequest, _ ...grpc.CallOption) (*gen.Alert, error) {
+	if m.alerts[req.Alert.Id] == nil {
+		return nil, errors.New("alert doesn't exists")
+	} else {
+		m.alerts[req.Alert.Id].ResolveTime = req.Alert.ResolveTime
+	}
+	return req.Alert, nil
+}
+
+func (m *memalert) DeleteAlert(_ context.Context, req *gen.DeleteAlertRequest, _ ...grpc.CallOption) (*gen.DeleteAlertResponse, error) {
+
+	if m.alerts[req.Id] == nil {
+		return nil, errors.New("alert doesn't exist")
+	}
+	delete(m.alerts, req.Id)
+	return &gen.DeleteAlertResponse{}, nil
+}
+
+func (m *memalert) ListAlerts(ctx context.Context, in *gen.ListAlertsRequest, _ ...grpc.CallOption) (*gen.ListAlertsResponse, error) {
+	// sort the map and then return
+	var alerts []*gen.Alert
+	for _, a := range m.alerts {
+		alerts = append(alerts, a)
+	}
+
+	sort.Slice(alerts, func(i, j int) bool {
+		return alerts[i].CreateTime.AsTime().Before(alerts[j].CreateTime.AsTime())
+	})
+	return &gen.ListAlertsResponse{
+		Alerts: alerts,
+	}, nil
+}


### PR DESCRIPTION
adds an automation which allows checking air temperature devices for; abnormal temperatures and/or whether the set point is reached in a certain time period. Raises a status alert when not ok conditions are met.

Was written to implement [SC-1046](https://vanti.youtrack.cloud/issue/SC-1046/Detect-abnormal-FCU-temperatures-set-point-vs-actual-discrepancies) but can be extended with other traits to abitarily monitor devices to detect abnormalities

There are some unit tests and you can also add the automation to the ugs example and adjust the FCU temperature to trigger the alerts