### PR TITLE
node: consistent locking for parent and metadata writes

### DIFF
--- a/pkg/node/metadata.go
+++ b/pkg/node/metadata.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -28,19 +27,13 @@ func (n *Node) PullAllMetadata(ctx context.Context, opts ...resource.ReadOption)
 }
 
 func (n *Node) mergeMetadata(name string, md *traits.Metadata) (Undo, error) {
-	for i := range 5 {
-		_, err := n.allMetadata.MergeMetadata(name, md, resource.WithCreateIfAbsent())
-		if isConcurrentUpdateDetectedError(err) && i < 4 {
-			n.Logger.Debug("writing metadata, will try again", zap.Int("attempt", i), zap.String("name", name))
-			continue
-		}
-		if err != nil {
-			return NilUndo, err
-		}
-		break // no err
+	_, err := n.allMetadata.MergeMetadata(name, md, resource.WithCreateIfAbsent())
+	if err != nil {
+		return NilUndo, err
 	}
-
 	undo := Undo(func() {
+		n.mu.Lock()
+		defer n.mu.Unlock()
 		_, _ = n.allMetadata.DeleteMetadata(name, resource.WithAllowMissing(true))
 	})
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -3,13 +3,10 @@ package node
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/smart-core-os/sc-api/go/traits"
@@ -30,13 +27,16 @@ import (
 // Calling Support after Register will not have any effect on the served apis.
 type Node struct {
 	name   string
-	mu     sync.Mutex // protects all fields below, typically Announce, Support, and methods that rely on that data
 	router *router.Router
 
+	// mu protects writes to children and allMetadata to avoid concurrent modification errors.
+	// The models that back these fields are consistent when accessed concurrently,
+	// but return errors if they are modified concurrently instead of waiting.
+	// We want them to wait.
+	mu sync.Mutex
 	// children keeps track of all the names that have been announced to this node.
 	// Lazy, initialised when addChildTrait via Announce(HasTrait) or Register are called.
 	children *parentpb.Model
-
 	// allMetadata allows users of the node to be notified of any metadata changes via Announce or when
 	// that announcement is undone.
 	allMetadata *metadatapb.Collection
@@ -204,64 +204,17 @@ func (n *Node) logAnnouncement(a *announcement, services []service) Undo {
 }
 
 func (n *Node) addChildTrait(name string, traitName ...trait.Name) Undo {
-	retryConcurrentOp(func() {
-		n.children.AddChildTrait(name, traitName...)
-	})
+	n.children.AddChildTrait(name, traitName...)
 	return func() {
-		var child *traits.Child
-		parentModel := n.children
-		retryConcurrentOp(func() {
-			child = parentModel.RemoveChildTrait(name, traitName...)
-		})
+		n.mu.Lock()
+		defer n.mu.Unlock()
+		child := n.children.RemoveChildTrait(name, traitName...)
 		// There's a huge assumption here that child was added via AddChildTrait,
 		// this should be true but isn't guaranteed
 		if child != nil && len(child.Traits) == 0 {
-			retryConcurrentOp(func() {
-				_, _ = parentModel.RemoveChildByName(child.Name)
-			})
+			_, _ = n.children.RemoveChildByName(child.Name)
 		}
 	}
-}
-
-// retryConcurrentOp runs fn retrying up to 5 times when any panics that isConcurrentUpdateDetectedPanic returns true for.
-func retryConcurrentOp(fn func()) (retried bool) {
-	var err any
-	for range 5 {
-		err = catchPanic(fn)
-		if isConcurrentUpdateDetectedPanic(err) {
-			retried = true
-			continue
-		}
-		if err != nil {
-			panic(err) // report other errors
-		}
-		break // no err
-	}
-	if err != nil {
-		panic(err) // we tried
-	}
-	return
-}
-
-func catchPanic(f func()) (res any) {
-	defer func() {
-		res = recover()
-	}()
-	f()
-	return
-}
-
-func isConcurrentUpdateDetectedPanic(err any) bool {
-	e, ok := err.(error)
-	return ok && isConcurrentUpdateDetectedError(e)
-}
-
-func isConcurrentUpdateDetectedError(err error) bool {
-	s, ok := status.FromError(err)
-	if !ok {
-		return false
-	}
-	return s.Code() == codes.Aborted && strings.Contains(s.Message(), "concurrent update detected")
 }
 
 // Supports s on the router.


### PR DESCRIPTION
While the underlying types used for routing, parent, and metadata modelling are thread safe, they don't behave consistently with each other, nor do they react to concurrent writes the way we want. A while ago we fixed this by locking around the Announce function, but we never completed that work.

This change adds locks to all writes to parent and metadata, updates the comment to make it clear what the lock is for, and deletes the old concurrency error checking code now we don't need it.

The lock isn't needed for reads as the router, parent, and metadata models are already safe for this kind of use.