### PR TITLE
ui/ops/ops: make all ops pages configurable via pages config

### DIFF
--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -782,180 +782,187 @@
           "title": "Dashboards",
           "icon": "mdi-view-dashboard",
           "path": "dashboards",
-          "layout": "builtin:LayoutGrid",
-          "cells": [
+          "children": [
             {
-              "loc": {"x": 1, "y": 1, "w": 3, "h": 3},
-              "id": "CurrentAirQuality",
-              "component": "builtin:environmental/AirQualityCard",
-              "props": {
-                "title": "Building Air Quality",
-                "name": "van/uk/brum/ugs/zones/building"
-              }
-            },
-            {
-              "loc": {"x": 4, "y": 1, "w": 3, "h": 3},
-              "id": "AirQualityHistory",
-              "component": "builtin:environmental/AirQualityHistoryCard",
-              "props": {
-                "title": "Weekly Air Quality",
-                "source": "van/uk/brum/ugs/zones/building",
-                "metric": "score",
-                "start": "day-7",
-                "end": "day-1"
-              }
-            },
-            {
-              "loc": {"x": 1, "y": 4, "w": 2, "h": 3},
-              "id": "CurrentPowerUse",
-              "component": "builtin:energy/PowerCompareCard",
-              "props": {
-                "title": "System Power Use",
-                "sources": [
-                  "van/uk/brum/ugs/zones/areas/comms-room",
-                  "van/uk/brum/ugs/zones/areas/lab",
-                  "van/uk/brum/ugs/zones/floors/ground",
-                  "van/uk/brum/ugs/zones/floors/basement"
-                ]
-              }
-            },
-            {
-              "loc": {"x": 3, "y": 4, "w": 4, "h": 3},
-              "id": "EnergyHistory",
-              "component": "builtin:meter/MeterHistoryCard",
-              "props": {
-                "title": "Weekly Energy Use",
-                "totalConsumptionName": "van/uk/brum/ugs/zones/building",
-                "totalProductionName": "van/uk/brum/ugs/zones/building/generated",
-                "start": "day-7",
-                "end": "day-1",
-                "minChartHeight": "100%",
-                "density": "compact"
-              }
-            },
-            {
-              "loc": {"x": 1, "y": 7, "w": 4, "h": 2},
-              "id": "PeopleCountHistory",
-              "component": "builtin:occupancy/PeopleCountHistoryChart",
-              "props": {
-                "totalOccupancyName": "van/uk/brum/ugs/zones/building",
-                "start": "day-7",
-                "end": "day-1"
-              }
-            },
-            {
-              "loc": {"x": 5, "y": 7, "w": 2, "h": 2},
-              "id": "CurrentPeopleCount",
-              "component": "builtin:occupancy/PeopleCountCard",
-              "props": {
-                "source": "van/uk/brum/ugs/zones/building",
-                "maxOccupancy": 1250
-              }
-            },
-            {
-              "loc": {"x": 1, "y": 9, "w": 4, "h": 4},
-              "id": "SecurityEvents",
-              "component": "builtin:security/SecurityEventsCard",
-              "props": {
-                "variant": "card",
-                "title": "Access Control Log",
-                "name": "van/uk/brum/ugs/devices/security-events",
-                "hideTableHeader": true,
-                "fixedRowCount": 5
-              }
-            },
-            {
-              "loc": {"x": 5, "y": 9, "w": 2, "h": 4},
-              "id": "Visitors",
-              "props": {
-                "title": "Visitors"
-              }
-            },
-            {
-              "loc": {"x": 7, "y": 1, "w": 2, "h": 1},
-              "id": "SCStatus",
-              "component": "builtin:general/CohortStatus",
-              "props": {
-                "size": "xx-large",
-                "class": "text-h4"
-              }
-            },
-            {
-              "loc": {"x": 9, "y": 1, "w": 2, "h": 1},
-              "id": "Weather",
-              "component": "builtin:general/OpenWeatherMap",
-              "props": {
-                "apiKey": "TODO",
-                "city": "Birmingham",
-                "hideToolbar": true,
-                "color": "transparent"
-              }
-            },
-            {
-              "loc": {"x": 11, "y": 1, "w": 2, "h": 1},
-              "id": "DateAndTime",
-              "component": "builtin:general/DateAndTime",
-              "props": {
-                "class": "text-h4"
-              }
-            },
-            {
-              "loc": {"x": 7, "y": 2, "w": 3, "h": 7},
-              "id": "FloorInfo",
-              "component": "builtin:building/FloorTraitCells",
-              "props": {
-                "floors": [
-                  {"level": 7},
-                  {"level": 6, "zoneName": "van/uk/brum/ugs/zones/rooms/bank"},
-                  {"level": 5, "zoneName": "van/uk/brum/ugs/zones/areas/loading-bay"},
-                  {"level": 4, "zoneName": "van/uk/brum/ugs/zones/areas/comms-room"},
-                  {"level": 3, "zoneName": "van/uk/brum/ugs/zones/areas/lab"},
-                  {"level": 2, "zoneName": "van/uk/brum/ugs/zones/areas/reception"},
-                  {"level": 1, "zoneName": "van/uk/brum/ugs/zones/floors/first"},
-                  {"level": 0, "zoneName": "van/uk/brum/ugs/zones/floors/ground"},
-                  {"level": -1, "zoneName": "van/uk/brum/ugs/zones/floors/basement"},
-                  {"level": -2}
-                ]
-              }
-            },
-            {
-              "loc": {"x": 10, "y": 2, "w": 1, "h": 7},
-              "id": "Floors",
-              "component": "builtin:building/BuildingFloors",
-              "props": {
-                "floors": [
-                  {"level": 7, "title": "Roof"},
-                  {"level": 6, "title": "Floor 6"},
-                  {"level": 5, "title": "Floor 5"},
-                  {"level": 4, "title": "Floor 4"},
-                  {"level": 3, "title": "Floor 3"},
-                  {"level": 2, "title": "Floor 2"},
-                  {"level": 1, "title": "Floor 1"},
-                  {"level": 0, "title": "Ground Floor"},
-                  {"level": -1, "title": "Basement 1"},
-                  {"level": -2, "title": "Basement 2"}
-                ]
-              }
-            },
-            {
-              "loc": {"x": 11, "y": 2, "w": 2, "h": 7},
-              "id": "Lifts",
-              "props": {
-                "title": "Lifts"
-              }
-            },
-            {
-              "loc": {"x": 7, "y": 9, "w": 6, "h": 4},
-              "id": "Notifications",
-              "component": "builtin:notifications/ZoneNotifications",
-              "props": {
-                "title": "Device Notifications",
-                "hidePaging": true,
-                "hideTableHeader": true,
-                "hideHeaderActions": true,
-                "columns": ["createTime", "severity", "source", "description"],
-                "fixedRowCount": 5
-              }
+              "title": "FM Dashboard",
+              "shortTitle": "FM",
+              "path": "fm",
+              "layout": "builtin:LayoutGrid",
+              "cells": [
+                {
+                  "loc": {"x": 1, "y": 1, "w": 3, "h": 3},
+                  "id": "CurrentAirQuality",
+                  "component": "builtin:environmental/AirQualityCard",
+                  "props": {
+                    "title": "Building Air Quality",
+                    "name": "van/uk/brum/ugs/zones/building"
+                  }
+                },
+                {
+                  "loc": {"x": 4, "y": 1, "w": 3, "h": 3},
+                  "id": "AirQualityHistory",
+                  "component": "builtin:environmental/AirQualityHistoryCard",
+                  "props": {
+                    "title": "Weekly Air Quality",
+                    "source": "van/uk/brum/ugs/zones/building",
+                    "metric": "score",
+                    "start": "day-7",
+                    "end": "day-1"
+                  }
+                },
+                {
+                  "loc": {"x": 1, "y": 4, "w": 2, "h": 3},
+                  "id": "CurrentPowerUse",
+                  "component": "builtin:energy/PowerCompareCard",
+                  "props": {
+                    "title": "System Power Use",
+                    "sources": [
+                      "van/uk/brum/ugs/zones/areas/comms-room",
+                      "van/uk/brum/ugs/zones/areas/lab",
+                      "van/uk/brum/ugs/zones/floors/ground",
+                      "van/uk/brum/ugs/zones/floors/basement"
+                    ]
+                  }
+                },
+                {
+                  "loc": {"x": 3, "y": 4, "w": 4, "h": 3},
+                  "id": "EnergyHistory",
+                  "component": "builtin:meter/MeterHistoryCard",
+                  "props": {
+                    "title": "Weekly Energy Use",
+                    "totalConsumptionName": "van/uk/brum/ugs/zones/building",
+                    "totalProductionName": "van/uk/brum/ugs/zones/building/generated",
+                    "start": "day-7",
+                    "end": "day-1",
+                    "minChartHeight": "100%",
+                    "density": "compact"
+                  }
+                },
+                {
+                  "loc": {"x": 1, "y": 7, "w": 4, "h": 2},
+                  "id": "PeopleCountHistory",
+                  "component": "builtin:occupancy/PeopleCountHistoryChart",
+                  "props": {
+                    "totalOccupancyName": "van/uk/brum/ugs/zones/building",
+                    "start": "day-7",
+                    "end": "day-1"
+                  }
+                },
+                {
+                  "loc": {"x": 5, "y": 7, "w": 2, "h": 2},
+                  "id": "CurrentPeopleCount",
+                  "component": "builtin:occupancy/PeopleCountCard",
+                  "props": {
+                    "source": "van/uk/brum/ugs/zones/building",
+                    "maxOccupancy": 1250
+                  }
+                },
+                {
+                  "loc": {"x": 1, "y": 9, "w": 4, "h": 4},
+                  "id": "SecurityEvents",
+                  "component": "builtin:security/SecurityEventsCard",
+                  "props": {
+                    "variant": "card",
+                    "title": "Access Control Log",
+                    "name": "van/uk/brum/ugs/devices/security-events",
+                    "hideTableHeader": true,
+                    "fixedRowCount": 5
+                  }
+                },
+                {
+                  "loc": {"x": 5, "y": 9, "w": 2, "h": 4},
+                  "id": "Visitors",
+                  "props": {
+                    "title": "Visitors"
+                  }
+                },
+                {
+                  "loc": {"x": 7, "y": 1, "w": 2, "h": 1},
+                  "id": "SCStatus",
+                  "component": "builtin:general/CohortStatus",
+                  "props": {
+                    "size": "xx-large",
+                    "class": "text-h4"
+                  }
+                },
+                {
+                  "loc": {"x": 9, "y": 1, "w": 2, "h": 1},
+                  "id": "Weather",
+                  "component": "builtin:general/OpenWeatherMap",
+                  "props": {
+                    "apiKey": "TODO",
+                    "city": "Birmingham",
+                    "hideToolbar": true,
+                    "color": "transparent"
+                  }
+                },
+                {
+                  "loc": {"x": 11, "y": 1, "w": 2, "h": 1},
+                  "id": "DateAndTime",
+                  "component": "builtin:general/DateAndTime",
+                  "props": {
+                    "class": "text-h4"
+                  }
+                },
+                {
+                  "loc": {"x": 7, "y": 2, "w": 3, "h": 7},
+                  "id": "FloorInfo",
+                  "component": "builtin:building/FloorTraitCells",
+                  "props": {
+                    "floors": [
+                      {"level": 7},
+                      {"level": 6, "zoneName": "van/uk/brum/ugs/zones/rooms/bank"},
+                      {"level": 5, "zoneName": "van/uk/brum/ugs/zones/areas/loading-bay"},
+                      {"level": 4, "zoneName": "van/uk/brum/ugs/zones/areas/comms-room"},
+                      {"level": 3, "zoneName": "van/uk/brum/ugs/zones/areas/lab"},
+                      {"level": 2, "zoneName": "van/uk/brum/ugs/zones/areas/reception"},
+                      {"level": 1, "zoneName": "van/uk/brum/ugs/zones/floors/first"},
+                      {"level": 0, "zoneName": "van/uk/brum/ugs/zones/floors/ground"},
+                      {"level": -1, "zoneName": "van/uk/brum/ugs/zones/floors/basement"},
+                      {"level": -2}
+                    ]
+                  }
+                },
+                {
+                  "loc": {"x": 10, "y": 2, "w": 1, "h": 7},
+                  "id": "Floors",
+                  "component": "builtin:building/BuildingFloors",
+                  "props": {
+                    "floors": [
+                      {"level": 7, "title": "Roof"},
+                      {"level": 6, "title": "Floor 6"},
+                      {"level": 5, "title": "Floor 5"},
+                      {"level": 4, "title": "Floor 4"},
+                      {"level": 3, "title": "Floor 3"},
+                      {"level": 2, "title": "Floor 2"},
+                      {"level": 1, "title": "Floor 1"},
+                      {"level": 0, "title": "Ground Floor"},
+                      {"level": -1, "title": "Basement 1"},
+                      {"level": -2, "title": "Basement 2"}
+                    ]
+                  }
+                },
+                {
+                  "loc": {"x": 11, "y": 2, "w": 2, "h": 7},
+                  "id": "Lifts",
+                  "props": {
+                    "title": "Lifts"
+                  }
+                },
+                {
+                  "loc": {"x": 7, "y": 9, "w": 6, "h": 4},
+                  "id": "Notifications",
+                  "component": "builtin:notifications/ZoneNotifications",
+                  "props": {
+                    "title": "Device Notifications",
+                    "hidePaging": true,
+                    "hideTableHeader": true,
+                    "hideHeaderActions": true,
+                    "columns": ["createTime", "severity", "source", "description"],
+                    "fixedRowCount": 5
+                  }
+                }
+              ]
             }
           ]
         }

