### PR TITLE
system/gateway: have the gateway support proxying legacy names (again)

### DIFF
--- a/pkg/system/gateway/scan.go
+++ b/pkg/system/gateway/scan.go
@@ -130,6 +130,9 @@ func (s *System) pullSystems(ctx context.Context, node *remoteNode) (task.Next, 
 			if id == "" {
 				continue // not sure what happened, all services should have an id
 			}
+			if id == LegacyName {
+				id = Name // legacy support for the old system name
+			}
 			switch id {
 			case Name:
 				systems.gateway = c.GetNewValue()


### PR DESCRIPTION
This was removed (incorrectly, imo) when we refactored to the new scan+announce model. We didn't pick up on it because it didn't actually break anything in the test, but did cause a lot of extra loops.