### PR TITLE
pkg/task: explictly signal stop has been called due to slow mtx acquisition

### DIFF
--- a/pkg/task/poll_test.go
+++ b/pkg/task/poll_test.go
@@ -61,7 +61,7 @@ func TestPollErr(t *testing.T) {
 		runCount2 := runCount.Load()
 
 		time.Sleep(10 * time.Millisecond)
-		if delta := runCount.Load() - runCount2; delta > 1 {
+		if delta := runCount.Load() - runCount2; delta > 0 {
 			t.Errorf("expected no more runs, got %d extra", delta)
 		}
 	})


### PR DESCRIPTION
There is a possibility the ctx provided to Intermittent.Attach() is cancelled before the goroutine that is listening for this cancellation has acquired the mutex lock. This means for short-running tasks, the underlying poll func is called more times than expected.

See: https://github.com/vanti-dev/sc-bos/actions/runs/14968760102/job/42044643884#step:5:207
