### PR TITLE
all: remove use of deprecated Node.Client

### DIFF
--- a/pkg/auto/export/source/bacnet.go
+++ b/pkg/auto/export/source/bacnet.go
@@ -32,10 +32,7 @@ type bacnet struct {
 }
 
 func (b *bacnet) applyConfig(ctx context.Context, cfg config.BacnetSource) error {
-	var bacnetDriverClient rpc.BacnetDriverServiceClient
-	if err := b.services.Node.Client(&bacnetDriverClient); err != nil {
-		return err
-	}
+	bacnetDriverClient := rpc.NewBacnetDriverServiceClient(b.services.Node.ClientConn())
 
 	delay := 5 * time.Second
 	if cfg.COV != nil && cfg.COV.PollDelay.Duration != 0 {

--- a/pkg/auto/export/source/mqtt.go
+++ b/pkg/auto/export/source/mqtt.go
@@ -31,11 +31,7 @@ type mqtt struct {
 func (m *mqtt) applyConfig(ctx context.Context, cfg config.MqttServiceSource) error {
 	clients := m.services.Node
 
-	var client gen.MqttServiceClient
-	err := clients.Client(&client)
-	if err != nil {
-		return err
-	}
+	client := gen.NewMqttServiceClient(clients.ClientConn())
 
 	sent := allowDuplicates()
 	if cfg.Duplicates.TrackDuplicates() {

--- a/pkg/auto/notificationsemail/auto.go
+++ b/pkg/auto/notificationsemail/auto.go
@@ -164,11 +164,7 @@ func (a *autoImpl) applyConfig(ctx context.Context, cfg config.Root) error {
 	logger := a.Logger
 	logger = logger.With(zap.String("snmp.addr", cfg.Destination.Addr()))
 
-	var alertClient gen.AlertApiClient
-	if err := a.Node.Client(&alertClient); err != nil {
-		a.Logger.Warn("failed to create gen.AlertApiClient", zap.Error(err))
-		return err
-	}
+	alertClient := gen.NewAlertApiClient(a.Node.ClientConn())
 
 	sendTime := cfg.Destination.SendTime
 	now := cfg.Now

--- a/pkg/auto/occupancyemail/auto.go
+++ b/pkg/auto/occupancyemail/auto.go
@@ -42,10 +42,7 @@ func (a *autoImpl) applyConfig(ctx context.Context, cfg config.Root) error {
 	logger := a.Logger
 	logger = logger.With(zap.String("snmp.host", cfg.Destination.Host), zap.Int("snmp.port", cfg.Destination.Port))
 
-	var ohClient gen.OccupancySensorHistoryClient
-	if err := a.Node.Client(&ohClient); err != nil {
-		return err
-	}
+	ohClient := gen.NewOccupancySensorHistoryClient(a.Node.ClientConn())
 	sendTime := cfg.Destination.SendTime
 	now := cfg.Now
 	if now == nil {

--- a/pkg/auto/resetenterleave/auto.go
+++ b/pkg/auto/resetenterleave/auto.go
@@ -44,11 +44,7 @@ func (a *Auto) applyConfig(ctx context.Context, cfg config.Root) error {
 		return nil
 	}
 
-	var elClient traits.EnterLeaveSensorApiClient
-	err := a.services.Node.Client(&elClient)
-	if err != nil {
-		return err
-	}
+	elClient := traits.NewEnterLeaveSensorApiClient(a.services.Node.ClientConn())
 
 	sched := cfg.Schedule
 	if sched == nil {

--- a/pkg/auto/statusemail/auto.go
+++ b/pkg/auto/statusemail/auto.go
@@ -41,11 +41,7 @@ func (a *autoImpl) applyConfig(ctx context.Context, cfg config.Root) error {
 	logger := a.Logger
 	logger = logger.With(zap.String("snmp.host", cfg.Destination.Host), zap.Int("snmp.port", cfg.Destination.Port))
 
-	var statusClient gen.StatusApiClient
-	err := a.Node.Client(&statusClient)
-	if err != nil {
-		return err
-	}
+	statusClient := gen.NewStatusApiClient(a.Node.ClientConn())
 
 	if cfg.DelayStart != nil {
 		time.Sleep(cfg.DelayStart.Duration)

--- a/pkg/auto/udmi/udmi.go
+++ b/pkg/auto/udmi/udmi.go
@@ -49,11 +49,7 @@ type udmiAuto struct {
 }
 
 func (e *udmiAuto) applyConfig(ctx context.Context, cfg config.Root) error {
-	var udmiClient gen.UdmiServiceClient
-	err := e.services.Node.Client(&udmiClient)
-	if err != nil {
-		return err
-	}
+	udmiClient := gen.NewUdmiServiceClient(e.services.Node.ClientConn())
 
 	client, err := newMqttClient(cfg)
 	if err != nil {

--- a/pkg/system/gateway/factory.go
+++ b/pkg/system/gateway/factory.go
@@ -110,10 +110,7 @@ func (s *System) applyConfig(ctx context.Context, cfg config.Root) error {
 		}
 		go s.scanRemoteHub(ctx, c, hubConn)
 	case config.HubModeLocal:
-		var hubClient gen.HubApiClient
-		if err := s.self.Client(&hubClient); err != nil {
-			return fmt.Errorf("local hub proxying not available, the node does not support the hub api: %w", err)
-		}
+		hubClient := gen.NewHubApiClient(s.self.ClientConn())
 		go s.scanLocalHub(ctx, c, hubClient)
 	}
 


### PR DESCRIPTION
This has been deprecated for a while now, lets get rid of it.