### PR TITLE
all: replace node.Clienter usage with node.ClientConner

### DIFF
--- a/internal/driver/settings/driver.go
+++ b/internal/driver/settings/driver.go
@@ -24,7 +24,6 @@ type factory struct{}
 func (f factory) New(services driver.Services) service.Lifecycle {
 	d := &Driver{
 		services:  services,
-		clients:   services.Node,
 		announcer: node.NewReplaceAnnouncer(services.Node),
 		logger:    services.Logger.Named("settings"),
 	}
@@ -35,7 +34,6 @@ func (f factory) New(services driver.Services) service.Lifecycle {
 type Driver struct {
 	*service.Service[config.Root]
 	services  driver.Services
-	clients   node.Clienter
 	announcer *node.ReplaceAnnouncer
 
 	logger *zap.Logger

--- a/pkg/auto/bms/action.go
+++ b/pkg/auto/bms/action.go
@@ -20,16 +20,13 @@ type Actions interface {
 	UpdateModeValues(ctx context.Context, req *traits.UpdateModeValuesRequest, ws *WriteState) error
 }
 
-// ClientActions creates a new Actions backed by node.Clienter clients.
-func ClientActions(clients node.Clienter) (Actions, error) {
-	res := &clientActions{}
-	if err := clients.Client(&res.airTemperatureClient); err != nil {
-		return nil, err
+// ClientActions creates a new Actions backed by node.ClientConner clients.
+func ClientActions(clients node.ClientConner) Actions {
+	conn := clients.ClientConn()
+	return &clientActions{
+		airTemperatureClient: traits.NewAirTemperatureApiClient(conn),
+		modeClient:           traits.NewModeApiClient(conn),
 	}
-	if err := clients.Client(&res.modeClient); err != nil {
-		return nil, err
-	}
-	return res, nil
 }
 
 type clientActions struct {

--- a/pkg/auto/bms/factory.go
+++ b/pkg/auto/bms/factory.go
@@ -42,7 +42,7 @@ func (f factory) New(services auto.Services) service.Lifecycle {
 type Auto struct {
 	*service.Service[config.Root]
 	logger  *zap.Logger
-	clients node.Clienter
+	clients node.ClientConner
 
 	setupOnce     sync.Once // reset on stop
 	setupErr      error
@@ -52,7 +52,7 @@ type Auto struct {
 
 	// test helpers
 	now           func() time.Time
-	clientActions func(clienter node.Clienter) (Actions, error)
+	clientActions func(clientConner node.ClientConner) Actions
 	newTimer      func(duration time.Duration) (<-chan time.Time, func() bool)
 	processDone   func(readState *ReadState, writeState *WriteState, ttl time.Duration, err error)
 }
@@ -60,10 +60,7 @@ type Auto struct {
 func (a *Auto) applyConfig(ctx context.Context, cfg config.Root) error {
 	a.setTestHelperFuncs()
 
-	actions, err := a.clientActions(a.clients)
-	if err != nil {
-		return err
-	}
+	actions := a.clientActions(a.clients)
 	cfgChanges, err := a.setup(actions)
 	if err != nil {
 		return err

--- a/pkg/auto/history/airqualitysensor.go
+++ b/pkg/auto/history/airqualitysensor.go
@@ -13,11 +13,7 @@ import (
 )
 
 func (a *automation) collectAirQualityChanges(ctx context.Context, source config.Source, payloads chan<- []byte) {
-	var client traits.AirQualitySensorApiClient
-	if err := a.clients.Client(&client); err != nil {
-		a.logger.Error("collection aborted", zap.Error(err))
-		return
-	}
+	client := traits.NewAirQualitySensorApiClient(a.clients.ClientConn())
 
 	pullFn := func(ctx context.Context, changes chan<- []byte) error {
 		stream, err := client.PullAirQuality(ctx, &traits.PullAirQualityRequest{Name: source.Name, UpdatesOnly: true, ReadMask: source.ReadMask.PB()})

--- a/pkg/auto/history/airtemperature.go
+++ b/pkg/auto/history/airtemperature.go
@@ -13,11 +13,7 @@ import (
 )
 
 func (a *automation) collectAirTemperatureChanges(ctx context.Context, source config.Source, payloads chan<- []byte) {
-	var client traits.AirTemperatureApiClient
-	if err := a.clients.Client(&client); err != nil {
-		a.logger.Error("collection aborted", zap.Error(err))
-		return
-	}
+	client := traits.NewAirTemperatureApiClient(a.clients.ClientConn())
 
 	pullFn := func(ctx context.Context, changes chan<- []byte) error {
 		stream, err := client.PullAirTemperature(ctx, &traits.PullAirTemperatureRequest{Name: source.Name, ReadMask: source.ReadMask.PB()})

--- a/pkg/auto/history/electric.go
+++ b/pkg/auto/history/electric.go
@@ -13,11 +13,7 @@ import (
 )
 
 func (a *automation) collectElectricDemandChanges(ctx context.Context, source config.Source, payloads chan<- []byte) {
-	var client traits.ElectricApiClient
-	if err := a.clients.Client(&client); err != nil {
-		a.logger.Error("collection aborted", zap.Error(err))
-		return
-	}
+	client := traits.NewElectricApiClient(a.clients.ClientConn())
 
 	pullFn := func(ctx context.Context, changes chan<- []byte) error {
 		stream, err := client.PullDemand(ctx, &traits.PullDemandRequest{Name: source.Name, UpdatesOnly: true, ReadMask: source.ReadMask.PB()})

--- a/pkg/auto/history/factory.go
+++ b/pkg/auto/history/factory.go
@@ -55,7 +55,7 @@ func NewAutomation(services auto.Services) service.Lifecycle {
 
 type automation struct {
 	*service.Service[config.Root]
-	clients   node.Clienter
+	clients   node.ClientConner
 	announcer *node.ReplaceAnnouncer
 	logger    *zap.Logger
 
@@ -118,10 +118,7 @@ func (a *automation) applyConfig(ctx context.Context, cfg config.Root) error {
 		if name == "" {
 			return errors.New("storage.name missing, must exist when storage.type is \"api\"")
 		}
-		var client gen.HistoryAdminApiClient
-		if err := a.clients.Client(&client); err != nil {
-			return err
-		}
+		client := gen.NewHistoryAdminApiClient(a.clients.ClientConn())
 		store = apistore.New(client, name, cfg.Source.SourceName())
 	case "hub":
 		if cfg.Storage.TTL != nil {

--- a/pkg/auto/history/meter.go
+++ b/pkg/auto/history/meter.go
@@ -13,11 +13,7 @@ import (
 )
 
 func (a *automation) collectMeterReadingChanges(ctx context.Context, source config.Source, payloads chan<- []byte) {
-	var client gen.MeterApiClient
-	if err := a.clients.Client(&client); err != nil {
-		a.logger.Error("collection aborted", zap.Error(err))
-		return
-	}
+	client := gen.NewMeterApiClient(a.clients.ClientConn())
 
 	pullFn := func(ctx context.Context, changes chan<- []byte) error {
 		stream, err := client.PullMeterReadings(ctx, &gen.PullMeterReadingsRequest{Name: source.Name, UpdatesOnly: true, ReadMask: source.ReadMask.PB()})

--- a/pkg/auto/history/occupancysensor.go
+++ b/pkg/auto/history/occupancysensor.go
@@ -13,11 +13,7 @@ import (
 )
 
 func (a *automation) collectOccupancyChanges(ctx context.Context, source config.Source, payloads chan<- []byte) {
-	var client traits.OccupancySensorApiClient
-	if err := a.clients.Client(&client); err != nil {
-		a.logger.Error("collection aborted", zap.Error(err))
-		return
-	}
+	client := traits.NewOccupancySensorApiClient(a.clients.ClientConn())
 
 	pullFn := func(ctx context.Context, changes chan<- []byte) error {
 		stream, err := client.PullOccupancy(ctx, &traits.PullOccupancyRequest{Name: source.Name, UpdatesOnly: true, ReadMask: source.ReadMask.PB()})

--- a/pkg/auto/history/status.go
+++ b/pkg/auto/history/status.go
@@ -13,11 +13,7 @@ import (
 )
 
 func (a *automation) collectCurrentStatusChanges(ctx context.Context, source config.Source, payloads chan<- []byte) {
-	var client gen.StatusApiClient
-	if err := a.clients.Client(&client); err != nil {
-		a.logger.Error("collection aborted", zap.Error(err))
-		return
-	}
+	client := gen.NewStatusApiClient(a.clients.ClientConn())
 
 	pullFn := func(ctx context.Context, changes chan<- []byte) error {
 		stream, err := client.PullCurrentStatus(ctx, &gen.PullCurrentStatusRequest{Name: source.Name, UpdatesOnly: true, ReadMask: source.ReadMask.PB()})

--- a/pkg/auto/lights/action.go
+++ b/pkg/auto/lights/action.go
@@ -20,13 +20,12 @@ type actions interface {
 	UpdateBrightness(ctx context.Context, now time.Time, req *traits.UpdateBrightnessRequest, state *WriteState) error
 }
 
-// newClientActions creates an actions backed by node.Clienter clients.
-func newClientActions(clients node.Clienter) (actions, error) {
-	res := &clientActions{}
-	if err := clients.Client(&res.lightClient); err != nil {
-		return nil, fmt.Errorf("%w traits.LightApiClient", err)
+// newClientActions creates an actions backed by node.ClientConner clients.
+func newClientActions(clients node.ClientConner) actions {
+	conn := clients.ClientConn()
+	return &clientActions{
+		lightClient: traits.NewLightApiClient(conn),
 	}
-	return res, nil
 }
 
 type clientActions struct {

--- a/pkg/node/client.go
+++ b/pkg/node/client.go
@@ -24,11 +24,18 @@ func (n *Node) ClientConn() grpc.ClientConnInterface {
 	return router.NewLoopback(n.router)
 }
 
+// ClientConner represents a type that can return a gRPC client connection.
+type ClientConner interface {
+	ClientConn() grpc.ClientConnInterface
+}
+
 func (n *Node) ServerHandler() grpc.StreamHandler {
 	return router.StreamHandler(n.router)
 }
 
 // Clienter represents a type that can respond with an API client.
+//
+// Deprecated: Use ClientConner to acquire a connection and construct clients directly.
 type Clienter interface {
 	// Client sets into the pointer p a client, if one is available, or returns an error.
 	// Argument p should be a pointer to a variable of the required client type.
@@ -37,6 +44,8 @@ type Clienter interface {
 	//
 	//	var client traits.OnOffApiClient
 	//	err := n.Client(&client)
+	//
+	// Deprecated: Use ClientConner.ClientConn() to acquire a connection and construct clients directly.
 	Client(p any) error
 }
 

--- a/pkg/system/authn/factory.go
+++ b/pkg/system/authn/factory.go
@@ -56,7 +56,7 @@ type System struct {
 	server *nextOrNotFound
 
 	configDirs    []string
-	clienter      node.Clienter
+	clienter      node.ClientConner
 	cohortManager node.Remote
 	logger        *zap.Logger
 

--- a/pkg/zone/feature/access/access.go
+++ b/pkg/zone/feature/access/access.go
@@ -29,7 +29,7 @@ type feature struct {
 	*service.Service[config.Root]
 	announcer *node.ReplaceAnnouncer
 	devices   *zone.Devices
-	clients   node.Clienter
+	clients   node.ClientConner
 	logger    *zap.Logger
 }
 
@@ -38,13 +38,8 @@ func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
 	logger := f.logger
 
 	if len(cfg.AccessPoints) > 0 {
-		var client gen.AccessApiClient
-		if err := f.clients.Client(&client); err != nil {
-			return err
-		}
-
 		group := &Group{
-			client: client,
+			client: gen.NewAccessApiClient(f.clients.ClientConn()),
 			names:  cfg.AccessPoints,
 			logger: logger,
 		}

--- a/pkg/zone/feature/airquality/airquality.go
+++ b/pkg/zone/feature/airquality/airquality.go
@@ -30,7 +30,7 @@ type feature struct {
 	*service.Service[config.Root]
 	announcer *node.ReplaceAnnouncer
 	devices   *zone.Devices
-	clients   node.Clienter
+	clients   node.ClientConner
 	logger    *zap.Logger
 }
 
@@ -39,13 +39,8 @@ func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
 	logger := f.logger
 
 	if len(cfg.AirQualitySensors) > 0 {
-		var client traits.AirQualitySensorApiClient
-		if err := f.clients.Client(&client); err != nil {
-			return err
-		}
-
 		group := &Group{
-			client: client,
+			client: traits.NewAirQualitySensorApiClient(f.clients.ClientConn()),
 			names:  cfg.AirQualitySensors,
 			logger: logger,
 		}

--- a/pkg/zone/feature/electric/electric.go
+++ b/pkg/zone/feature/electric/electric.go
@@ -31,7 +31,7 @@ type feature struct {
 	*service.Service[config.Root]
 	announcer *node.ReplaceAnnouncer
 	devices   *zone.Devices
-	clients   node.Clienter
+	clients   node.ClientConner
 	logger    *zap.Logger
 }
 
@@ -39,10 +39,7 @@ func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
 	if len(cfg.Electrics) == 0 && len(cfg.ElectricGroups) == 0 {
 		return nil
 	}
-	var client traits.ElectricApiClient
-	if err := f.clients.Client(&client); err != nil {
-		return err
-	}
+	client := traits.NewElectricApiClient(f.clients.ClientConn())
 
 	announce := f.announcer.Replace(ctx)
 	logger := f.logger

--- a/pkg/zone/feature/enterleave/enterleave.go
+++ b/pkg/zone/feature/enterleave/enterleave.go
@@ -31,11 +31,9 @@ func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
 
 		if len(cfg.EnterLeaveSensors) > 0 {
 			elServer := &enterLeave{
-				model: occupancysensorpb.NewModel(),
-				names: cfg.EnterLeaveSensors,
-			}
-			if err := f.clients.Client(&elServer.client); err != nil {
-				return err
+				model:  occupancysensorpb.NewModel(),
+				names:  cfg.EnterLeaveSensors,
+				client: traits.NewEnterLeaveSensorApiClient(f.clients.ClientConn()),
 			}
 			group.enterLeaveClients = append(group.enterLeaveClients, enterleavesensorpb.WrapApi(elServer))
 		}

--- a/pkg/zone/feature/enterleave/group.go
+++ b/pkg/zone/feature/enterleave/group.go
@@ -33,7 +33,7 @@ type feature struct {
 	*service.Service[config.Root]
 	announcer *node.ReplaceAnnouncer
 	devices   *zone.Devices
-	clients   node.Clienter
+	clients   node.ClientConner
 	logger    *zap.Logger
 }
 

--- a/pkg/zone/feature/hvac/hvac.go
+++ b/pkg/zone/feature/hvac/hvac.go
@@ -31,19 +31,15 @@ type feature struct {
 	*service.Service[config.Root]
 	announcer *node.ReplaceAnnouncer
 	devices   *zone.Devices
-	clients   node.Clienter
+	clients   node.ClientConner
 	logger    *zap.Logger
 }
 
 func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
 	announce := f.announcer.Replace(ctx)
 	logger := f.logger
+	client := traits.NewAirTemperatureApiClient(f.clients.ClientConn())
 	publish := func(name string, t config.Thermostat) error {
-		var client traits.AirTemperatureApiClient
-		if err := f.clients.Client(&client); err != nil {
-			return err
-		}
-
 		group := &Group{
 			client:   client,
 			names:    t.Thermostats,

--- a/pkg/zone/feature/meter/meter.go
+++ b/pkg/zone/feature/meter/meter.go
@@ -30,7 +30,7 @@ type feature struct {
 	*service.Service[config.Root]
 	announcer *node.ReplaceAnnouncer
 	devices   *zone.Devices
-	clients   node.Clienter
+	clients   node.ClientConner
 	logger    *zap.Logger
 }
 
@@ -38,16 +38,9 @@ func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
 	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 
-	var apiClient gen.MeterApiClient
-	var infoClient gen.MeterInfoClient
-	if len(cfg.Meters) > 0 || len(cfg.MeterGroups) > 0 {
-		if err := f.clients.Client(&apiClient); err != nil {
-			return err
-		}
-		if err := f.clients.Client(&infoClient); err != nil {
-			return err
-		}
-	}
+	conn := f.clients.ClientConn()
+	apiClient := gen.NewMeterApiClient(conn)
+	infoClient := gen.NewMeterInfoClient(conn)
 	announceGroup := func(name string, devices []string) {
 		if len(devices) == 0 {
 			return

--- a/pkg/zone/feature/mode/mode.go
+++ b/pkg/zone/feature/mode/mode.go
@@ -30,7 +30,7 @@ type feature struct {
 	*service.Service[config.Root]
 	announcer *node.ReplaceAnnouncer
 	devices   *zone.Devices
-	clients   node.Clienter
+	clients   node.ClientConner
 	logger    *zap.Logger
 }
 
@@ -41,13 +41,9 @@ func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
 	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 
-	var api traits.ModeApiClient
-	if err := f.clients.Client(&api); err != nil {
-		return err
-	}
 	f.devices.Add(cfg.AllDeviceNames()...)
 	group := &Group{
-		client: api,
+		client: traits.NewModeApiClient(f.clients.ClientConn()),
 		cfg:    cfg,
 		logger: logger,
 	}

--- a/pkg/zone/feature/openclose/openclose.go
+++ b/pkg/zone/feature/openclose/openclose.go
@@ -35,7 +35,7 @@ type feature struct {
 	*service.Service[config.Root]
 	announcer *node.ReplaceAnnouncer
 	devices   *zone.Devices
-	clients   node.Clienter
+	clients   node.ClientConner
 	logger    *zap.Logger
 }
 
@@ -43,12 +43,7 @@ func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
 	announce := f.announcer.Replace(ctx)
 	logger := f.logger
 
-	var apiClient traits.OpenCloseApiClient
-	if len(cfg.OpenClose) > 0 || len(cfg.OpenCloseGroups) > 0 {
-		if err := f.clients.Client(&apiClient); err != nil {
-			return err
-		}
-	}
+	apiClient := traits.NewOpenCloseApiClient(f.clients.ClientConn())
 	announceGroup := func(name string, devices []string) {
 		if len(devices) == 0 {
 			return

--- a/pkg/zone/feature/status/status.go
+++ b/pkg/zone/feature/status/status.go
@@ -29,7 +29,7 @@ type feature struct {
 	*service.Service[config.Root]
 	announcer *node.ReplaceAnnouncer
 	devices   *zone.Devices
-	clients   node.Clienter
+	clients   node.ClientConner
 	logger    *zap.Logger
 }
 
@@ -38,10 +38,7 @@ func (f *feature) applyConfig(ctx context.Context, cfg config.Root) error {
 	logger := f.logger
 
 	if len(cfg.StatusLogs) > 0 || cfg.StatusLogAll {
-		var client gen.StatusApiClient
-		if err := f.clients.Client(&client); err != nil {
-			return err
-		}
+		client := gen.NewStatusApiClient(f.clients.ClientConn())
 
 		f.devices.Add(cfg.StatusLogs...)
 		if cfg.StatusLogAll {


### PR DESCRIPTION
The node.Node.Client method was already deprecated, but not the node.Clienter interface nor node.Clienter.Client method so there were still plenty of uses throughout the code. The former is brittle and prone to runtime issues, like I just found with the client credential auth not working in single node mode.

This change replaces all usage of the old mechanism with the new one while keeping the behaviour the same. In fact some code will have got a little more reliable as boot order is no longer important when resolving client instances.

Downstream projects should now see deprecation warnings if they use the old Clienter interface, we'll give them a bit of time to update before we delete node.Clienter and all the associated types, funcs, and packages (like alltraits).