### PR TITLE
ui/ops: fix broken emergency lighting test click

### DIFF
--- a/ui/ops/src/routes/ops/emergency-lighting/EmergencyLighting.vue
+++ b/ui/ops/src/routes/ops/emergency-lighting/EmergencyLighting.vue
@@ -149,7 +149,7 @@ function functionTest() {
 async function doTest(type) {
   const lightingTests = selectedLights.value.map((light) => {
     const req = {
-      name: light.name,
+      name: light,
       test: type
     };
     return runTest(req);


### PR DESCRIPTION
fixes this issue which was happening on the test emergency lighting page
<img width="427" height="57" alt="image" src="https://github.com/user-attachments/assets/66705c7f-e457-4b76-8c9d-0f2a1dc2a85b" />
