### PR TITLE
driver/helvanet: set confidence of pir sensors to 1 all the time

### DIFF
--- a/pkg/driver/helvarnet/pir.go
+++ b/pkg/driver/helvarnet/pir.go
@@ -62,7 +62,8 @@ func (p *Pir) refreshOccupancyStatus() error {
 
 	// Update the occupancy status
 	_, _ = p.occupancy.Set(&traits.Occupancy{
-		State: occupancy,
+		State:      occupancy,
+		Confidence: 1,
 	})
 
 	return nil


### PR DESCRIPTION
Confidence of 0 are filtered by some automations. This guarantees the occupancy state is used during exports.