### PR TITLE
ui/ops: add a button to show password in browser when clicked

### DIFF
--- a/ui/ops/src/routes/login/LocalLogin.vue
+++ b/ui/ops/src/routes/login/LocalLogin.vue
@@ -19,7 +19,9 @@
           :rules="[rules.required]"
           variant="outlined"
           v-model="password"
-          type="password"
+          :type="showPassword ? 'text' : 'password'"
+          :append-inner-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
+          @click:append-inner="showPassword = !showPassword"
           required/>
       <v-card-actions class="mx-2">
         <v-btn
@@ -43,6 +45,7 @@ import {computed, ref} from 'vue';
 
 const accountStore = useAccountStore();
 const password = ref('');
+const showPassword = ref(false);
 const username = ref('');
 const rules = {
   required: (value) => !!value || 'Required.'


### PR DESCRIPTION
One of the facilities managers on-site complained she couldn't view her Ops UI password when entering it for the first time (received on one machine, and entered via a keyboard halfway across the room).

I am hoping this PR shows we are responding to their complaints / suggestions.

https://github.com/user-attachments/assets/339c5e98-7c60-4545-8a7a-52f29fc2823f

