### PR TITLE
proto/dali: add start & end time to test result

### DIFF
--- a/pkg/gen/dali.pb.go
+++ b/pkg/gen/dali.pb.go
@@ -10,6 +10,7 @@ import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -1103,11 +1104,15 @@ func (x *UpdateTestIntervalResponse) GetInterval() *durationpb.Duration {
 }
 
 type TestResult struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Test          EmergencyStatus_Test   `protobuf:"varint,1,opt,name=test,proto3,enum=smartcore.bos.driver.dali.EmergencyStatus_Test" json:"test,omitempty"`
-	Pass          bool                   `protobuf:"varint,4,opt,name=pass,proto3" json:"pass,omitempty"`
-	Duration      *durationpb.Duration   `protobuf:"bytes,5,opt,name=duration,proto3" json:"duration,omitempty"` // only present for duration tests
-	Etag          string                 `protobuf:"bytes,6,opt,name=etag,proto3" json:"etag,omitempty"`
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Test     EmergencyStatus_Test   `protobuf:"varint,1,opt,name=test,proto3,enum=smartcore.bos.driver.dali.EmergencyStatus_Test" json:"test,omitempty"`
+	Pass     bool                   `protobuf:"varint,4,opt,name=pass,proto3" json:"pass,omitempty"`
+	Duration *durationpb.Duration   `protobuf:"bytes,5,opt,name=duration,proto3" json:"duration,omitempty"` // only present for duration tests
+	Etag     string                 `protobuf:"bytes,6,opt,name=etag,proto3" json:"etag,omitempty"`
+	// the time the test was started (if known)
+	StartTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
+	// the time the test was completed
+	EndTime       *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=end_time,json=endTime,proto3" json:"end_time,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1168,6 +1173,20 @@ func (x *TestResult) GetEtag() string {
 		return x.Etag
 	}
 	return ""
