### PR TITLE
node: fix undoing an announcement would delete the device

### DIFF
--- a/pkg/gentrait/devicespb/collection.go
+++ b/pkg/gentrait/devicespb/collection.go
@@ -99,6 +99,15 @@ func (c *Collection) Merge(d *gen.Device, opts ...resource.WriteOption) (*gen.De
 	return update.(*gen.Device), nil
 }
 
+// Update updates the device with the given name in the collection.
+func (c *Collection) Update(d *gen.Device, opts ...resource.WriteOption) (*gen.Device, error) {
+	update, err := c.names.Update(d.Name, d, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return update.(*gen.Device), nil
+}
+
 // Delete removes the device with the given name from the collection.
 func (c *Collection) Delete(name string, opts ...resource.WriteOption) (*gen.Device, error) {
 	old, err := c.names.Delete(name, opts...)

--- a/pkg/node/metadata.go
+++ b/pkg/node/metadata.go
@@ -1,19 +1,23 @@
 package node
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
 	"google.golang.org/protobuf/proto"
 
 	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"github.com/smart-core-os/sc-golang/pkg/trait/metadatapb"
+	"github.com/vanti-dev/sc-bos/pkg/gen"
+	"github.com/vanti-dev/sc-bos/pkg/gentrait/devicespb"
 )
 
 // mergeAllMetadata uses the metadatapb.Merge algorithm to merge multiple metadata objects into one.
 // The input metadata objects will not be modified.
 // Metadata at higher indexes in the mds slice will override metadata at lower indexes.
-func (n *Node) mergeAllMetadata(name string, mds ...*traits.Metadata) *traits.Metadata {
+func mergeAllMetadata(name string, mds ...*traits.Metadata) *traits.Metadata {
 	if len(mds) == 0 {
 		return nil
 	}
@@ -36,4 +40,77 @@ func (n *Node) mergeAllMetadata(name string, mds ...*traits.Metadata) *traits.Me
 		md = m
 	}
 	return md
+}
+
+// metadataList is a list of metadata entries, each with a unique, strictly increasing, ID.
+type metadataList []metadataEntry
+
+type metadataEntry struct {
+	id uint64
+	md *traits.Metadata
+}
+
+func (ml *metadataList) add(md *traits.Metadata) uint64 {
+	if len(*ml) == 0 {
+		*ml = append(*ml, metadataEntry{id: 0, md: md})
+		return 0
+	}
+	id := (*ml)[len(*ml)-1].id + 1
+	*ml = append(*ml, metadataEntry{id: id, md: md})
+	return id
+}
+
+func (ml *metadataList) remove(id uint64) {
+	i, found := slices.BinarySearchFunc(*ml, id, func(e metadataEntry, id uint64) int {
+		if e.id < id {
+			return -1
+		} else if e.id > id {
+			return 1
+		}
+		return 0
+	})
+	if !found {
+		return
+	}
+	*ml = slices.Replace(*ml, i, i+1)
+}
+
+func (ml *metadataList) merge() *traits.Metadata {
+	if len(*ml) == 0 {
+		return nil
+	}
+	if len(*ml) == 1 {
+		return (*ml)[0].md
+	}
+
+	name := ""
+	mds := make([]*traits.Metadata, len(*ml))
+	for i, entry := range *ml {
+		mds[i] = entry.md
+		if name == "" && entry.md.Name != "" {
+			name = entry.md.Name
+		}
+	}
+	return mergeAllMetadata(name, mds...)
+}
+
+func (ml *metadataList) isEmpty() bool {
+	return len(*ml) == 0
+}
+
+func (ml *metadataList) updateCollection(c *devicespb.Collection, opts ...resource.WriteOption) error {
+	if ml.isEmpty() {
+		return fmt.Errorf("no name: empty metadata list")
+	}
+	name := (*ml)[0].md.Name
+	if name == "" {
+		return fmt.Errorf("no name: list item has no name")
+	}
+	md := ml.merge()
+	opts = append(opts, resource.WithUpdatePaths("name", "metadata"), resource.InterceptAfter(func(old, new proto.Message) {
+		newDevice := new.(*gen.Device)
+		newDevice.Metadata = md
+	}))
+	_, err := c.Update(&gen.Device{Name: name}, opts...)
+	return err
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -151,7 +151,7 @@ func (n *Node) announceLocked(name string, features ...Feature) Undo {
 		if err != nil {
 			log.Errorf("merge metadata %q: %v", name, err)
 		} else {
-			undo = append(undo, func() {
+			undo = append(undo, UndoOnce(func() {
 				n.mu.Lock()
 				defer n.mu.Unlock()
 				mlList.remove(id)
@@ -164,7 +164,7 @@ func (n *Node) announceLocked(name string, features ...Feature) Undo {
 						log.Errorf("undo merge metadata %q: %v", name, err)
 					}
 				}
-			})
+			}))
 		}
 	}
 


### PR DESCRIPTION
I've added a list of metadata that gets collapsed to form the announced metadata, both on add and undo. This increases the memory footprint, but not that significantly.

Unfortunately the change was made on top of existing work and other PRs. Hopefully it can be merged after those, if desired I can rework all the PRs to put this one first, though that's not insignificant work.