### PR TITLE
auth/policy: return Unauthenticated instead of PermissionDenied when no valid cert or token is found

### DIFF
--- a/pkg/auth/policy/interceptor_test.go
+++ b/pkg/auth/policy/interceptor_test.go
@@ -66,8 +66,8 @@ func TestInterceptor_GRPC(t *testing.T) {
 	if err == nil {
 		t.Error("expected error")
 	}
-	if c := status.Code(err); c != codes.PermissionDenied {
-		t.Errorf("expected PermissionDenied, got %v", err)
+	if c := status.Code(err); c != codes.Unauthenticated {
+		t.Errorf("expected Unauthenticated, got %v", err)
 	}
 
 	// check action based auth, specific to this trait
@@ -79,8 +79,8 @@ func TestInterceptor_GRPC(t *testing.T) {
 	if err == nil {
 		t.Error("expected error")
 	}
-	if c := status.Code(err); c != codes.PermissionDenied {
-		t.Errorf("expected PermissionDenied, got %v", err)
+	if c := status.Code(err); c != codes.Unauthenticated {
+		t.Errorf("expected Unauthenticated, got %v", err)
 	}
 }
 
@@ -117,7 +117,7 @@ func TestInterceptor_HTTP(t *testing.T) {
 	check(http.MethodGet, "/bar", http.StatusOK)
 	// POST requests are only allowed for /foo
 	check(http.MethodPost, "/foo", http.StatusOK)
-	check(http.MethodPost, "/bar", http.StatusForbidden)
+	check(http.MethodPost, "/bar", http.StatusUnauthorized)
 }
 
 var regoFiles = map[string]string{

--- a/pkg/auth/policy/policy_test.go
+++ b/pkg/auth/policy/policy_test.go
@@ -44,7 +44,7 @@ func TestValidate(t *testing.T) {
 				Protocol: ProtocolGRPC,
 				Service:  "foo.bar.baz",
 			},
-			expectErr: ErrPermissionDenied,
+			expectErr: ErrUnauthenticated,
 			expectQueries: []string{
 				"data.foo.bar.baz.allow",
 				"data.foo.bar.allow",
@@ -78,10 +78,40 @@ func TestValidate(t *testing.T) {
 				"data.foo.bar.allow":     deny,
 				"data.foo.allow":         allow,
 			},
-			expectErr: ErrPermissionDenied,
+			expectErr: ErrUnauthenticated,
 			expectQueries: []string{
 				"data.foo.bar.baz.allow",
 				"data.foo.bar.allow",
+			},
+		},
+		"PermissionDenied_token": {
+			attr: Attributes{
+				Protocol:     ProtocolGRPC,
+				Service:      "foo.bar.baz",
+				TokenPresent: true,
+				TokenValid:   true,
+			},
+			responses: map[string]rego.ResultSet{
+				"data.foo.bar.baz.allow": deny,
+			},
+			expectErr: ErrPermissionDenied,
+			expectQueries: []string{
+				"data.foo.bar.baz.allow",
+			},
+		},
+		"PermissionDenied_cert": {
+			attr: Attributes{
+				Protocol:           ProtocolGRPC,
+				Service:            "foo.bar.baz",
+				CertificatePresent: true,
+				CertificateValid:   true,
+			},
+			responses: map[string]rego.ResultSet{
+				"data.foo.bar.baz.allow": deny,
+			},
+			expectErr: ErrPermissionDenied,
+			expectQueries: []string{
+				"data.foo.bar.baz.allow",
 			},
 		},
 	}
@@ -129,7 +159,7 @@ func TestValidate_Integration(t *testing.T) {
 				Protocol: ProtocolGRPC,
 				Service:  "foo.bar",
 			},
-			expectErr: ErrPermissionDenied,
+			expectErr: ErrUnauthenticated,
 		},
 		"foo.baz": {
 			attr: Attributes{


### PR DESCRIPTION
This only happens after the policy has decided that the request is not allowed, giving the policy a chance to grant access to unauthenticated APIs.