### PR TITLE
driver/helvarnet: add support for emergency light tests

### DIFF
--- a/pkg/driver/helvarnet/command.go
+++ b/pkg/driver/helvarnet/command.go
@@ -61,3 +61,59 @@ func querySceneNames() string {
 func queryLoadLevel(addr string) string {
 	return fmt.Sprintf(">V:1,C:152,@%s#", addr)
 }
+
+// Emergency Function Test (Device)
+// Request an Emergency Function Test to an emergency lighting ballast.
+func deviceEmergencyFunctionTest(addr string) string {
+	return fmt.Sprintf(">V:1,C:20,@%s#", addr)
+}
+
+// Emergency Duration Test (Device)
+// Request an Emergency Duration Test to an emergency lighting ballast.
+func deviceEmergencyDurationTest(addr string) string {
+	return fmt.Sprintf(">V:1,C:22,@%s#", addr)
+}
+
+// Stop Emergency Tests (Device)
+// Stop any Emergency Test running in an emergency ballast.
+func deviceStopEmergencyTests(addr string) string {
+	return fmt.Sprintf(">V:1,C:24,@%s#", addr)
+}
+
+// Query Emergency Function Test State
+//
+// - Emergency State Values
+//
+// - Pass 0
+//
+// - Lamp Failure 1
+//
+// - Battery Failure 2
+//
+// - Faulty 4
+//
+// - Failure 8
+//
+// - Test Pending 16
+//
+// - Unknown 32
+func queryEmergencyFunctionTestState(addr string) string {
+	return fmt.Sprintf(">V:1,C:171,@%s#", addr)
+}
+
+// Query Emergency Duration Test State
+func queryEmergencyDurationTestState(addr string) string {
+	return fmt.Sprintf(">V:1,C:173,@%s#", addr)
+}
+
+// todo: the below commands are not used yet, the DALI trait needs to be updated first to support test result times
+
+// Query Emergency Duration Test Time
+func queryEmergencyDurationTestTime(addr string) string {
+	return fmt.Sprintf(">V:1,C:172,@%s#", addr)
+}
+
+// Query Emergency Function Test Time
+func queryEmergencyFunctionTestTime(addr string) string {
+	return fmt.Sprintf(">V:1,C:170,@%s#", addr)
+}

--- a/pkg/driver/helvarnet/config/root.go
+++ b/pkg/driver/helvarnet/config/root.go
@@ -30,9 +30,10 @@ type Root struct {
 
 	ConnectTimeout *jsontypes.Duration `json:"connectTimeout,omitempty"`
 
-	Lights         []*Device `json:"lights,omitempty"`
-	LightingGroups []*Device `json:"lightingGroups,omitempty"`
-	Pirs           []*Device `json:"pirs,omitempty"`
+	EmergencyLights []*Device `json:"emergencyLights,omitempty"`
+	Lights          []*Device `json:"lights,omitempty"`
+	LightingGroups  []*Device `json:"lightingGroups,omitempty"`
+	Pirs            []*Device `json:"pirs,omitempty"`
 	// RefreshOccupancy is the duration at which the pir sensors refresh their occupancy status
 	// Defaults to every 10 seconds
 	RefreshOccupancy *jsontypes.Duration `json:"refreshOccupancy,omitempty,omitzero"`

--- a/pkg/driver/helvarnet/light.go
+++ b/pkg/driver/helvarnet/light.go
@@ -22,6 +22,9 @@ import (
 type Light struct {
 	gen.UnimplementedStatusApiServer
 	traits.UnimplementedLightApiServer
+	// Helvarnet is not really DALI, but it is really just a wrapper around DALI devices
+	// the DALI API has the stuff in for emergency lighting tests, so just use it for now.
+	gen.UnimplementedDaliApiServer
 
 	brightness *resource.Value // *traits.Brightness
 	client     *tcpClient
@@ -248,4 +251,188 @@ func (l *Light) runHealthCheck(ctx context.Context, t time.Duration) error {
 			}
 		}
 	}
+}
+
+// runFunctionTest requests a function test from the device. Does not expect a response.
+// To get the result of the function test, you need to call queryEmergencyFunctionTestState
+func (l *Light) runFunctionTest() error {
+	command := deviceEmergencyFunctionTest(l.conf.Address)
+
+	_, err := l.client.sendAndReceive(command, "")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// runDurationTest requests a duration test from the device. Does not expect a response.
+// To get the result of the duration test, you need to call queryEmergencyDurationTestState
+func (l *Light) runDurationTest() error {
+	command := deviceEmergencyDurationTest(l.conf.Address)
+
+	_, err := l.client.sendAndReceive(command, "")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// stopTest stops any running emergency test on the device.
+func (l *Light) stopTest() error {
+	command := deviceStopEmergencyTests(l.conf.Address)
+
+	_, err := l.client.sendAndReceive(command, "")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// EmergencyState Values
+//
+// - Pass 0
+//
+// - Lamp Failure 1
+//
+// - Battery Failure 2
+//
+// - Faulty 4
+//
+// - Failure 8
+//
+// - Test Pending 16
+//
+// - Unknown 32
+type EmergencyState int
+
+const (
+	Pass           EmergencyState = 0
+	LampFailure    EmergencyState = 1
+	BatteryFailure EmergencyState = 2
+	Faulty         EmergencyState = 4
+	Failure        EmergencyState = 8
+	TestPending    EmergencyState = 16
+	Unknown        EmergencyState = 32
+)
+
+func parseGetResultResponse(r string) (*EmergencyState, error) {
+	// example response ?V:1,C:171,@1.1.2.15=16#
+	split := strings.Split(r, "=")
+	if len(split) < 2 {
+		return nil, fmt.Errorf("invalid response in getFunctionTestResult: %s", r)
+	}
+	state := strings.TrimSuffix(split[1], "#")
+	stateInt, err := strconv.Atoi(state)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse function test state: %w", err)
+	}
+
+	switch EmergencyState(stateInt) {
+	case Pass, LampFailure, BatteryFailure, Faulty, Failure, TestPending, Unknown:
+		// Do nothing, we have a valid state
+	default:
+		return nil, fmt.Errorf("unknown emergency state: %d", stateInt)
+	}
+
+	e := EmergencyState(stateInt)
+	return &e, nil
+}
+
+// getFunctionTestResult queries the device for the result of the last function test.
+// The result is a valid EmergencyState value as defined by the protocol, else an error is returned.
+func (l *Light) getFunctionTestResult() (*EmergencyState, error) {
+
+	command := queryEmergencyFunctionTestState(l.conf.Address)
+	want := "?" + command[1:len(command)-1]
+
+	r, err := l.client.sendAndReceive(command, want)
+	l.logger.Debug("getFunctionTestResult", zap.String("response", r), zap.String("command", command))
+	if err != nil {
+		return nil, err
+	}
+
+	// todo implement GetEmergencyStatus, if the response is bad we want it to show up
+	return parseGetResultResponse(r)
+}
+
+// getDurationTestResult queries the device for the result of the last duration test.
+// The result is a valid EmergencyState value as defined by the protocol, else an error is returned.
+func (l *Light) getDurationTestResult() (*EmergencyState, error) {
+
+	command := queryEmergencyDurationTestState(l.conf.Address)
+	want := "?" + command[1:len(command)-1]
+
+	r, err := l.client.sendAndReceive(command, want)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseGetResultResponse(r)
+}
+
+// StartTest Attempt to start a function or duration test.
+func (l *Light) StartTest(_ context.Context, req *gen.StartTestRequest) (*gen.StartTestResponse, error) {
+
+	switch req.Test {
+	case gen.EmergencyStatus_FUNCTION_TEST:
+		l.logger.Info("Starting function test for light", zap.String("name", l.conf.Name))
+		err := l.runFunctionTest()
+		if err != nil {
+			l.logger.Error("Failed to start function test", zap.String("name", l.conf.Name), zap.Error(err))
+			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to start function test"))
+		}
+	case gen.EmergencyStatus_DURATION_TEST:
+		l.logger.Info("Starting duration test for light", zap.String("name", l.conf.Name))
+		err := l.runDurationTest()
+		if err != nil {
+			l.logger.Error("Failed to start duration test", zap.String("name", l.conf.Name), zap.Error(err))
+			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to start duration test"))
+		}
+	default:
+		l.logger.Error("Unsupported test type requested", zap.String("name", l.conf.Name), zap.String("test", req.Test.String()))
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("unsupported test type %s", req.Test.String()))
+	}
+	return &gen.StartTestResponse{}, nil
+}
+
+func (l *Light) StopTest(context.Context, *gen.StopTestRequest) (*gen.StopTestResponse, error) {
+	l.logger.Info("Stopping test for light", zap.String("name", l.conf.Name))
+	err := l.stopTest()
+	if err != nil {
+		l.logger.Error("Failed to stop test", zap.String("name", l.conf.Name), zap.Error(err))
+		return nil, status.Error(codes.Internal, "failed to stop test")
+	}
+	return &gen.StopTestResponse{}, nil
+}
+
+func (l *Light) GetTestResult(_ context.Context, req *gen.GetTestResultRequest) (*gen.TestResult, error) {
+
+	var eState *EmergencyState
+	var err error
+	switch req.Test {
+	case gen.EmergencyStatus_FUNCTION_TEST:
+		eState, err = l.getFunctionTestResult()
+		if err != nil {
+			l.logger.Error("Failed to get function test result", zap.String("name", l.conf.Name), zap.Error(err))
+			return nil, status.Error(codes.Internal, "failed to get function test result")
+		}
+	case gen.EmergencyStatus_DURATION_TEST:
+		eState, err = l.getDurationTestResult()
+		if err != nil {
+			l.logger.Error("Failed to get duration test result", zap.String("name", l.conf.Name), zap.Error(err))
+			return nil, status.Error(codes.Internal, "failed to get duration test result")
+		}
+	default:
+		l.logger.Error("Unsupported test type requested", zap.String("name", l.conf.Name), zap.String("test", req.Test.String()))
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("unsupported test type %s", req.Test.String()))
+	}
+
+	pass := false
+	if eState != nil && *eState == Pass {
+		pass = true
+	}
+	return &gen.TestResult{
+		Test: req.Test,
+		Pass: pass,
+	}, nil
 }

--- a/pkg/driver/helvarnet/light.go
+++ b/pkg/driver/helvarnet/light.go
@@ -427,10 +427,7 @@ func (l *Light) GetTestResult(_ context.Context, req *gen.GetTestResultRequest) 
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("unsupported test type %s", req.Test.String()))
 	}
 
-	pass := false
-	if eState != nil && *eState == Pass {
-		pass = true
-	}
+	pass := eState != nil && *eState == Pass
 	return &gen.TestResult{
 		Test: req.Test,
 		Pass: pass,


### PR DESCRIPTION
adds support to the Helvarnet driver to run emergency light tests and get the results. Uses the DALI proto API, while Helvarnet itself is not DALI, it is basically just a wrapper around DALI lights.

Tested on invoking function tests and querying the results. Testing duration tests is a bit more invloved, I will need to arrange this but the logic is the same.

At the moment this does not use the GetTestTime commands, see the todo, support for these will follow once I have added it into the DALI proto