### PR TITLE
auth/policy: fix fail-after-complete race error

### DIFF
--- a/pkg/auth/policy/interceptor_test.go
+++ b/pkg/auth/policy/interceptor_test.go
@@ -33,7 +33,7 @@ func TestInterceptor_GRPC(t *testing.T) {
 	traits.RegisterOnOffApiServer(server, onoffpb.NewModelServer(onoffpb.NewModel()))
 	go func() {
 		if err := server.Serve(lis); err != nil {
-			t.Errorf("server stopped with error: %v", err)
+			t.Logf("server stopped with error: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
Calling T.Fail (or related utils) after the test has completed races with the test going into ignore-fails mode. The easiest way to fix this is to log instead of failing in this non-test case.

Fixes SC-1137