### PR TITLE
auto/lights: hope to make the test more reliable

### DIFF
--- a/pkg/auto/lights/auto.go
+++ b/pkg/auto/lights/auto.go
@@ -239,16 +239,16 @@ func (b *BrightnessAutomation) processStateChanges(ctx context.Context, readStat
 			retryReason = "ttl"
 		}
 
-		if b.processComplete != nil {
-			b.processComplete(ttl, err, readState, writeState) // used only for testing
-		}
-
 		// Setup ttl for the transformed model.
 		// After this time it should be recalculated.
 		retry, cancelRetry = b.newTimer(ttl)
 
 		// log side effects and why they were made
 		logProcessComplete(b.logger, readState, writeState, actionCounts, duration, ttl, err)
+
+		if b.processComplete != nil {
+			b.processComplete(ttl, err, readState, writeState) // used only for testing
+		}
 
 		return nil
 	}

--- a/pkg/auto/lights/auto_test.go
+++ b/pkg/auto/lights/auto_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
 
 	"go.uber.org/zap"
-	"golang.org/x/exp/rand"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/smart-core-os/sc-api/go/traits"
@@ -37,8 +36,8 @@ func TestPirsTurnLightsOn(t *testing.T) {
 
 	loggerConfig := zap.NewDevelopmentConfig()
 	loggerConfig.DisableStacktrace = true
-	logger, _ := loggerConfig.Build()                                          // the test is sometimes failing, this might help with debugging
-	logger = logger.Named(fmt.Sprintf("%x", math.Float64bits(rand.Float64()))) // helps with --count>1 tests
+	logger, _ := loggerConfig.Build()                       // the test is sometimes failing, this might help with debugging
+	logger = logger.Named(fmt.Sprintf("%x", rand.Uint64())) // helps with --count>1 tests
 	automation := PirsTurnLightsOn(rootNode, logger)
 	automation.makeActions = func(_ node.ClientConner) actions { return testActions }
 	automation.autoStartTime = clock.now

--- a/pkg/auto/lights/logic_test.go
+++ b/pkg/auto/lights/logic_test.go
@@ -1026,6 +1026,12 @@ func (ta *testActions) assertNextCall(req any) {
 	}
 }
 
+func (ta *testActions) nextCallReturnsError(err error) {
+	ta.m.Lock()
+	defer ta.m.Unlock()
+	ta.err = err
+}
+
 func (ta *testActions) UpdateBrightness(ctx context.Context, now time.Time, req *traits.UpdateBrightnessRequest, state *WriteState) error {
 	ta.m.Lock()
 	defer ta.m.Unlock()


### PR DESCRIPTION
This includes a bunch of changes that might help us diagnose flaky tests:

1. Increase the timeout for state changes by an order of magnitude
2. Replace use of emitter with a blocking call to reduce async-iness
3. Hold a lock when signalling the next call should return an error
4. Turn on logging for when the above inevitably fails to fix the issue