--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -27,6 +27,7 @@
       }
     },
     "ops": {
+      "airQuality": false,
       "pages": [
         {
           "title": "Building Overview",
@@ -761,6 +762,12 @@
                   }
                 }
               ]
+            },
+            {
+              "title": "Air Quality",
+              "icon": "mdi-air-filter",
+              "path": "iaq",
+              "layout": "builtin:page/AirQuality"
             },
             {
               "title": "Security Events",

--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -29,6 +29,7 @@
     "ops": {
       "airQuality": false,
       "emergencyLighting": false,
+      "security": false,
       "pages": [
         {
           "title": "Building Overview",
@@ -775,6 +776,12 @@
               "icon": "mdi-alarm-light-outline",
               "path": "elt",
               "layout": "builtin:page/EmergencyLighting"
+            },
+            {
+              "title": "Security",
+              "icon": "mdi-shield-key",
+              "path": "security",
+              "layout": "builtin:page/Security"
             },
             {
               "title": "Security Events",

--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -28,6 +28,7 @@
     },
     "ops": {
       "airQuality": false,
+      "emergencyLighting": false,
       "pages": [
         {
           "title": "Building Overview",
@@ -768,6 +769,12 @@
               "icon": "mdi-air-filter",
               "path": "iaq",
               "layout": "builtin:page/AirQuality"
+            },
+            {
+              "title": "Emergency Lighting",
+              "icon": "mdi-alarm-light-outline",
+              "path": "elt",
+              "layout": "builtin:page/EmergencyLighting"
             },
             {
               "title": "Security Events",

--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -761,6 +761,20 @@
                   }
                 }
               ]
+            },
+            {
+              "title": "Security Events",
+              "icon": "mdi-shield-alert",
+              "path": "security-events",
+              "layout": "builtin:page/SecurityEvents",
+              "name": "van/uk/brum/ugs/devices/security-events"
+            },
+            {
+              "title": "Waste",
+              "icon": "mdi-recycle",
+              "path": "waste",
+              "layout": "builtin:page/Waste",
+              "source": "van/uk/brum/ugs/devices/waste"
             }
           ]
         },