+}
+
+func (x *TestResult) GetStartTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartTime
+	}
+	return nil
+}
+
+func (x *TestResult) GetEndTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.EndTime
+	}
+	return nil
 }
 
 type GetTestResultRequest struct {
@@ -1287,7 +1306,7 @@ var File_dali_proto protoreflect.FileDescriptor
 const file_dali_proto_rawDesc = "" +
 	"\n" +
 	"\n" +
-	"dali.proto\x12\x19smartcore.bos.driver.dali\x1a\x1egoogle/protobuf/duration.proto\"/\n" +
+	"dali.proto\x12\x19smartcore.bos.driver.dali\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"/\n" +
 	"\x19GetGroupMembershipRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"4\n" +
 	"\x1aGetGroupMembershipResponse\x12\x16\n" +
@@ -1358,13 +1377,16 @@ const file_dali_proto_rawDesc = "" +
 	"\x04test\x18\x02 \x01(\x0e2/.smartcore.bos.driver.dali.EmergencyStatus.TestR\x04test\x125\n" +
 	"\binterval\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\binterval\"S\n" +
 	"\x1aUpdateTestIntervalResponse\x125\n" +
-	"\binterval\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\binterval\"\xb0\x01\n" +
+	"\binterval\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\binterval\"\xa2\x02\n" +
 	"\n" +
 	"TestResult\x12C\n" +
 	"\x04test\x18\x01 \x01(\x0e2/.smartcore.bos.driver.dali.EmergencyStatus.TestR\x04test\x12\x12\n" +
 	"\x04pass\x18\x04 \x01(\bR\x04pass\x125\n" +
 	"\bduration\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\bduration\x12\x12\n" +
-	"\x04etag\x18\x06 \x01(\tR\x04etag\"o\n" +
+	"\x04etag\x18\x06 \x01(\tR\x04etag\x129\n" +
+	"\n" +
+	"start_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x125\n" +
+	"\bend_time\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\aendTime\"o\n" +
 	"\x14GetTestResultRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12C\n" +
 	"\x04test\x18\x02 \x01(\x0e2/.smartcore.bos.driver.dali.EmergencyStatus.TestR\x04test\"\x86\x01\n" +
@@ -1426,6 +1448,7 @@ var file_dali_proto_goTypes = []any{
 	(*GetTestResultRequest)(nil),        // 23: smartcore.bos.driver.dali.GetTestResultRequest
 	(*DeleteTestResultRequest)(nil),     // 24: smartcore.bos.driver.dali.DeleteTestResultRequest
 	(*durationpb.Duration)(nil),         // 25: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),       // 26: google.protobuf.Timestamp
 }
 var file_dali_proto_depIdxs = []int32{
 	1,  // 0: smartcore.bos.driver.dali.EmergencyStatus.active_modes:type_name -> smartcore.bos.driver.dali.EmergencyStatus.Mode
@@ -1440,33 +1463,35 @@ var file_dali_proto_depIdxs = []int32{
 	25, // 9: smartcore.bos.driver.dali.UpdateTestIntervalResponse.interval:type_name -> google.protobuf.Duration
 	0,  // 10: smartcore.bos.driver.dali.TestResult.test:type_name -> smartcore.bos.driver.dali.EmergencyStatus.Test
 	25, // 11: smartcore.bos.driver.dali.TestResult.duration:type_name -> google.protobuf.Duration
-	0,  // 12: smartcore.bos.driver.dali.GetTestResultRequest.test:type_name -> smartcore.bos.driver.dali.EmergencyStatus.Test
-	0,  // 13: smartcore.bos.driver.dali.DeleteTestResultRequest.test:type_name -> smartcore.bos.driver.dali.EmergencyStatus.Test
-	6,  // 14: smartcore.bos.driver.dali.DaliApi.AddToGroup:input_type -> smartcore.bos.driver.dali.AddToGroupRequest
-	8,  // 15: smartcore.bos.driver.dali.DaliApi.RemoveFromGroup:input_type -> smartcore.bos.driver.dali.RemoveFromGroupRequest
-	4,  // 16: smartcore.bos.driver.dali.DaliApi.GetGroupMembership:input_type -> smartcore.bos.driver.dali.GetGroupMembershipRequest
-	13, // 17: smartcore.bos.driver.dali.DaliApi.GetControlGearStatus:input_type -> smartcore.bos.driver.dali.GetControlGearStatusRequest
-	11, // 18: smartcore.bos.driver.dali.DaliApi.GetEmergencyStatus:input_type -> smartcore.bos.driver.dali.GetEmergencyStatusRequest
-	14, // 19: smartcore.bos.driver.dali.DaliApi.Identify:input_type -> smartcore.bos.driver.dali.IdentifyRequest
-	16, // 20: smartcore.bos.driver.dali.DaliApi.StartTest:input_type -> smartcore.bos.driver.dali.StartTestRequest
-	18, // 21: smartcore.bos.driver.dali.DaliApi.StopTest:input_type -> smartcore.bos.driver.dali.StopTestRequest
-	23, // 22: smartcore.bos.driver.dali.DaliApi.GetTestResult:input_type -> smartcore.bos.driver.dali.GetTestResultRequest
-	24, // 23: smartcore.bos.driver.dali.DaliApi.DeleteTestResult:input_type -> smartcore.bos.driver.dali.DeleteTestResultRequest
-	7,  // 24: smartcore.bos.driver.dali.DaliApi.AddToGroup:output_type -> smartcore.bos.driver.dali.AddToGroupResponse
-	9,  // 25: smartcore.bos.driver.dali.DaliApi.RemoveFromGroup:output_type -> smartcore.bos.driver.dali.RemoveFromGroupResponse
-	5,  // 26: smartcore.bos.driver.dali.DaliApi.GetGroupMembership:output_type -> smartcore.bos.driver.dali.GetGroupMembershipResponse
-	12, // 27: smartcore.bos.driver.dali.DaliApi.GetControlGearStatus:output_type -> smartcore.bos.driver.dali.ControlGearStatus
-	10, // 28: smartcore.bos.driver.dali.DaliApi.GetEmergencyStatus:output_type -> smartcore.bos.driver.dali.EmergencyStatus
-	15, // 29: smartcore.bos.driver.dali.DaliApi.Identify:output_type -> smartcore.bos.driver.dali.IdentifyResponse
-	17, // 30: smartcore.bos.driver.dali.DaliApi.StartTest:output_type -> smartcore.bos.driver.dali.StartTestResponse
-	19, // 31: smartcore.bos.driver.dali.DaliApi.StopTest:output_type -> smartcore.bos.driver.dali.StopTestResponse
-	22, // 32: smartcore.bos.driver.dali.DaliApi.GetTestResult:output_type -> smartcore.bos.driver.dali.TestResult
-	22, // 33: smartcore.bos.driver.dali.DaliApi.DeleteTestResult:output_type -> smartcore.bos.driver.dali.TestResult
-	24, // [24:34] is the sub-list for method output_type
-	14, // [14:24] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	26, // 12: smartcore.bos.driver.dali.TestResult.start_time:type_name -> google.protobuf.Timestamp
+	26, // 13: smartcore.bos.driver.dali.TestResult.end_time:type_name -> google.protobuf.Timestamp
+	0,  // 14: smartcore.bos.driver.dali.GetTestResultRequest.test:type_name -> smartcore.bos.driver.dali.EmergencyStatus.Test
+	0,  // 15: smartcore.bos.driver.dali.DeleteTestResultRequest.test:type_name -> smartcore.bos.driver.dali.EmergencyStatus.Test
+	6,  // 16: smartcore.bos.driver.dali.DaliApi.AddToGroup:input_type -> smartcore.bos.driver.dali.AddToGroupRequest
+	8,  // 17: smartcore.bos.driver.dali.DaliApi.RemoveFromGroup:input_type -> smartcore.bos.driver.dali.RemoveFromGroupRequest
+	4,  // 18: smartcore.bos.driver.dali.DaliApi.GetGroupMembership:input_type -> smartcore.bos.driver.dali.GetGroupMembershipRequest
+	13, // 19: smartcore.bos.driver.dali.DaliApi.GetControlGearStatus:input_type -> smartcore.bos.driver.dali.GetControlGearStatusRequest
+	11, // 20: smartcore.bos.driver.dali.DaliApi.GetEmergencyStatus:input_type -> smartcore.bos.driver.dali.GetEmergencyStatusRequest
+	14, // 21: smartcore.bos.driver.dali.DaliApi.Identify:input_type -> smartcore.bos.driver.dali.IdentifyRequest
+	16, // 22: smartcore.bos.driver.dali.DaliApi.StartTest:input_type -> smartcore.bos.driver.dali.StartTestRequest
+	18, // 23: smartcore.bos.driver.dali.DaliApi.StopTest:input_type -> smartcore.bos.driver.dali.StopTestRequest
+	23, // 24: smartcore.bos.driver.dali.DaliApi.GetTestResult:input_type -> smartcore.bos.driver.dali.GetTestResultRequest
+	24, // 25: smartcore.bos.driver.dali.DaliApi.DeleteTestResult:input_type -> smartcore.bos.driver.dali.DeleteTestResultRequest
+	7,  // 26: smartcore.bos.driver.dali.DaliApi.AddToGroup:output_type -> smartcore.bos.driver.dali.AddToGroupResponse
+	9,  // 27: smartcore.bos.driver.dali.DaliApi.RemoveFromGroup:output_type -> smartcore.bos.driver.dali.RemoveFromGroupResponse
+	5,  // 28: smartcore.bos.driver.dali.DaliApi.GetGroupMembership:output_type -> smartcore.bos.driver.dali.GetGroupMembershipResponse
+	12, // 29: smartcore.bos.driver.dali.DaliApi.GetControlGearStatus:output_type -> smartcore.bos.driver.dali.ControlGearStatus
+	10, // 30: smartcore.bos.driver.dali.DaliApi.GetEmergencyStatus:output_type -> smartcore.bos.driver.dali.EmergencyStatus
+	15, // 31: smartcore.bos.driver.dali.DaliApi.Identify:output_type -> smartcore.bos.driver.dali.IdentifyResponse
+	17, // 32: smartcore.bos.driver.dali.DaliApi.StartTest:output_type -> smartcore.bos.driver.dali.StartTestResponse
+	19, // 33: smartcore.bos.driver.dali.DaliApi.StopTest:output_type -> smartcore.bos.driver.dali.StopTestResponse
+	22, // 34: smartcore.bos.driver.dali.DaliApi.GetTestResult:output_type -> smartcore.bos.driver.dali.TestResult
+	22, // 35: smartcore.bos.driver.dali.DaliApi.DeleteTestResult:output_type -> smartcore.bos.driver.dali.TestResult
+	26, // [26:36] is the sub-list for method output_type
+	16, // [16:26] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_dali_proto_init() }

--- a/proto/dali.proto
+++ b/proto/dali.proto
@@ -5,6 +5,7 @@ package smartcore.bos.driver.dali;
 option go_package = "github.com/vanti-dev/sc-bos/pkg/gen";
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 
 service DaliApi {
   // Group commands
@@ -144,6 +145,10 @@ message TestResult {
   bool pass = 4;
   google.protobuf.Duration duration = 5; // only present for duration tests
   string etag = 6;
+  // the time the test was started (if known)
+  google.protobuf.Timestamp start_time = 7;
+  // the time the test was completed
+  google.protobuf.Timestamp end_time = 8;
 }
 
 message GetTestResultRequest {

--- a/ui/ui-gen/proto/dali_grpc_web_pb.js
+++ b/ui/ui-gen/proto/dali_grpc_web_pb.js
@@ -21,6 +21,8 @@ grpc.web = require('grpc-web');
 
 
 var google_protobuf_duration_pb = require('google-protobuf/google/protobuf/duration_pb.js')
+
+var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js')
 const proto = {};
 proto.smartcore = {};
 proto.smartcore.bos = {};

--- a/ui/ui-gen/proto/dali_pb.d.ts
+++ b/ui/ui-gen/proto/dali_pb.d.ts
@@ -1,6 +1,7 @@
 import * as jspb from 'google-protobuf'
 
 import * as google_protobuf_duration_pb from 'google-protobuf/google/protobuf/duration_pb'; // proto import: "google/protobuf/duration.proto"
+import * as google_protobuf_timestamp_pb from 'google-protobuf/google/protobuf/timestamp_pb'; // proto import: "google/protobuf/timestamp.proto"
 
 
 export class GetGroupMembershipRequest extends jspb.Message {
@@ -423,6 +424,16 @@ export class TestResult extends jspb.Message {
   getEtag(): string;
   setEtag(value: string): TestResult;
 
+  getStartTime(): google_protobuf_timestamp_pb.Timestamp | undefined;
+  setStartTime(value?: google_protobuf_timestamp_pb.Timestamp): TestResult;
+  hasStartTime(): boolean;
+  clearStartTime(): TestResult;
+
+  getEndTime(): google_protobuf_timestamp_pb.Timestamp | undefined;
+  setEndTime(value?: google_protobuf_timestamp_pb.Timestamp): TestResult;
+  hasEndTime(): boolean;
+  clearEndTime(): TestResult;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): TestResult.AsObject;
   static toObject(includeInstance: boolean, msg: TestResult): TestResult.AsObject;
@@ -437,6 +448,8 @@ export namespace TestResult {
     pass: boolean,
     duration?: google_protobuf_duration_pb.Duration.AsObject,
     etag: string,
+    startTime?: google_protobuf_timestamp_pb.Timestamp.AsObject,
+    endTime?: google_protobuf_timestamp_pb.Timestamp.AsObject,
   }
 }
 

--- a/ui/ui-gen/proto/dali_pb.js
+++ b/ui/ui-gen/proto/dali_pb.js
@@ -23,6 +23,8 @@ var global =
 
 var google_protobuf_duration_pb = require('google-protobuf/google/protobuf/duration_pb.js');
 goog.object.extend(proto, google_protobuf_duration_pb);
+var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
+goog.object.extend(proto, google_protobuf_timestamp_pb);
 goog.exportSymbol('proto.smartcore.bos.driver.dali.AddToGroupRequest', null, global);
 goog.exportSymbol('proto.smartcore.bos.driver.dali.AddToGroupResponse', null, global);
 goog.exportSymbol('proto.smartcore.bos.driver.dali.ControlGearStatus', null, global);
@@ -3336,7 +3338,9 @@ proto.smartcore.bos.driver.dali.TestResult.toObject = function(includeInstance, 
 test: jspb.Message.getFieldWithDefault(msg, 1, 0),
 pass: jspb.Message.getBooleanFieldWithDefault(msg, 4, false),
 duration: (f = msg.getDuration()) && google_protobuf_duration_pb.Duration.toObject(includeInstance, f),
-etag: jspb.Message.getFieldWithDefault(msg, 6, "")
+etag: jspb.Message.getFieldWithDefault(msg, 6, ""),
+startTime: (f = msg.getStartTime()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
+endTime: (f = msg.getEndTime()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -3389,6 +3393,16 @@ proto.smartcore.bos.driver.dali.TestResult.deserializeBinaryFromReader = functio
     case 6:
       var value = /** @type {string} */ (reader.readString());
       msg.setEtag(value);
+      break;
+    case 7:
+      var value = new google_protobuf_timestamp_pb.Timestamp;
+      reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
+      msg.setStartTime(value);
+      break;
+    case 8:
+      var value = new google_protobuf_timestamp_pb.Timestamp;
+      reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
+      msg.setEndTime(value);
       break;
     default:
       reader.skipField();
@@ -3446,6 +3460,22 @@ proto.smartcore.bos.driver.dali.TestResult.serializeBinaryToWriter = function(me
     writer.writeString(
       6,
       f
+    );
+  }
+  f = message.getStartTime();
+  if (f != null) {
+    writer.writeMessage(
+      7,
+      f,
+      google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
+    );
+  }
+  f = message.getEndTime();
+  if (f != null) {
+    writer.writeMessage(
+      8,
+      f,
+      google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
     );
   }
 };
@@ -3539,6 +3569,80 @@ proto.smartcore.bos.driver.dali.TestResult.prototype.getEtag = function() {
  */
 proto.smartcore.bos.driver.dali.TestResult.prototype.setEtag = function(value) {
   return jspb.Message.setProto3StringField(this, 6, value);
+};
+
+
+/**
+ * optional google.protobuf.Timestamp start_time = 7;
+ * @return {?proto.google.protobuf.Timestamp}
+ */
+proto.smartcore.bos.driver.dali.TestResult.prototype.getStartTime = function() {
+  return /** @type{?proto.google.protobuf.Timestamp} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 7));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Timestamp|undefined} value
+ * @return {!proto.smartcore.bos.driver.dali.TestResult} returns this
+*/
+proto.smartcore.bos.driver.dali.TestResult.prototype.setStartTime = function(value) {
+  return jspb.Message.setWrapperField(this, 7, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.smartcore.bos.driver.dali.TestResult} returns this
+ */
+proto.smartcore.bos.driver.dali.TestResult.prototype.clearStartTime = function() {
+  return this.setStartTime(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.driver.dali.TestResult.prototype.hasStartTime = function() {
+  return jspb.Message.getField(this, 7) != null;
+};
+
+
+/**
+ * optional google.protobuf.Timestamp end_time = 8;
+ * @return {?proto.google.protobuf.Timestamp}
+ */
+proto.smartcore.bos.driver.dali.TestResult.prototype.getEndTime = function() {
+  return /** @type{?proto.google.protobuf.Timestamp} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 8));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Timestamp|undefined} value
+ * @return {!proto.smartcore.bos.driver.dali.TestResult} returns this
+*/
+proto.smartcore.bos.driver.dali.TestResult.prototype.setEndTime = function(value) {
+  return jspb.Message.setWrapperField(this, 8, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.smartcore.bos.driver.dali.TestResult} returns this
+ */
+proto.smartcore.bos.driver.dali.TestResult.prototype.clearEndTime = function() {
+  return this.setEndTime(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.driver.dali.TestResult.prototype.hasEndTime = function() {
+  return jspb.Message.getField(this, 8) != null;
 };
 
 


### PR DESCRIPTION
we can query the Helvarnet devices to tell us the last time the test was run, add support for this in the DALI trait. 