### PR TITLE
ui/ops: consistently format electrical and meter usage

### DIFF
--- a/ui/ops/src/traits/electricDemand/ElectricDemandCell.vue
+++ b/ui/ops/src/traits/electricDemand/ElectricDemandCell.vue
@@ -16,6 +16,7 @@
 <script setup>
 import StatusAlert from '@/components/StatusAlert.vue';
 import {useElectricDemand} from '@/traits/electricDemand/electric.js';
+import {format} from '@/util/number.js';
 import {computed} from 'vue';
 
 const props = defineProps({
@@ -35,10 +36,7 @@ const props = defineProps({
 });
 
 const {realPower, realPowerUnit} = useElectricDemand(() => props.value);
-const powerUseStr = computed(() => {
-  if (!realPower.value) return '';
-  return `${realPower.value.toFixed(2)}${realPowerUnit.value}`;
-});
+const powerUseStr = computed(() => format(realPower.value, realPowerUnit.value));
 </script>
 
 <style scoped>

--- a/ui/ops/src/traits/meter/meter.js
+++ b/ui/ops/src/traits/meter/meter.js
@@ -1,6 +1,7 @@
 import {timestampToDate} from '@/api/convpb.js';
 import {closeResource, newActionTracker, newResourceValue} from '@/api/resource';
 import {describeMeterReading, listMeterReadingHistory, pullMeterReading} from '@/api/sc/traits/meter';
+import {format} from '@/util/number.js';
 import {toQueryObject, watchResource} from '@/util/traits.js';
 import {isNullOrUndef} from '@/util/types.js';
 import {computed, effectScope, onScopeDispose, reactive, ref, toRefs, toValue, watch} from 'vue';
@@ -78,15 +79,7 @@ export function useDescribeMeterReading(query) {
  * @return {string}
  */
 export function usageToString(usage, unit = '') {
-  const usageStr = (() => {
-    if (isNullOrUndef(usage)) return '-';
-    if (Math.abs(usage) < 100) return usage.toPrecision(2);
-    return usage.toLocaleString(undefined, {maximumFractionDigits: 0});
-  })();
-  if (unit) {
-    return `${usageStr} ${unit}`;
-  }
-  return usageStr;
+  return format(usage, unit)
 }
 
 /**

--- a/ui/ops/src/util/number.js
+++ b/ui/ops/src/util/number.js
@@ -1,3 +1,5 @@
+import {isNullOrUndef} from '@/util/types.js';
+
 export const MAX_INT32 = 2147483647; // 2^31 - 1
 
 /**
@@ -44,4 +46,33 @@ export function roundTo(num, decimals) {
 
   const factor = Math.pow(10, decimals);
   return Math.round(num * factor) / factor;
+}
+
+/**
+ * Returns a string representation of a number, formatted for display.
+ *
+ * @example
+ * format(1234.5678) // "1,235"
+ * format(0)         // "0"
+ * format(null)      // "-"
+ * format(0.0123)    // "0.012"
+ * format(0.000123)  // "~0"
+ *
+ * @param {number|null|undefined} num
+ * @param {string} [unit]
+ * @return {string}
+ */
+export function format(num, unit = '') {
+  const usageStr = (() => {
+    if (isNullOrUndef(num)) return '-';
+    if (num === 0) return '0';
+    if (Math.abs(num) < 0.001) return '~0'
+    if (Math.abs(num) < 0.01) return num.toPrecision(1);
+    if (Math.abs(num) < 100) return num.toPrecision(2);
+    return num.toLocaleString(undefined, {maximumFractionDigits: 0});
+  })();
+  if (unit) {
+    return `${usageStr} ${unit}`;
+  }
+  return usageStr;
 }


### PR DESCRIPTION
Fixes an issue where small values would show as `-0.00`, now they show as `~0`