@@ -945,13 +959,8 @@
             }
           ]
         }
-      ],
-      "waste" : {
-        "source" : "van/uk/brum/ugs/devices/waste",
-        "unit" : "kg"
-      }
+      ]
     },
-    "securityEventsSource": "van/uk/brum/ugs/devices/security-events",
     "proxy": true,
     "siteFloorPlans": [
       {"name": "Ground Floor", "svgPath": "./assets/floor0-bg.svg"},

--- a/ui/ops/src/dynamic/layout/pallet.js
+++ b/ui/ops/src/dynamic/layout/pallet.js
@@ -6,6 +6,7 @@ export const builtinLayouts = {
   // full pages, not widget containers
   'page/AirQuality': defineAsyncComponent(() => import('@/routes/ops/air-quality/AirQuality.vue')),
   'page/EmergencyLighting': defineAsyncComponent(() => import('@/routes/ops/emergency-lighting/EmergencyLighting.vue')),
+  'page/Security': defineAsyncComponent(() => import('@/routes/ops/security/SecurityHome.vue')),
   'page/SecurityEvents': defineAsyncComponent(() => import('@/routes/ops/security-events/SecurityEventsTable.vue')),
   'page/Waste': defineAsyncComponent(() => import('@/routes/ops/waste/WasteTable.vue'))
 };

--- a/ui/ops/src/dynamic/layout/pallet.js
+++ b/ui/ops/src/dynamic/layout/pallet.js
@@ -4,6 +4,7 @@ export const builtinLayouts = {
   'LayoutMainSide': defineAsyncComponent(() => import('@/dynamic/layout/LayoutMainSide.vue')),
   'LayoutGrid': defineAsyncComponent(() => import('@/dynamic/layout/LayoutGrid.vue')),
   // full pages, not widget containers
+  'page/AirQuality': defineAsyncComponent(() => import('@/routes/ops/air-quality/AirQuality.vue')),
   'page/SecurityEvents': defineAsyncComponent(() => import('@/routes/ops/security-events/SecurityEventsTable.vue')),
   'page/Waste': defineAsyncComponent(() => import('@/routes/ops/waste/WasteTable.vue'))
 };

--- a/ui/ops/src/dynamic/layout/pallet.js
+++ b/ui/ops/src/dynamic/layout/pallet.js
@@ -3,4 +3,6 @@ import {defineAsyncComponent} from 'vue';
 export const builtinLayouts = {
   'LayoutMainSide': defineAsyncComponent(() => import('@/dynamic/layout/LayoutMainSide.vue')),
   'LayoutGrid': defineAsyncComponent(() => import('@/dynamic/layout/LayoutGrid.vue')),
+  // full pages, not widget containers
+  'page/Waste': defineAsyncComponent(() => import('@/routes/ops/waste/WasteTable.vue'))
 };

--- a/ui/ops/src/dynamic/layout/pallet.js
+++ b/ui/ops/src/dynamic/layout/pallet.js
@@ -5,6 +5,7 @@ export const builtinLayouts = {
   'LayoutGrid': defineAsyncComponent(() => import('@/dynamic/layout/LayoutGrid.vue')),
   // full pages, not widget containers
   'page/AirQuality': defineAsyncComponent(() => import('@/routes/ops/air-quality/AirQuality.vue')),
+  'page/EmergencyLighting': defineAsyncComponent(() => import('@/routes/ops/emergency-lighting/EmergencyLighting.vue')),
   'page/SecurityEvents': defineAsyncComponent(() => import('@/routes/ops/security-events/SecurityEventsTable.vue')),
   'page/Waste': defineAsyncComponent(() => import('@/routes/ops/waste/WasteTable.vue'))
 };

--- a/ui/ops/src/dynamic/layout/pallet.js
+++ b/ui/ops/src/dynamic/layout/pallet.js
@@ -4,5 +4,6 @@ export const builtinLayouts = {
   'LayoutMainSide': defineAsyncComponent(() => import('@/dynamic/layout/LayoutMainSide.vue')),
   'LayoutGrid': defineAsyncComponent(() => import('@/dynamic/layout/LayoutGrid.vue')),
   // full pages, not widget containers
+  'page/SecurityEvents': defineAsyncComponent(() => import('@/routes/ops/security-events/SecurityEventsTable.vue')),
   'page/Waste': defineAsyncComponent(() => import('@/routes/ops/waste/WasteTable.vue'))
 };

--- a/ui/ops/src/routes/ops/nav.js
+++ b/ui/ops/src/routes/ops/nav.js
@@ -45,13 +45,21 @@ export const navItems = [
     title: 'Security Events',
     icon: 'mdi-shield-alert',
     link: {path: '/ops/security-events'},
-    badgeType: null
+    badgeType: null,
+    enabled: () => {
+      const uiConfig = useUiConfigStore();
+      return uiConfig.pathEnabled('/ops/security-events') && uiConfig.config?.securityEventsSource;
+    }
   },
   {
     title: 'Waste Records',
     icon: 'mdi-recycle',
     link: {path: '/ops/waste'},
     badgeType: null,
+    enabled: () => {
+      const uiConfig = useUiConfigStore();
+      return uiConfig.pathEnabled('/ops/waste') && uiConfig.config?.ops?.waste;
+    }
   }
 ];
 

