### PR TITLE
ui/ops/ops: support child-only dashboard pages

### DIFF
--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -601,111 +601,166 @@
           ]
         },
         {
-          "title": "Energy",
-          "icon": "mdi-flash",
-          "layout": "builtin:LayoutMainSide",
-          "path": "energy",
-          "mainWidgetMinHeight": 0,
-          "sideWidth": 420,
-          "main": [
+          "title": "Subsystems",
+          "icon": "mdi-shape",
+          "path": "subsystems",
+          "children": [
             {
-              "component": "builtin:meter/MeterHistoryCard",
-              "props": {
-                "title": "Electricity Usage",
-                "totalConsumptionName": "van/uk/brum/ugs/zones/building",
-                "totalProductionName": "van/uk/brum/ugs/zones/building/generated",
-                "subConsumptionNames": [
-                  "van/uk/brum/ugs/zones/floors/ground",
-                  "van/uk/brum/ugs/zones/floors/basement"
-                ]
-              }
+              "title": "Energy",
+              "icon": "mdi-flash",
+              "layout": "builtin:LayoutMainSide",
+              "path": "energy",
+              "mainWidgetMinHeight": 0,
+              "sideWidth": 420,
+              "main": [
+                {
+                  "component": "builtin:meter/MeterHistoryCard",
+                  "props": {
+                    "title": "Electricity Usage",
+                    "totalConsumptionName": "van/uk/brum/ugs/zones/building",
+                    "totalProductionName": "van/uk/brum/ugs/zones/building/generated",
+                    "subConsumptionNames": [
+                      "van/uk/brum/ugs/zones/floors/ground",
+                      "van/uk/brum/ugs/zones/floors/basement"
+                    ]
+                  }
+                },
+                {
+                  "component": "builtin:power-history/PowerHistoryCard",
+                  "props": {
+                    "demand": "van/uk/brum/ugs/zones/building",
+                    "generated": "van/uk/brum/ugs/zones/building/generated",
+                    "occupancy": "van/uk/brum/ugs/zones/building"
+                  }
+                }
+              ],
+              "after": [
+                {
+                  "component": "builtin:container/FlexRow",
+                  "props": {
+                    "itemMinWidth": "14em",
+                    "title": "Total Today",
+                    "items": [
+                      {
+                        "component": "builtin:meter/ConsumptionCard",
+                        "props": {
+                          "name": "van/uk/brum/ugs/zones/building",
+                          "period": "day",
+                          "title": "Consumed"
+                        }
+                      },
+                      {
+                        "component": "builtin:meter/ConsumptionCard",
+                        "props": {
+                          "name": "van/uk/brum/ugs/zones/building/generated",
+                          "period": "day",
+                          "title": "Produced"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "component": "builtin:container/FlexRow",
+                  "props": {
+                    "itemMinWidth": "14em",
+                    "title": "Total Month",
+                    "items": [
+                      {
+                        "component": "builtin:meter/ConsumptionCard",
+                        "props": {
+                          "name": "van/uk/brum/ugs/zones/building",
+                          "period": "month",
+                          "title": "Consumed"
+                        }
+                      },
+                      {
+                        "component": "builtin:meter/ConsumptionCard",
+                        "props": {
+                          "name": "van/uk/brum/ugs/zones/building/generated",
+                          "period": "month",
+                          "title": "Produced"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "component": "builtin:container/FlexRow",
+                  "props": {
+                    "itemMinWidth": "14em",
+                    "title": "Last Month",
+                    "items": [
+                      {
+                        "component": "builtin:meter/ConsumptionCard",
+                        "props": {
+                          "name": "van/uk/brum/ugs/zones/building",
+                          "period": "month",
+                          "offset": 1,
+                          "title": "Consumed"
+                        }
+                      },
+                      {
+                        "component": "builtin:meter/ConsumptionCard",
+                        "props": {
+                          "name": "van/uk/brum/ugs/zones/building/generated",
+                          "period": "month",
+                          "offset": 1,
+                          "title": "Produced"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
             },
             {
-              "component": "builtin:power-history/PowerHistoryCard",
-              "props": {
-                "demand": "van/uk/brum/ugs/zones/building",
-                "generated": "van/uk/brum/ugs/zones/building/generated",
-                "occupancy": "van/uk/brum/ugs/zones/building"
-              }
-            }
-          ],
-          "after": [
-            {
-              "component": "builtin:container/FlexRow",
-              "props": {
-                "itemMinWidth": "14em",
-                "title": "Total Today",
-                "items": [
-                  {
-                    "component": "builtin:meter/ConsumptionCard",
-                    "props": {
-                      "name": "van/uk/brum/ugs/zones/building",
-                      "period": "day",
-                      "title": "Consumed"
-                    }
-                  },
-                  {
-                    "component": "builtin:meter/ConsumptionCard",
-                    "props": {
-                      "name": "van/uk/brum/ugs/zones/building/generated",
-                      "period": "day",
-                      "title": "Produced"
-                    }
+              "title": "Water",
+              "icon": "mdi-water",
+              "layout": "builtin:LayoutMainSide",
+              "path": "water",
+              "mainWidgetMinHeight": 0,
+              "sideWidth": 420,
+              "main": [
+                {
+                  "component": "builtin:meter/MeterHistoryCard",
+                  "props": {
+                    "title": "Water Usage",
+                    "totalConsumptionName": "van/uk/brum/ugs/zones/building/water",
+                    "subConsumptionNames": [
+                      "van/uk/brum/ugs/devices/WMT-L00-01",
+                      "van/uk/brum/ugs/devices/WMT-L00-02"
+                    ]
                   }
-                ]
-              }
-            },
-            {
-              "component": "builtin:container/FlexRow",
-              "props": {
-                "itemMinWidth": "14em",
-                "title": "Total Month",
-                "items": [
-                  {
-                    "component": "builtin:meter/ConsumptionCard",
-                    "props": {
-                      "name": "van/uk/brum/ugs/zones/building",
-                      "period": "month",
-                      "title": "Consumed"
-                    }
-                  },
-                  {
-                    "component": "builtin:meter/ConsumptionCard",
-                    "props": {
-                      "name": "van/uk/brum/ugs/zones/building/generated",
-                      "period": "month",
-                      "title": "Produced"
-                    }
+                }
+              ],
+              "after": [
+                {
+                  "component": "builtin:container/FlexRow",
+                  "props": {
+                    "itemMinWidth": "14em",
+                    "title": "Total Today",
+                    "items": [
+                      {
+                        "component": "builtin:meter/ConsumptionCard",
+                        "props": {
+                          "name": "van/uk/brum/ugs/devices/WMT-L00-01",
+                          "period": "day",
+                          "title": "Meter 1"
+                        }
+                      },
+                      {
+                        "component": "builtin:meter/ConsumptionCard",
+                        "props": {
+                          "name": "van/uk/brum/ugs/devices/WMT-L00-02",
+                          "period": "day",
+                          "title": "Meter 2"
+                        }
+                      }
+                    ]
                   }
-                ]
-              }
-            },
-            {
-              "component": "builtin:container/FlexRow",
-              "props": {
-                "itemMinWidth": "14em",
-                "title": "Last Month",
-                "items": [
-                  {
-                    "component": "builtin:meter/ConsumptionCard",
-                    "props": {
-                      "name": "van/uk/brum/ugs/zones/building",
-                      "period": "month",
-                      "offset": 1,
-                      "title": "Consumed"
-                    }
-                  },
-                  {
-                    "component": "builtin:meter/ConsumptionCard",
-                    "props": {
-                      "name": "van/uk/brum/ugs/zones/building/generated",
-                      "period": "month",
-                      "offset": 1,
-                      "title": "Produced"
-                    }
-                  }
-                ]
-              }
+                }
+              ]
             }
           ]
         },
@@ -886,54 +941,6 @@
                 "hideHeaderActions": true,
                 "columns": ["createTime", "severity", "source", "description"],
                 "fixedRowCount": 5
-              }
-            }
-          ]
-        },
-        {
-          "title": "Water",
-          "icon": "mdi-water",
-          "layout": "builtin:LayoutMainSide",
-          "path": "water",
-          "mainWidgetMinHeight": 0,
-          "sideWidth": 420,
-          "main": [
-            {
-              "component": "builtin:meter/MeterHistoryCard",
-              "props": {
-                "title": "Water Usage",
-                "totalConsumptionName": "van/uk/brum/ugs/zones/building/water",
-                "subConsumptionNames": [
-                  "van/uk/brum/ugs/devices/WMT-L00-01",
-                  "van/uk/brum/ugs/devices/WMT-L00-02"
-                ]
-              }
-            }
-          ],
-          "after": [
-            {
-              "component": "builtin:container/FlexRow",
-              "props": {
-                "itemMinWidth": "14em",
-                "title": "Total Today",
-                "items": [
-                  {
-                    "component": "builtin:meter/ConsumptionCard",
-                    "props": {
-                      "name": "van/uk/brum/ugs/devices/WMT-L00-01",
-                      "period": "day",
-                      "title": "Meter 1"
-                    }
-                  },
-                  {
-                    "component": "builtin:meter/ConsumptionCard",
-                    "props": {
-                      "name": "van/uk/brum/ugs/devices/WMT-L00-02",
-                      "period": "day",
-                      "title": "Meter 2"
-                    }
-                  }
-                ]
               }
             }
           ]

--- a/ui/ops/src/routes/ops/overview/OpsNavListItem.vue
+++ b/ui/ops/src/routes/ops/overview/OpsNavListItem.vue
@@ -1,26 +1,54 @@
 <template>
   <v-list-group v-if="hasChildren" :value="props.item.title">
     <template #activator="{props: _props, isOpen: _isOpen}">
-      <v-list-item
-          :to="toAreaLink"
-          :active="active"
-          :class="{activeExact}">
-        <template #prepend>
-          <v-icon v-if="!props.miniVariant || !props.item.shortTitle">{{ props.item.icon }}</v-icon>
-          <v-list-item-title v-else class="v-icon text-center text-truncate" style="width: 24px">
-            {{ props.item.shortTitle }}
-          </v-list-item-title>
-        </template>
-        <v-list-item-title>{{ props.item.title }}</v-list-item-title>
-        <template #append>
-          <v-btn
-              @click.prevent.stop="_props.onClick"
-              variant="text"
-              size="x-small"
-              style="font-size: 120%"
-              :icon="_isOpen ? 'mdi-chevron-down' : 'mdi-chevron-left'"/>
-        </template>
-      </v-list-item>
+      <!--
+      Slightly different behaviour for containers that have their own pages, vs those that don't.
+      The first we expand on button click only, clicking the activator navs to the page.
+      The second we expand on activator click, the button is just there for visual consistency.
+      -->
+      <template v-if="props.item.layout">
+        <v-list-item
+            :to="toAreaLink"
+            :active="active"
+            :class="{activeExact}">
+          <template #prepend>
+            <v-icon v-if="!props.miniVariant || !props.item.shortTitle">{{ props.item.icon }}</v-icon>
+            <v-list-item-title v-else class="v-icon text-center text-truncate" style="width: 24px">
+              {{ props.item.shortTitle }}
+            </v-list-item-title>
+          </template>
+          <v-list-item-title>{{ props.item.title }}</v-list-item-title>
+          <template #append>
+            <v-btn
+                @click.prevent.stop="_props.onClick"
+                variant="text"
+                size="x-small"
+                style="font-size: 120%"
+                :icon="_isOpen ? 'mdi-chevron-down' : 'mdi-chevron-left'"/>
+          </template>
+        </v-list-item>
+      </template>
+      <template v-else>
+        <v-list-item
+            @click.prevent.stop="_props.onClick"
+            :active="active"
+            :class="{activeExact}">
+          <template #prepend>
+            <v-icon v-if="!props.miniVariant || !props.item.shortTitle">{{ props.item.icon }}</v-icon>
+            <v-list-item-title v-else class="v-icon text-center text-truncate" style="width: 24px">
+              {{ props.item.shortTitle }}
+            </v-list-item-title>
+          </template>
+          <v-list-item-title>{{ props.item.title }}</v-list-item-title>
+          <template #append>
+            <v-btn
+                variant="text"
+                size="x-small"
+                style="font-size: 120%"
+                :icon="_isOpen ? 'mdi-chevron-down' : 'mdi-chevron-left'"/>
+          </template>
+        </v-list-item>
+      </template>
     </template>
     <ops-nav-list-items
         :items="props.item.children"


### PR DESCRIPTION
For any page that is configured with children but no layout of itself, configure the nav to treat this as a non-navigable page. This means clicking on the nav item will not navigate, but will instead directly expand the child items.

Fixes SC-1087

![image](https://github.com/user-attachments/assets/88d7d970-a369-42c0-8b53-4fae60e6f8dc)

The UGS example has been updated to group the energy and water pages like this.