### PR TITLE
system/gateway: use DevicesApi instead of ParentApi+MetadataApi for each child

### DIFF
--- a/pkg/system/gateway/factory.go
+++ b/pkg/system/gateway/factory.go
@@ -89,8 +89,8 @@ type System struct {
 
 // applyConfig runs this system based on the given config.
 // This will query the hub for nodes,
-// for each node (not ignored) it will query for all children,
-// announcing each trait for each child.
+// for each node (not ignored) it will query for all devices,
+// announcing metadata for each.
 func (s *System) applyConfig(ctx context.Context, cfg config.Root) error {
 	s.logger.Debug("applying config", zap.Any("config", cfg))
 	ignore := append([]string{}, s.ignore...)

--- a/pkg/system/gateway/model.go
+++ b/pkg/system/gateway/model.go
@@ -39,7 +39,7 @@ type remoteNode struct {
 	Self     *rx.Val[remoteDesc]
 	Systems  *rx.Val[remoteSystems]
 	Services *rx.Set[protoreflect.ServiceDescriptor]
-	Children *rx.Set[remoteDesc]
+	Devices  *rx.Set[remoteDesc]
 }
 
 func newRemoteNode(addr string, conn *grpc.ClientConn) *remoteNode {
@@ -51,7 +51,7 @@ func newRemoteNode(addr string, conn *grpc.ClientConn) *remoteNode {
 		Services: rx.NewSet(slices.NewSortedFunc[protoreflect.ServiceDescriptor](func(a, b protoreflect.ServiceDescriptor) int {
 			return strings.Compare(string(a.FullName()), string(b.FullName()))
 		})),
-		Children: rx.NewSet(slices.NewSortedFunc[remoteDesc](func(a, b remoteDesc) int {
+		Devices: rx.NewSet(slices.NewSortedFunc[remoteDesc](func(a, b remoteDesc) int {
 			return strings.Compare(a.name, b.name)
 		})),
 	}

--- a/pkg/system/gateway/routes.md
+++ b/pkg/system/gateway/routes.md
@@ -1,14 +1,13 @@
-# Overview of proxy routing
+# Overview of gateway routing
 
 Here are the routing rules we expect the gateway to support:
 
-| Service                | Payload                        | Target                              | Comments                                                                        |
-|------------------------|--------------------------------|-------------------------------------|---------------------------------------------------------------------------------|
-| `{gateway}/ServiceApi` | `{name: "{name}/{type}", ...}` | `{nodeByHubName[name]}/ServiceApi`  | Adjusting the payload to `{name: "{type}", ... }`                               |
-| `{gateway}/ServiceApi` | `{name: "{type}", ...}`        | `{proxy}/ServiceApi`                | The gateway should report its own services.                                     |
-| `{gateway}/DeviceApi`  | `*`                            | `{proxy}/DeviceApi`                 | The gateway should report on all known devices.                                 |
-| `{gateway}/ParentApi`  | `{name: "{proxy}"}`            | `{proxy}/ParentApi`                 | The gateway should report on all known children.                                |
-| `{gateway}/{api}`      | `{name: "{name}", ...}`        | `{nodeByAnnouncedName[name]}/{api}` | All named API requests should be forwarded to the node that announced the name. |
+| Service                 | Payload                 | Target                              | Comments                                                                        |
+|-------------------------|-------------------------|-------------------------------------|---------------------------------------------------------------------------------|
+| `{gateway}/DevicesApi`  | `*`                     | `{gateway}/DevicesApi`              | The gateway should report on all known devices.                                 |
+| `{gateway}/ParentApi`   | `{name: "{gateway}"}`   | `{gateway}/ParentApi`               | The gateway should report on all known children.                                |
+| `{gateway}/MetadataApi` | `{name: "{name}"}`      | `{gateway}/MetadataApi`             | The gateway reports the metadata for all devices from its own cache.            |
+| `{gateway}/{api}`       | `{name: "{name}", ...}` | `{nodeByAnnouncedName[name]}/{api}` | All named API requests should be forwarded to the node that announced the name. |
 
 All other non-named API requests should be forwarded to the hub:
 
@@ -17,8 +16,5 @@ All other non-named API requests should be forwarded to the hub:
 - LightTestApi
 - Other future APIs
 
-`nodeByHubName` maps from node name (as recorded on the hub) to a connection to that node.
-This should also include the hub and the gateway. The hub needs special processing because a hub does not return itself
-when asked for enrolled nodes.
 `nodeByAnnouncedName` maps from the name of an announced device/child on a node to a connection to that node.
-`{proxy}/DeviceApi` means the `smartcore.bos.DeviceApi` hosted on the `proxy` server.
+`{gateway}/DevicesApi` means the `smartcore.bos.DevicesApi` hosted on the `proxy` server.


### PR DESCRIPTION
This drastically reduces the network and goroutine usage. Before we'd need one routine and one pull stream for each node, then another goroutine and pull for each child on each node. Now we only need one per node. This will reduce the scale from ~10,000 down to ~10, a marked improvement, though I haven't benchmarked or tested this.

As part of this change, announcing the remote node itself no longer needs special-casing as the DevicesApi responds with the node and all its children. We still need to track the remote node for gateway processing, but hopefully that will go away once we know the host node of a device.

I've refactored the model to swap fields/types of child[ren] for device[s] as this now more accurately reflects what the data is modelling.

I've also taken the opportunity to update the routing doc as it had become a little out of date.