### PR TITLE
node: remove NoAddChildTrait

### DIFF
--- a/pkg/node/announce.go
+++ b/pkg/node/announce.go
@@ -166,8 +166,6 @@ type traitFeature struct {
 	name     trait.Name
 	services []service
 	metadata map[string]string
-
-	noAddChildTrait bool
 }
 
 // Feature describes some aspect of a named device.
@@ -337,13 +335,6 @@ func WithClients(clients ...wrap.ServiceUnwrapper) TraitOption {
 // ServiceUnwrapper will succeed.
 func WithOptClients(clients ...wrap.ServiceUnwrapper) TraitOption {
 	return WithClients(clients...)
-}
-
-// NoAddChildTrait instructs the Node not to add the trait to the nodes parent.Model.
-func NoAddChildTrait() TraitOption {
-	return func(t *traitFeature) {
-		t.noAddChildTrait = true
-	}
 }
 
 type capturingRegistrar struct {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -132,7 +132,7 @@ func (n *Node) announceLocked(name string, features ...Feature) Undo {
 		ts = append(ts, traitFeature{name: trait.Metadata})
 	}
 	for _, t := range ts {
-		if !t.noAddChildTrait && name != n.name {
+		if name != n.name {
 			undo = append(undo, n.addChildTrait(a.name, t.name))
 		}
 	}
@@ -171,11 +171,7 @@ func (n *Node) logAnnouncement(a *announcement, services []service) Undo {
 	}
 	traitsString := make([]string, 0, len(a.traits))
 	for _, t := range a.traits {
-		n := t.name.Local()
-		if t.noAddChildTrait {
-			n = "-" + n
-		}
-		traitsString = append(traitsString, n)
+		traitsString = append(traitsString, t.name.Local())
 	}
 	var flags []string
 	if len(a.metadata) > 0 {

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -149,7 +149,7 @@ func TestNode_ListAllMetadata(t *testing.T) {
 
 	t.Run("HasTrait", func(t *testing.T) {
 		n := newNode()
-		n.Announce("d1", HasTrait(trait.Light, NoAddChildTrait()))
+		n.Announce("d1", HasTrait(trait.Light))
 		got := n.ListAllMetadata()
 		want := []*traits.Metadata{
 			nodeMd,
@@ -162,8 +162,8 @@ func TestNode_ListAllMetadata(t *testing.T) {
 
 	t.Run("HasTrait merges", func(t *testing.T) {
 		n := newNode()
-		n.Announce("d1", HasTrait(trait.Light, NoAddChildTrait()))
-		n.Announce("d1", HasTrait(trait.Booking, NoAddChildTrait()))
+		n.Announce("d1", HasTrait(trait.Light))
+		n.Announce("d1", HasTrait(trait.Booking))
 		got := n.ListAllMetadata()
 		want := []*traits.Metadata{
 			nodeMd,


### PR DESCRIPTION
I found no usages (outside of tests) in all projects using GitHub search.

This is preparation for making the ParentApi and the DevicesApi much more consistent. With this option it's possible to construct a node that returns "foo" from DevicesApi but not from the ParentApi:

```go
n.Announce("foo", NoAddChildTrait(), WithMetadata(md))
```

Note, the DevicesApi and ParentApi will always disagree on one name as the DevicesApi contains the node, the ParentApi does not. But we can still make it better.

A future change will reimplement the node's ParentApi on top of the existing metadata collection, instead of maintaining a separate collection of children.