### PR TITLE
systems/gateway: wait for gateway checks before announcing

### DIFF
--- a/pkg/system/gateway/model.go
+++ b/pkg/system/gateway/model.go
@@ -65,5 +65,6 @@ type remoteDesc struct {
 
 // remoteSystems describes relevant systems a remote node has.
 type remoteSystems struct {
-	gateway *gen.Service // a description of the gateway system
+	msgRecvd bool         // true if we've heard from the remote node
+	gateway  *gen.Service // a description of the gateway system
 }

--- a/pkg/system/gateway/scan.go
+++ b/pkg/system/gateway/scan.go
@@ -125,6 +125,7 @@ func (s *System) pullSystems(ctx context.Context, node *remoteNode) (task.Next, 
 		}
 
 		oldSystems := systems
+		systems.msgRecvd = true
 		for _, c := range msg.Changes {
 			id := cmp.Or(c.GetNewValue().GetId(), c.GetOldValue().GetId())
 			if id == "" {

--- a/pkg/util/chans/context.go
+++ b/pkg/util/chans/context.go
@@ -2,6 +2,7 @@ package chans
 
 import (
 	"context"
+	"errors"
 )
 
 // SendContext sends v on c unless ctx is Done.
@@ -22,5 +23,33 @@ func RecvContext[T any](ctx context.Context, c <-chan T) (T, error) {
 		return t, ctx.Err()
 	case v := <-c:
 		return v, nil
+	}
+}
+
+var (
+	// ErrSkip is used to indicate that a value should be skipped when processing a channel.
+	ErrSkip = errors.New("skip")
+)
+
+// RecvContextFunc applies fn to each value received from c until fn returns nil, ctx is done, or an error occurs.
+// fn should return ErrSkip to continue receiving values without returning an error.
+func RecvContextFunc[T any](ctx context.Context, c <-chan T, fn func(T) error) (accepted T, _ error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return accepted, ctx.Err()
+		case v, ok := <-c:
+			if !ok {
+				return v, ErrClosed
+			}
+			err := fn(v)
+			switch {
+			case err == nil:
+				return v, nil
+			case errors.Is(err, ErrSkip): // continue for loop
+			default:
+				return accepted, err
+			}
+		}
 	}
 }

--- a/pkg/util/chans/context_test.go
+++ b/pkg/util/chans/context_test.go
@@ -2,8 +2,11 @@ package chans
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSendContext(t *testing.T) {
@@ -31,6 +34,81 @@ func TestSendContext(t *testing.T) {
 		err := SendContext(ctx, c, "hello")
 		if err == nil {
 			t.Fatal("expecting error")
+		}
+	})
+}
+
+func TestRecvContextFunc(t *testing.T) {
+	t.Run("first success", func(t *testing.T) {
+		c := make(chan string, 1)
+		c <- "hello"
+		ctx := context.Background()
+		got, err := RecvContextFunc(ctx, c, func(v string) error {
+			if v != "hello" {
+				return ErrSkip
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "hello" {
+			t.Fatalf("want %v, got %v", "hello", got)
+		}
+	})
+	t.Run("skip", func(t *testing.T) {
+		items := []string{"hello", "world", "after"}
+		c := make(chan string, len(items))
+		for _, v := range items {
+			c <- v
+		}
+		var checked []string
+		ctx := context.Background()
+		got, err := RecvContextFunc(ctx, c, func(v string) error {
+			checked = append(checked, v)
+			if v != "world" {
+				return ErrSkip
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "world" {
+			t.Fatalf("want %v, got %v", "world", got)
+		}
+		if diff := cmp.Diff(items[:2], checked); diff != "" {
+			t.Fatalf("checked mismatch (-want +got):\n%s", diff)
+		}
+	})
+	t.Run("fn error", func(t *testing.T) {
+		wantErr := errors.New("fn error")
+		c := make(chan string, 1)
+		c <- "hello"
+		ctx := context.Background()
+		got, err := RecvContextFunc(ctx, c, func(v string) error {
+			return wantErr
+		})
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("want %v, got %v", wantErr, err)
+		}
+		if got != "" {
+			t.Fatalf("want empty string, got %v", got)
+		}
+	})
+	t.Run("context done", func(t *testing.T) {
+		c := make(chan string)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // immediately cancel the context
+		got, err := RecvContextFunc(ctx, c, func(v string) error {
+			t.Fatalf("filter func called when context is done")
+			return nil // this should not be called
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("want %v, got %v", context.Canceled, err)
+		}
+		if got != "" {
+			t.Fatalf("want empty string, got %v", got)
 		}
 	})
 }


### PR DESCRIPTION
See commit messages for details. TL;DR wait a little before announcing a remote node to give the scan a chance to get a response from the node about whether it's a gateway or not.

This is an optimisation, it should not change behaviour from before.