--- a/ui/ops/src/routes/ops/nav.js
+++ b/ui/ops/src/routes/ops/nav.js
@@ -27,7 +27,11 @@ export const navItems = [
     title: 'Air Quality',
     icon: 'mdi-air-filter',
     link: {path: '/ops/air-quality'},
-    badgeType: null
+    badgeType: null,
+    enabled: () => {
+      const uiConfig = useUiConfigStore();
+      return uiConfig.pathEnabled('/ops/air-quality') && (uiConfig.config?.ops?.airQuality ?? true);
+    }
   },
   {
     title: 'Emergency Lighting',

--- a/ui/ops/src/routes/ops/nav.js
+++ b/ui/ops/src/routes/ops/nav.js
@@ -47,7 +47,11 @@ export const navItems = [
     title: 'Security',
     icon: 'mdi-shield-key',
     link: {path: '/ops/security'},
-    badgeType: null
+    badgeType: null,
+    enabled: () => {
+      const uiConfig = useUiConfigStore();
+      return uiConfig.pathEnabled('/ops/security') && (uiConfig.config?.ops?.security ?? true);
+    }
   },
   {
     title: 'Security Events',

--- a/ui/ops/src/routes/ops/nav.js
+++ b/ui/ops/src/routes/ops/nav.js
@@ -37,7 +37,11 @@ export const navItems = [
     title: 'Emergency Lighting',
     icon: 'mdi-alarm-light-outline',
     link: {path: '/ops/emergency-lighting'},
-    badgeType: null
+    badgeType: null,
+    enabled: () => {
+      const uiConfig = useUiConfigStore();
+      return uiConfig.pathEnabled('/ops/emergency-lighting') && (uiConfig.config?.ops?.emergencyLighting ?? true);
+    }
   },
   {
     title: 'Security',

--- a/ui/ops/src/routes/ops/waste/WasteTable.vue
+++ b/ui/ops/src/routes/ops/waste/WasteTable.vue
@@ -16,13 +16,13 @@
           {{ timestampToDate(item.wasteCreateTime).toLocaleString() }}
         </template>
         <template #item.weight="{ item }">
-          {{ item.weight.toFixed(2) }} {{ uiConfig.config?.ops?.waste?.unit ?? "kg" }}
+          {{ item.weight.toFixed(2) }} {{ unit }}
         </template>
         <template #item.co2Saved="{ item }">
-          {{ item.co2Saved.toFixed(2) }} {{ uiConfig.config?.ops?.waste?.co2SavedUnit ?? "kg" }}
+          {{ item.co2Saved.toFixed(2) }} {{ co2SavedUnit }}
         </template>
         <template #item.landSaved="{ item }">
-          {{ item.landSaved.toFixed(2) }} {{ uiConfig.config?.ops?.waste?.landSavedUnit ?? "km²" }}
+          {{ item.landSaved.toFixed(2) }} {{ landSavedUnit }}
         </template>
         <template #item.treesSaved="{ item }">
           {{ item.treesSaved.toFixed(2) }}
@@ -44,9 +44,32 @@ import {useCohortStore} from '@/stores/cohort.js';
 import {useUiConfigStore} from '@/stores/uiConfig.js';
 import {computed, ref} from 'vue';
 
+const props = defineProps({
+  source: {
+    type: String,
+    default: ''
+  },
+  unit: {
+    type: String,
+    default: 'kg'
+  },
+  co2SavedUnit: {
+    type: String,
+    default: 'kg'
+  },
+  landSavedUnit: {
+    type: String,
+    default: 'km²'
+  }
+})
+
 const uiConfig = useUiConfigStore();
 const cohort = useCohortStore();
-const name = computed(() => uiConfig.config?.ops?.waste?.source ?? cohort.hubNode?.name ?? '');
+const name = computed(() => props.source || (uiConfig.config?.ops?.waste?.source ?? cohort.hubNode?.name ?? ''));
+
+const unit = computed(() => props.unit || uiConfig.config?.ops?.waste?.unit || 'kg');
+const co2SavedUnit = computed(() => props.co2SavedUnit || uiConfig.config?.ops?.waste?.co2SavedUnit || 'kg');
+const landSavedUnit = computed(() => props.landSavedUnit || uiConfig.config?.ops?.waste?.landSavedUnit || 'km²');
 
 const wasteRecordsRequest = computed(() => ({
   name: name.value


### PR DESCRIPTION
This PR allows static ops pages like security or air quality to be placed anywhere in the ops nav via the existing pages config.

The UGS example has been updated to place them into the subsystems container.

<img width="306" height="605" alt="image" src="https://github.com/user-attachments/assets/c8335df9-cafe-4a2f-8105-790183fc6748" />

There are now two ways to configure the inclusion of the static pages in the ops nav:

1. Use the `features` object to explicitly allow only the pages you want
2. _New_: Remove config for the static pages or add a `page: false` to the ops config object where no specific config is needed. See the UGS example for details.

The only page not configurable via this mechanism is the Notifications page because of the badge number. I'd like this to move into the main toolbar at some point so won't be configuring it here.