### PR TITLE
feat/light health last test time

### DIFF
--- a/pkg/driver/helvarnet/command.go
+++ b/pkg/driver/helvarnet/command.go
@@ -106,14 +106,14 @@ func queryEmergencyDurationTestState(addr string) string {
 	return fmt.Sprintf(">V:1,C:173,@%s#", addr)
 }
 
-// todo: the below commands are not used yet, the DALI trait needs to be updated first to support test result times
-
 // Query Emergency Duration Test Time
+// This is the time the test completed.
 func queryEmergencyDurationTestTime(addr string) string {
 	return fmt.Sprintf(">V:1,C:172,@%s#", addr)
 }
 
 // Query Emergency Function Test Time
+// This is the time the test completed.
 func queryEmergencyFunctionTestTime(addr string) string {
 	return fmt.Sprintf(">V:1,C:170,@%s#", addr)
 }

--- a/pkg/gen/dali.pb.go
+++ b/pkg/gen/dali.pb.go
@@ -1112,7 +1112,8 @@ type TestResult struct {
 	// the time the test was started (if known)
 	StartTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
 	// the time the test was completed
-	EndTime       *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=end_time,json=endTime,proto3" json:"end_time,omitempty"`
+	EndTime       *timestamppb.Timestamp  `protobuf:"bytes,8,opt,name=end_time,json=endTime,proto3" json:"end_time,omitempty"`
+	FailureReason EmergencyStatus_Failure `protobuf:"varint,9,opt,name=failure_reason,json=failureReason,proto3,enum=smartcore.bos.driver.dali.EmergencyStatus_Failure" json:"failure_reason,omitempty"` // if the test failed, this will be set to the reason for failure
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1187,6 +1188,13 @@ func (x *TestResult) GetEndTime() *timestamppb.Timestamp {
 		return x.EndTime
 	}
 	return nil
+}
+
+func (x *TestResult) GetFailureReason() EmergencyStatus_Failure {
+	if x != nil {
+		return x.FailureReason
+	}
+	return EmergencyStatus_FAILURE_UNSPECIFIED
 }
 
 type GetTestResultRequest struct {
@@ -1377,7 +1385,7 @@ const file_dali_proto_rawDesc = "" +
 	"\x04test\x18\x02 \x01(\x0e2/.smartcore.bos.driver.dali.EmergencyStatus.TestR\x04test\x125\n" +
 	"\binterval\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\binterval\"S\n" +
 	"\x1aUpdateTestIntervalResponse\x125\n" +
-	"\binterval\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\binterval\"\xa2\x02\n" +
+	"\binterval\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\binterval\"\xfd\x02\n" +
 	"\n" +
 	"TestResult\x12C\n" +
 	"\x04test\x18\x01 \x01(\x0e2/.smartcore.bos.driver.dali.EmergencyStatus.TestR\x04test\x12\x12\n" +
@@ -1386,7 +1394,8 @@ const file_dali_proto_rawDesc = "" +
 	"\x04etag\x18\x06 \x01(\tR\x04etag\x129\n" +
 	"\n" +
 	"start_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x125\n" +
-	"\bend_time\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\aendTime\"o\n" +
+	"\bend_time\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\aendTime\x12Y\n" +
+	"\x0efailure_reason\x18\t \x01(\x0e22.smartcore.bos.driver.dali.EmergencyStatus.FailureR\rfailureReason\"o\n" +
 	"\x14GetTestResultRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12C\n" +
 	"\x04test\x18\x02 \x01(\x0e2/.smartcore.bos.driver.dali.EmergencyStatus.TestR\x04test\"\x86\x01\n" +
@@ -1465,33 +1474,34 @@ var file_dali_proto_depIdxs = []int32{
 	25, // 11: smartcore.bos.driver.dali.TestResult.duration:type_name -> google.protobuf.Duration
 	26, // 12: smartcore.bos.driver.dali.TestResult.start_time:type_name -> google.protobuf.Timestamp
 	26, // 13: smartcore.bos.driver.dali.TestResult.end_time:type_name -> google.protobuf.Timestamp
-	0,  // 14: smartcore.bos.driver.dali.GetTestResultRequest.test:type_name -> smartcore.bos.driver.dali.EmergencyStatus.Test
-	0,  // 15: smartcore.bos.driver.dali.DeleteTestResultRequest.test:type_name -> smartcore.bos.driver.dali.EmergencyStatus.Test
-	6,  // 16: smartcore.bos.driver.dali.DaliApi.AddToGroup:input_type -> smartcore.bos.driver.dali.AddToGroupRequest
-	8,  // 17: smartcore.bos.driver.dali.DaliApi.RemoveFromGroup:input_type -> smartcore.bos.driver.dali.RemoveFromGroupRequest
-	4,  // 18: smartcore.bos.driver.dali.DaliApi.GetGroupMembership:input_type -> smartcore.bos.driver.dali.GetGroupMembershipRequest
-	13, // 19: smartcore.bos.driver.dali.DaliApi.GetControlGearStatus:input_type -> smartcore.bos.driver.dali.GetControlGearStatusRequest
-	11, // 20: smartcore.bos.driver.dali.DaliApi.GetEmergencyStatus:input_type -> smartcore.bos.driver.dali.GetEmergencyStatusRequest
-	14, // 21: smartcore.bos.driver.dali.DaliApi.Identify:input_type -> smartcore.bos.driver.dali.IdentifyRequest
-	16, // 22: smartcore.bos.driver.dali.DaliApi.StartTest:input_type -> smartcore.bos.driver.dali.StartTestRequest
-	18, // 23: smartcore.bos.driver.dali.DaliApi.StopTest:input_type -> smartcore.bos.driver.dali.StopTestRequest
-	23, // 24: smartcore.bos.driver.dali.DaliApi.GetTestResult:input_type -> smartcore.bos.driver.dali.GetTestResultRequest
-	24, // 25: smartcore.bos.driver.dali.DaliApi.DeleteTestResult:input_type -> smartcore.bos.driver.dali.DeleteTestResultRequest
-	7,  // 26: smartcore.bos.driver.dali.DaliApi.AddToGroup:output_type -> smartcore.bos.driver.dali.AddToGroupResponse
-	9,  // 27: smartcore.bos.driver.dali.DaliApi.RemoveFromGroup:output_type -> smartcore.bos.driver.dali.RemoveFromGroupResponse
-	5,  // 28: smartcore.bos.driver.dali.DaliApi.GetGroupMembership:output_type -> smartcore.bos.driver.dali.GetGroupMembershipResponse
-	12, // 29: smartcore.bos.driver.dali.DaliApi.GetControlGearStatus:output_type -> smartcore.bos.driver.dali.ControlGearStatus
-	10, // 30: smartcore.bos.driver.dali.DaliApi.GetEmergencyStatus:output_type -> smartcore.bos.driver.dali.EmergencyStatus
-	15, // 31: smartcore.bos.driver.dali.DaliApi.Identify:output_type -> smartcore.bos.driver.dali.IdentifyResponse
-	17, // 32: smartcore.bos.driver.dali.DaliApi.StartTest:output_type -> smartcore.bos.driver.dali.StartTestResponse
-	19, // 33: smartcore.bos.driver.dali.DaliApi.StopTest:output_type -> smartcore.bos.driver.dali.StopTestResponse
-	22, // 34: smartcore.bos.driver.dali.DaliApi.GetTestResult:output_type -> smartcore.bos.driver.dali.TestResult
-	22, // 35: smartcore.bos.driver.dali.DaliApi.DeleteTestResult:output_type -> smartcore.bos.driver.dali.TestResult
-	26, // [26:36] is the sub-list for method output_type
-	16, // [16:26] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	2,  // 14: smartcore.bos.driver.dali.TestResult.failure_reason:type_name -> smartcore.bos.driver.dali.EmergencyStatus.Failure
+	0,  // 15: smartcore.bos.driver.dali.GetTestResultRequest.test:type_name -> smartcore.bos.driver.dali.EmergencyStatus.Test
+	0,  // 16: smartcore.bos.driver.dali.DeleteTestResultRequest.test:type_name -> smartcore.bos.driver.dali.EmergencyStatus.Test
+	6,  // 17: smartcore.bos.driver.dali.DaliApi.AddToGroup:input_type -> smartcore.bos.driver.dali.AddToGroupRequest
+	8,  // 18: smartcore.bos.driver.dali.DaliApi.RemoveFromGroup:input_type -> smartcore.bos.driver.dali.RemoveFromGroupRequest
+	4,  // 19: smartcore.bos.driver.dali.DaliApi.GetGroupMembership:input_type -> smartcore.bos.driver.dali.GetGroupMembershipRequest
+	13, // 20: smartcore.bos.driver.dali.DaliApi.GetControlGearStatus:input_type -> smartcore.bos.driver.dali.GetControlGearStatusRequest
+	11, // 21: smartcore.bos.driver.dali.DaliApi.GetEmergencyStatus:input_type -> smartcore.bos.driver.dali.GetEmergencyStatusRequest
+	14, // 22: smartcore.bos.driver.dali.DaliApi.Identify:input_type -> smartcore.bos.driver.dali.IdentifyRequest
+	16, // 23: smartcore.bos.driver.dali.DaliApi.StartTest:input_type -> smartcore.bos.driver.dali.StartTestRequest
+	18, // 24: smartcore.bos.driver.dali.DaliApi.StopTest:input_type -> smartcore.bos.driver.dali.StopTestRequest
+	23, // 25: smartcore.bos.driver.dali.DaliApi.GetTestResult:input_type -> smartcore.bos.driver.dali.GetTestResultRequest
+	24, // 26: smartcore.bos.driver.dali.DaliApi.DeleteTestResult:input_type -> smartcore.bos.driver.dali.DeleteTestResultRequest
+	7,  // 27: smartcore.bos.driver.dali.DaliApi.AddToGroup:output_type -> smartcore.bos.driver.dali.AddToGroupResponse
+	9,  // 28: smartcore.bos.driver.dali.DaliApi.RemoveFromGroup:output_type -> smartcore.bos.driver.dali.RemoveFromGroupResponse
+	5,  // 29: smartcore.bos.driver.dali.DaliApi.GetGroupMembership:output_type -> smartcore.bos.driver.dali.GetGroupMembershipResponse
+	12, // 30: smartcore.bos.driver.dali.DaliApi.GetControlGearStatus:output_type -> smartcore.bos.driver.dali.ControlGearStatus
+	10, // 31: smartcore.bos.driver.dali.DaliApi.GetEmergencyStatus:output_type -> smartcore.bos.driver.dali.EmergencyStatus
+	15, // 32: smartcore.bos.driver.dali.DaliApi.Identify:output_type -> smartcore.bos.driver.dali.IdentifyResponse
+	17, // 33: smartcore.bos.driver.dali.DaliApi.StartTest:output_type -> smartcore.bos.driver.dali.StartTestResponse
+	19, // 34: smartcore.bos.driver.dali.DaliApi.StopTest:output_type -> smartcore.bos.driver.dali.StopTestResponse
+	22, // 35: smartcore.bos.driver.dali.DaliApi.GetTestResult:output_type -> smartcore.bos.driver.dali.TestResult
+	22, // 36: smartcore.bos.driver.dali.DaliApi.DeleteTestResult:output_type -> smartcore.bos.driver.dali.TestResult
+	27, // [27:37] is the sub-list for method output_type
+	17, // [17:27] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_dali_proto_init() }

--- a/pkg/gen/lighting_test.pb.go
+++ b/pkg/gen/lighting_test.pb.go
@@ -89,10 +89,12 @@ type LightHealth struct {
 	// The Smart Core device name of the emergency light.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// The last time this data was updated.
-	UpdateTime    *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=update_time,json=updateTime,proto3" json:"update_time,omitempty"`
-	Faults        []LightFault           `protobuf:"varint,3,rep,packed,name=faults,proto3,enum=smartcore.bos.LightFault" json:"faults,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	UpdateTime       *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=update_time,json=updateTime,proto3" json:"update_time,omitempty"`
+	Faults           []LightFault           `protobuf:"varint,3,rep,packed,name=faults,proto3,enum=smartcore.bos.LightFault" json:"faults,omitempty"`
+	LastFunctionTest *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=last_function_test,json=lastFunctionTest,proto3" json:"last_function_test,omitempty"`
+	LastDurationTest *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=last_duration_test,json=lastDurationTest,proto3" json:"last_duration_test,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *LightHealth) Reset() {
@@ -142,6 +144,20 @@ func (x *LightHealth) GetUpdateTime() *timestamppb.Timestamp {
 func (x *LightHealth) GetFaults() []LightFault {
 	if x != nil {
 		return x.Faults
+	}
+	return nil
+}
+
+func (x *LightHealth) GetLastFunctionTest() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastFunctionTest
+	}
+	return nil
+}
+
+func (x *LightHealth) GetLastDurationTest() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastDurationTest
 	}
 	return nil
 }
