### PR TITLE
fix/ui-build-warnings

### DIFF
--- a/ui/ops/src/dynamic/layout/LayoutGrid.vue
+++ b/ui/ops/src/dynamic/layout/LayoutGrid.vue
@@ -11,8 +11,9 @@
 </template>
 
 <script setup>
+import {defineAsyncComponent} from 'vue';
 import useSignage from '@/composables/signage.js';
-import PlaceholderCard from '@/dynamic/widgets/general/PlaceholderCard.vue';
+const PlaceholderCard = defineAsyncComponent(() => import('@/dynamic/widgets/general/PlaceholderCard.vue'));
 import {computed} from 'vue';
 
 const props = defineProps({

--- a/ui/ops/src/routes/auth/accounts/route.js
+++ b/ui/ops/src/routes/auth/accounts/route.js
@@ -4,7 +4,7 @@ export default [
     name: 'accounts',
     components: {
       default: () => import('./AccountsPage.vue'),
-      sidebar: () => import('./AccountsSidebar.vue')
+      sidebar: () => import('./AccountsSideBar.vue')
     },
     props: {
       default: true,

--- a/ui/ops/src/routes/ops/overview/pageConfig.js
+++ b/ui/ops/src/routes/ops/overview/pageConfig.js
@@ -1,11 +1,11 @@
 import {builtinLayouts} from '@/dynamic/layout/pallet.js';
-import PlaceholderCard from '@/dynamic/widgets/general/PlaceholderCard.vue';
+const PlaceholderCard = defineAsyncComponent(() => import('@/dynamic/widgets/general/PlaceholderCard.vue'));
 import {builtinWidgets} from '@/dynamic/widgets/pallet.js';
 import useBuildingConfig from '@/routes/ops/overview/pages/buildingConfig.js';
 import useDashPage from '@/routes/ops/overview/pages/dashPage.js';
 import {useUiConfigStore} from '@/stores/uiConfig.js';
 import {findActiveItem} from '@/util/router.js';
-import {computed, markRaw, reactive, toValue} from 'vue';
+import {computed, defineAsyncComponent, markRaw, reactive, toValue} from 'vue';
 
 /**
  * @param {MaybeRefOrGetter<string|string[]>} path - uri decoded path to the page


### PR DESCRIPTION
2 commits which fix 2 separate things:

- make imports of PlaceholderCard.vue dynamic to remove `yarn build` warnings
- fix casing of `AccountsSideBar` import which was breaking on certain systems