### PR TITLE
ui/ops: format airQualityCard values to 1 decimal point

### DIFF
--- a/ui/ops/src/traits/airQuality/AirQualityCard.vue
+++ b/ui/ops/src/traits/airQuality/AirQualityCard.vue
@@ -9,7 +9,7 @@
       <v-list-item v-for="(val, key) of presentMetrics" :key="key" class="py-1">
         <v-list-item-title class="text-body-small">{{ key }}</v-list-item-title>
         <template #append>
-          <v-list-item-subtitle class="font-weight-medium text-body-1">{{ val.value }}</v-list-item-subtitle>
+          <v-list-item-subtitle class="font-weight-medium text-body-1">{{ intlNumbers.format(val.value ?? 0) }}</v-list-item-subtitle>
         </template>
       </v-list-item>
     </v-list>
@@ -42,6 +42,8 @@ const props = defineProps({
     required: true
   }
 });
+
+const intlNumbers = new Intl.NumberFormat();
 
 const {score, presentMetrics} = useAirQuality(() => props.value);
 const scoreColor = useStatusColor(score);


### PR DESCRIPTION
Small change to fix a numerical text overflow problem:

Before:
![Screenshot 2025-06-13 at 11 47 02](https://github.com/user-attachments/assets/92de0742-cb91-4290-a160-836a14839e47)


After:
![Screenshot 2025-06-13 at 11 46 12](https://github.com/user-attachments/assets/b9fefce4-dcce-444e-867d-3c183b738351)