@@ -756,12 +772,14 @@ var File_lighting_test_proto protoreflect.FileDescriptor
 
 const file_lighting_test_proto_rawDesc = "" +
 	"\n" +
-	"\x13lighting_test.proto\x12\rsmartcore.bos\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto\"\x91\x01\n" +
+	"\x13lighting_test.proto\x12\rsmartcore.bos\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto\"\xa5\x02\n" +
 	"\vLightHealth\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12;\n" +
 	"\vupdate_time\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"updateTime\x121\n" +
-	"\x06faults\x18\x03 \x03(\x0e2\x19.smartcore.bos.LightFaultR\x06faults\"\xb9\x04\n" +
+	"\x06faults\x18\x03 \x03(\x0e2\x19.smartcore.bos.LightFaultR\x06faults\x12H\n" +
+	"\x12last_function_test\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x10lastFunctionTest\x12H\n" +
+	"\x12last_duration_test\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x10lastDurationTest\"\xb9\x04\n" +
 	"\rLightingEvent\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x128\n" +
@@ -846,27 +864,29 @@ var file_lighting_test_proto_goTypes = []any{
 var file_lighting_test_proto_depIdxs = []int32{
 	13, // 0: smartcore.bos.LightHealth.update_time:type_name -> google.protobuf.Timestamp
 	0,  // 1: smartcore.bos.LightHealth.faults:type_name -> smartcore.bos.LightFault
-	13, // 2: smartcore.bos.LightingEvent.timestamp:type_name -> google.protobuf.Timestamp
-	10, // 3: smartcore.bos.LightingEvent.duration_test_pass:type_name -> smartcore.bos.LightingEvent.DurationTestPass
-	11, // 4: smartcore.bos.LightingEvent.function_test_pass:type_name -> smartcore.bos.LightingEvent.FunctionTestPass
-	12, // 5: smartcore.bos.LightingEvent.status_report:type_name -> smartcore.bos.LightingEvent.StatusReport
-	1,  // 6: smartcore.bos.ListLightHealthResponse.emergency_lights:type_name -> smartcore.bos.LightHealth
-	2,  // 7: smartcore.bos.ListLightEventsResponse.events:type_name -> smartcore.bos.LightingEvent
-	14, // 8: smartcore.bos.LightingEvent.DurationTestPass.achieved_duration:type_name -> google.protobuf.Duration
-	0,  // 9: smartcore.bos.LightingEvent.StatusReport.faults:type_name -> smartcore.bos.LightFault
-	3,  // 10: smartcore.bos.LightingTestApi.GetLightHealth:input_type -> smartcore.bos.GetLightHealthRequest
-	4,  // 11: smartcore.bos.LightingTestApi.ListLightHealth:input_type -> smartcore.bos.ListLightHealthRequest
-	6,  // 12: smartcore.bos.LightingTestApi.ListLightEvents:input_type -> smartcore.bos.ListLightEventsRequest
-	8,  // 13: smartcore.bos.LightingTestApi.GetReportCSV:input_type -> smartcore.bos.GetReportCSVRequest
-	1,  // 14: smartcore.bos.LightingTestApi.GetLightHealth:output_type -> smartcore.bos.LightHealth
-	5,  // 15: smartcore.bos.LightingTestApi.ListLightHealth:output_type -> smartcore.bos.ListLightHealthResponse
-	7,  // 16: smartcore.bos.LightingTestApi.ListLightEvents:output_type -> smartcore.bos.ListLightEventsResponse
-	9,  // 17: smartcore.bos.LightingTestApi.GetReportCSV:output_type -> smartcore.bos.ReportCSV
-	14, // [14:18] is the sub-list for method output_type
-	10, // [10:14] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	13, // 2: smartcore.bos.LightHealth.last_function_test:type_name -> google.protobuf.Timestamp
+	13, // 3: smartcore.bos.LightHealth.last_duration_test:type_name -> google.protobuf.Timestamp
+	13, // 4: smartcore.bos.LightingEvent.timestamp:type_name -> google.protobuf.Timestamp
+	10, // 5: smartcore.bos.LightingEvent.duration_test_pass:type_name -> smartcore.bos.LightingEvent.DurationTestPass
+	11, // 6: smartcore.bos.LightingEvent.function_test_pass:type_name -> smartcore.bos.LightingEvent.FunctionTestPass
+	12, // 7: smartcore.bos.LightingEvent.status_report:type_name -> smartcore.bos.LightingEvent.StatusReport
+	1,  // 8: smartcore.bos.ListLightHealthResponse.emergency_lights:type_name -> smartcore.bos.LightHealth
+	2,  // 9: smartcore.bos.ListLightEventsResponse.events:type_name -> smartcore.bos.LightingEvent
+	14, // 10: smartcore.bos.LightingEvent.DurationTestPass.achieved_duration:type_name -> google.protobuf.Duration
+	0,  // 11: smartcore.bos.LightingEvent.StatusReport.faults:type_name -> smartcore.bos.LightFault
+	3,  // 12: smartcore.bos.LightingTestApi.GetLightHealth:input_type -> smartcore.bos.GetLightHealthRequest
+	4,  // 13: smartcore.bos.LightingTestApi.ListLightHealth:input_type -> smartcore.bos.ListLightHealthRequest
+	6,  // 14: smartcore.bos.LightingTestApi.ListLightEvents:input_type -> smartcore.bos.ListLightEventsRequest
+	8,  // 15: smartcore.bos.LightingTestApi.GetReportCSV:input_type -> smartcore.bos.GetReportCSVRequest
+	1,  // 16: smartcore.bos.LightingTestApi.GetLightHealth:output_type -> smartcore.bos.LightHealth
+	5,  // 17: smartcore.bos.LightingTestApi.ListLightHealth:output_type -> smartcore.bos.ListLightHealthResponse
+	7,  // 18: smartcore.bos.LightingTestApi.ListLightEvents:output_type -> smartcore.bos.ListLightEventsResponse
+	9,  // 19: smartcore.bos.LightingTestApi.GetReportCSV:output_type -> smartcore.bos.ReportCSV
+	16, // [16:20] is the sub-list for method output_type
+	12, // [12:16] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_lighting_test_proto_init() }

--- a/proto/dali.proto
+++ b/proto/dali.proto
@@ -149,6 +149,7 @@ message TestResult {
   google.protobuf.Timestamp start_time = 7;
   // the time the test was completed
   google.protobuf.Timestamp end_time = 8;
+  EmergencyStatus.Failure failure_reason = 9; // if the test failed, this will be set to the reason for failure
 }
 
 message GetTestResultRequest {

--- a/proto/lighting_test.proto
+++ b/proto/lighting_test.proto
@@ -34,6 +34,8 @@ message LightHealth {
   // The last time this data was updated.
   google.protobuf.Timestamp update_time = 2;
   repeated LightFault faults = 3;
+  google.protobuf.Timestamp last_function_test = 4;
+  google.protobuf.Timestamp last_duration_test = 5;
 }
 
 message LightingEvent {

--- a/ui/ops/src/routes/ops/emergency-lighting/EmergencyLighting.vue
+++ b/ui/ops/src/routes/ops/emergency-lighting/EmergencyLighting.vue
@@ -42,12 +42,27 @@
           {{ value.map((v) => faultToString(v)).join(', ') }}
         </span>
       </template>
-      <template #item.updateTime="{ value }">{{ parseDate(value.seconds) }}</template>
+      <template #item.updateTime="{ item }">
+        <span v-if="timestampToDate(item.updateTime)">
+          {{ timestampToDate(item.updateTime).toLocaleString() }}
+        </span>
+      </template>
+      <template #item.lastFunctionTest="{ item }">
+        <span v-if="timestampToDate(item.lastFunctionTest)">
+          {{ timestampToDate(item.lastFunctionTest).toLocaleString() }}
+        </span>
+      </template>
+      <template #item.lastDurationTest="{ item }">
+        <span v-if="timestampToDate(item.lastDurationTest)">
+          {{ timestampToDate(item.lastDurationTest).toLocaleString() }}
+        </span>
+      </template>
     </v-data-table>
   </content-card>
 </template>
 
 <script setup>
+import {timestampToDate} from '@/api/convpb.js';
 import {newActionTracker} from '@/api/resource';
 import {faultToString, getReportCSV, listLightHealth, runTest} from '@/api/sc/traits/lighting-test';
 import ContentCard from '@/components/ContentCard.vue';
@@ -60,8 +75,10 @@ const {blockActions} = useAuthSetup();
 
 const headers = [
   {title: 'Name', key: 'name'},
-  {title: 'Status', key: 'faultsList'}
-  // {title: 'Updated', key: 'updateTime'}
+  {title: 'Status', key: 'faultsList'},
+  {title: 'Updated', key: 'updateTime'},
+  {title: 'Last Function Test', key: 'lastFunctionTest'},
+  {title: 'Last Duration Test', key: 'lastDurationTest'}
 ];
 
 const selectedLights = ref([]);
@@ -101,16 +118,6 @@ async function refreshLightHealth() {
     if (!resp.nextPageToken) break;
     req.pageToken = resp.nextPageToken;
   }
-}
-
-/**
- *
- * @param {number} seconds
- * @return {string}
- */
-function parseDate(seconds) {
-  const d = new Date(seconds * 1000);
-  return d.toLocaleDateString() + ' ' + d.toLocaleTimeString();
 }
 
 /**

--- a/ui/ui-gen/proto/dali_pb.d.ts
+++ b/ui/ui-gen/proto/dali_pb.d.ts
@@ -434,6 +434,9 @@ export class TestResult extends jspb.Message {
   hasEndTime(): boolean;
   clearEndTime(): TestResult;
 
+  getFailureReason(): EmergencyStatus.Failure;
+  setFailureReason(value: EmergencyStatus.Failure): TestResult;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): TestResult.AsObject;
   static toObject(includeInstance: boolean, msg: TestResult): TestResult.AsObject;
@@ -450,6 +453,7 @@ export namespace TestResult {
     etag: string,
     startTime?: google_protobuf_timestamp_pb.Timestamp.AsObject,
     endTime?: google_protobuf_timestamp_pb.Timestamp.AsObject,
+    failureReason: EmergencyStatus.Failure,
   }
 }
 

--- a/ui/ui-gen/proto/dali_pb.js
+++ b/ui/ui-gen/proto/dali_pb.js
@@ -3340,7 +3340,8 @@ pass: jspb.Message.getBooleanFieldWithDefault(msg, 4, false),
 duration: (f = msg.getDuration()) && google_protobuf_duration_pb.Duration.toObject(includeInstance, f),
 etag: jspb.Message.getFieldWithDefault(msg, 6, ""),
 startTime: (f = msg.getStartTime()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
-endTime: (f = msg.getEndTime()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f)
+endTime: (f = msg.getEndTime()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
+failureReason: jspb.Message.getFieldWithDefault(msg, 9, 0)
   };
 
   if (includeInstance) {
@@ -3403,6 +3404,10 @@ proto.smartcore.bos.driver.dali.TestResult.deserializeBinaryFromReader = functio
       var value = new google_protobuf_timestamp_pb.Timestamp;
       reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
       msg.setEndTime(value);
+      break;
+    case 9:
+      var value = /** @type {!proto.smartcore.bos.driver.dali.EmergencyStatus.Failure} */ (reader.readEnum());
+      msg.setFailureReason(value);
       break;
     default:
       reader.skipField();
@@ -3476,6 +3481,13 @@ proto.smartcore.bos.driver.dali.TestResult.serializeBinaryToWriter = function(me
       8,
       f,
       google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
+    );
+  }
+  f = message.getFailureReason();
+  if (f !== 0.0) {
+    writer.writeEnum(
+      9,
+      f
     );
   }
 };
@@ -3643,6 +3655,24 @@ proto.smartcore.bos.driver.dali.TestResult.prototype.clearEndTime = function() {
  */
 proto.smartcore.bos.driver.dali.TestResult.prototype.hasEndTime = function() {
   return jspb.Message.getField(this, 8) != null;
+};
+
+
+/**
+ * optional EmergencyStatus.Failure failure_reason = 9;
+ * @return {!proto.smartcore.bos.driver.dali.EmergencyStatus.Failure}
+ */
+proto.smartcore.bos.driver.dali.TestResult.prototype.getFailureReason = function() {
+  return /** @type {!proto.smartcore.bos.driver.dali.EmergencyStatus.Failure} */ (jspb.Message.getFieldWithDefault(this, 9, 0));
+};
+
+
+/**
+ * @param {!proto.smartcore.bos.driver.dali.EmergencyStatus.Failure} value
+ * @return {!proto.smartcore.bos.driver.dali.TestResult} returns this
+ */
+proto.smartcore.bos.driver.dali.TestResult.prototype.setFailureReason = function(value) {
+  return jspb.Message.setProto3EnumField(this, 9, value);
 };
 
 

--- a/ui/ui-gen/proto/lighting_test_pb.d.ts
+++ b/ui/ui-gen/proto/lighting_test_pb.d.ts
@@ -18,6 +18,16 @@ export class LightHealth extends jspb.Message {
   clearFaultsList(): LightHealth;
   addFaults(value: LightFault, index?: number): LightHealth;
 
+  getLastFunctionTest(): google_protobuf_timestamp_pb.Timestamp | undefined;
+  setLastFunctionTest(value?: google_protobuf_timestamp_pb.Timestamp): LightHealth;
+  hasLastFunctionTest(): boolean;
+  clearLastFunctionTest(): LightHealth;
+
+  getLastDurationTest(): google_protobuf_timestamp_pb.Timestamp | undefined;
+  setLastDurationTest(value?: google_protobuf_timestamp_pb.Timestamp): LightHealth;
+  hasLastDurationTest(): boolean;
+  clearLastDurationTest(): LightHealth;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): LightHealth.AsObject;
   static toObject(includeInstance: boolean, msg: LightHealth): LightHealth.AsObject;
@@ -31,6 +41,8 @@ export namespace LightHealth {
     name: string,
     updateTime?: google_protobuf_timestamp_pb.Timestamp.AsObject,
     faultsList: Array<LightFault>,
+    lastFunctionTest?: google_protobuf_timestamp_pb.Timestamp.AsObject,
+    lastDurationTest?: google_protobuf_timestamp_pb.Timestamp.AsObject,
   }
 }
 

--- a/ui/ui-gen/proto/lighting_test_pb.js
+++ b/ui/ui-gen/proto/lighting_test_pb.js
@@ -332,7 +332,9 @@ proto.smartcore.bos.LightHealth.toObject = function(includeInstance, msg) {
   var f, obj = {
 name: jspb.Message.getFieldWithDefault(msg, 1, ""),
 updateTime: (f = msg.getUpdateTime()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
-faultsList: (f = jspb.Message.getRepeatedField(msg, 3)) == null ? undefined : f
+faultsList: (f = jspb.Message.getRepeatedField(msg, 3)) == null ? undefined : f,
+lastFunctionTest: (f = msg.getLastFunctionTest()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
+lastDurationTest: (f = msg.getLastDurationTest()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -384,6 +386,16 @@ proto.smartcore.bos.LightHealth.deserializeBinaryFromReader = function(msg, read
         msg.addFaults(values[i]);
       }
       break;
+    case 4:
+      var value = new google_protobuf_timestamp_pb.Timestamp;
+      reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
+      msg.setLastFunctionTest(value);
+      break;
+    case 5:
+      var value = new google_protobuf_timestamp_pb.Timestamp;
+      reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
+      msg.setLastDurationTest(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -433,6 +445,22 @@ proto.smartcore.bos.LightHealth.serializeBinaryToWriter = function(message, writ
     writer.writePackedEnum(
       3,
       f
+    );
+  }
+  f = message.getLastFunctionTest();
+  if (f != null) {
+    writer.writeMessage(
+      4,
+      f,
+      google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
+    );
+  }
+  f = message.getLastDurationTest();
+  if (f != null) {
+    writer.writeMessage(
+      5,
+      f,
+      google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
     );
   }
 };
@@ -527,6 +555,80 @@ proto.smartcore.bos.LightHealth.prototype.addFaults = function(value, opt_index)
  */
 proto.smartcore.bos.LightHealth.prototype.clearFaultsList = function() {
   return this.setFaultsList([]);
+};
+
+
+/**
+ * optional google.protobuf.Timestamp last_function_test = 4;
+ * @return {?proto.google.protobuf.Timestamp}
+ */
+proto.smartcore.bos.LightHealth.prototype.getLastFunctionTest = function() {
+  return /** @type{?proto.google.protobuf.Timestamp} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 4));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Timestamp|undefined} value
+ * @return {!proto.smartcore.bos.LightHealth} returns this
+*/
+proto.smartcore.bos.LightHealth.prototype.setLastFunctionTest = function(value) {
+  return jspb.Message.setWrapperField(this, 4, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.smartcore.bos.LightHealth} returns this
+ */
+proto.smartcore.bos.LightHealth.prototype.clearLastFunctionTest = function() {
+  return this.setLastFunctionTest(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.LightHealth.prototype.hasLastFunctionTest = function() {
+  return jspb.Message.getField(this, 4) != null;
+};
+
+
+/**
+ * optional google.protobuf.Timestamp last_duration_test = 5;
+ * @return {?proto.google.protobuf.Timestamp}
+ */
+proto.smartcore.bos.LightHealth.prototype.getLastDurationTest = function() {
+  return /** @type{?proto.google.protobuf.Timestamp} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 5));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Timestamp|undefined} value
+ * @return {!proto.smartcore.bos.LightHealth} returns this
+*/
+proto.smartcore.bos.LightHealth.prototype.setLastDurationTest = function(value) {
+  return jspb.Message.setWrapperField(this, 5, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.smartcore.bos.LightHealth} returns this
+ */
+proto.smartcore.bos.LightHealth.prototype.clearLastDurationTest = function() {
+  return this.setLastDurationTest(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.LightHealth.prototype.hasLastDurationTest = function() {
+  return jspb.Message.getField(this, 5) != null;
 };
 
 


### PR DESCRIPTION
3 small commits to improve emergency lighting tests:
 - add the failure reason when we return test result from Dali API
 - get last function & duration test time in Helvarnet driver
 - add the last function and duration test times to the emergency lighting

Ideally I would not like to add to the lighting test API anymore and just do these instead -> [SCBOS-684](https://vanti.youtrack.cloud/issue/SCBOS-684) & [SCBOS-7](https://vanti.youtrack.cloud/issue/SCBOS-7) but ran out of time.