### PR TITLE
node: add examples for AnnounceScope

### DIFF
--- a/pkg/node/announce_scope_test.go
+++ b/pkg/node/announce_scope_test.go
@@ -1,0 +1,30 @@
+package node
+
+type Scoped struct {
+	announcer Announcer
+	undo      Undo
+}
+
+// Reset clears old scopes and creates a new scope with the announced name.
+// The caller should never call Reset concurrently.
+func (s *Scoped) Reset(name string) {
+	// undo the previous scope if it exists
+	if s.undo != nil {
+		s.undo()
+	}
+	// set up the new scope
+	var announcer Announcer
+	announcer, s.undo = AnnounceScope(s.announcer)
+	// use the new scope to announce our name
+	announcer.Announce(name)
+}
+
+func ExampleAnnounceScope_scoped() {
+	scoped := &Scoped{announcer: New("test")}
+
+	// set up the first scope
+	scoped.Reset("a")
+
+	// some time later, set up a new scope
+	scoped.Reset("b")
+}

--- a/pkg/node/announce_test.go
+++ b/pkg/node/announce_test.go
@@ -9,6 +9,20 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func ExampleAnnounceScope() {
+	rootAnnouncer := New("test")
+
+	announcer, undo := AnnounceScope(rootAnnouncer)
+	// announce names in the new scope
+	announcer.Announce("a")
+
+	// undo must be called in the same goroutine as the new scope,
+	// ideally just before the new scope is created.
+	undo()
+	announcer, undo = AnnounceScope(rootAnnouncer)
+	announcer.Announce("b")
+}
+
 func TestAnnounceScope(t *testing.T) {
 	var names []string
 	var m sync.Mutex


### PR DESCRIPTION
We found it was being used incorrectly, hopefully this will help.