### PR TITLE
proto/devices: allow querying by timestamp

### DIFF
--- a/pkg/gen/devices.pb.go
+++ b/pkg/gen/devices.pb.go
@@ -752,7 +752,6 @@ type Device_Query_Condition struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The name of a field relative to Device using '.' as a path separator.
 	// For example "metadata.membership.group".
-	// If absent then any field may be matched against the value.
 	Field string `protobuf:"bytes,1,opt,name=field,proto3" json:"field,omitempty"`
 	// Types that are valid to be assigned to Value:
 	//
@@ -762,6 +761,11 @@ type Device_Query_Condition struct {
 	//	*Device_Query_Condition_StringContainsFold
 	//	*Device_Query_Condition_StringIn
 	//	*Device_Query_Condition_StringInFold
+	//	*Device_Query_Condition_TimestampEqual
+	//	*Device_Query_Condition_TimestampGt
+	//	*Device_Query_Condition_TimestampGte
+	//	*Device_Query_Condition_TimestampLt
+	//	*Device_Query_Condition_TimestampLte
 	Value         isDevice_Query_Condition_Value `protobuf_oneof:"value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -865,6 +869,51 @@ func (x *Device_Query_Condition) GetStringInFold() *Device_Query_StringList {
 	return nil
 }
 
+func (x *Device_Query_Condition) GetTimestampEqual() *timestamppb.Timestamp {
+	if x != nil {
+		if x, ok := x.Value.(*Device_Query_Condition_TimestampEqual); ok {
+			return x.TimestampEqual
+		}
+	}
+	return nil
+}
+
+func (x *Device_Query_Condition) GetTimestampGt() *timestamppb.Timestamp {
+	if x != nil {
+		if x, ok := x.Value.(*Device_Query_Condition_TimestampGt); ok {
+			return x.TimestampGt
+		}
+	}
+	return nil
+}
+
+func (x *Device_Query_Condition) GetTimestampGte() *timestamppb.Timestamp {
+	if x != nil {
+		if x, ok := x.Value.(*Device_Query_Condition_TimestampGte); ok {
+			return x.TimestampGte
+		}
+	}
+	return nil
+}
+
+func (x *Device_Query_Condition) GetTimestampLt() *timestamppb.Timestamp {
+	if x != nil {
+		if x, ok := x.Value.(*Device_Query_Condition_TimestampLt); ok {
+			return x.TimestampLt
+		}
+	}
+	return nil
+}
+
+func (x *Device_Query_Condition) GetTimestampLte() *timestamppb.Timestamp {
+	if x != nil {
+		if x, ok := x.Value.(*Device_Query_Condition_TimestampLte); ok {
+			return x.TimestampLte
+		}
+	}
+	return nil
+}
+
 type isDevice_Query_Condition_Value interface {
 	isDevice_Query_Condition_Value()
 }
@@ -902,6 +951,31 @@ type Device_Query_Condition_StringInFold struct {
 	StringInFold *Device_Query_StringList `protobuf:"bytes,7,opt,name=string_in_fold,json=stringInFold,proto3,oneof"`
 }
 
+type Device_Query_Condition_TimestampEqual struct {
+	// The condition matches if the field is equal to this timestamp.
+	TimestampEqual *timestamppb.Timestamp `protobuf:"bytes,20,opt,name=timestamp_equal,json=timestampEqual,proto3,oneof"`
+}
+
+type Device_Query_Condition_TimestampGt struct {
+	// The condition matches if the field is greater than this timestamp.
+	TimestampGt *timestamppb.Timestamp `protobuf:"bytes,21,opt,name=timestamp_gt,json=timestampGt,proto3,oneof"`
+}
+
+type Device_Query_Condition_TimestampGte struct {
+	// The condition matches if the field is greater than or equal to this timestamp.
+	TimestampGte *timestamppb.Timestamp `protobuf:"bytes,22,opt,name=timestamp_gte,json=timestampGte,proto3,oneof"`
+}
+
+type Device_Query_Condition_TimestampLt struct {
+	// The condition matches if the field is less than this timestamp.
+	TimestampLt *timestamppb.Timestamp `protobuf:"bytes,23,opt,name=timestamp_lt,json=timestampLt,proto3,oneof"`
+}
+
+type Device_Query_Condition_TimestampLte struct {
+	// The condition matches if the field is less than or equal to this timestamp.
+	TimestampLte *timestamppb.Timestamp `protobuf:"bytes,24,opt,name=timestamp_lte,json=timestampLte,proto3,oneof"`
+}
+
 func (*Device_Query_Condition_StringEqual) isDevice_Query_Condition_Value() {}
 
 func (*Device_Query_Condition_StringEqualFold) isDevice_Query_Condition_Value() {}
@@ -913,6 +987,16 @@ func (*Device_Query_Condition_StringContainsFold) isDevice_Query_Condition_Value
 func (*Device_Query_Condition_StringIn) isDevice_Query_Condition_Value() {}
 
 func (*Device_Query_Condition_StringInFold) isDevice_Query_Condition_Value() {}
+
+func (*Device_Query_Condition_TimestampEqual) isDevice_Query_Condition_Value() {}
+
+func (*Device_Query_Condition_TimestampGt) isDevice_Query_Condition_Value() {}
+
+func (*Device_Query_Condition_TimestampGte) isDevice_Query_Condition_Value() {}
+
+func (*Device_Query_Condition_TimestampLt) isDevice_Query_Condition_Value() {}
+
+func (*Device_Query_Condition_TimestampLte) isDevice_Query_Condition_Value() {}
 
 // A list of strings, because oneof can't be repeated.
 type Device_Query_StringList struct {
@@ -1315,14 +1399,14 @@ var File_devices_proto protoreflect.FileDescriptor
 
 const file_devices_proto_rawDesc = "" +
 	"\n" +
-	"\rdevices.proto\x12\rsmartcore.bos\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x15traits/metadata.proto\x1a\x12types/change.proto\x1a\x17types/time/period.proto\"\xc3\x04\n" +
+	"\rdevices.proto\x12\rsmartcore.bos\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x15traits/metadata.proto\x1a\x12types/change.proto\x1a\x17types/time/period.proto\"\x92\a\n" +
 	"\x06Device\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x126\n" +
-	"\bmetadata\x18\x02 \x01(\v2\x1a.smartcore.traits.MetadataR\bmetadata\x1a\xec\x03\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x1a.smartcore.traits.MetadataR\bmetadata\x1a\xbb\x06\n" +
 	"\x05Query\x12E\n" +
 	"\n" +
 	"conditions\x18\x01 \x03(\v2%.smartcore.bos.Device.Query.ConditionR\n" +
-	"conditions\x1a\xf3\x02\n" +
+	"conditions\x1a\xc2\x05\n" +
 	"\tCondition\x12\x14\n" +
 	"\x05field\x18\x01 \x01(\tR\x05field\x12#\n" +
 	"\fstring_equal\x18\x02 \x01(\tH\x00R\vstringEqual\x12,\n" +
@@ -1330,7 +1414,12 @@ const file_devices_proto_rawDesc = "" +
 	"\x0fstring_contains\x18\x04 \x01(\tH\x00R\x0estringContains\x122\n" +
 	"\x14string_contains_fold\x18\x05 \x01(\tH\x00R\x12stringContainsFold\x12E\n" +
 	"\tstring_in\x18\x06 \x01(\v2&.smartcore.bos.Device.Query.StringListH\x00R\bstringIn\x12N\n" +
-	"\x0estring_in_fold\x18\a \x01(\v2&.smartcore.bos.Device.Query.StringListH\x00R\fstringInFoldB\a\n" +
+	"\x0estring_in_fold\x18\a \x01(\v2&.smartcore.bos.Device.Query.StringListH\x00R\fstringInFold\x12E\n" +
+	"\x0ftimestamp_equal\x18\x14 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\x0etimestampEqual\x12?\n" +
+	"\ftimestamp_gt\x18\x15 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\vtimestampGt\x12A\n" +
+	"\rtimestamp_gte\x18\x16 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\ftimestampGte\x12?\n" +
+	"\ftimestamp_lt\x18\x17 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\vtimestampLt\x12A\n" +
+	"\rtimestamp_lte\x18\x18 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\ftimestampLteB\a\n" +
 	"\x05value\x1a&\n" +
 	"\n" +
 	"StringList\x12\x18\n" +
@@ -1474,30 +1563,35 @@ var file_devices_proto_depIdxs = []int32{
 	12, // 17: smartcore.bos.Device.Query.conditions:type_name -> smartcore.bos.Device.Query.Condition
 	13, // 18: smartcore.bos.Device.Query.Condition.string_in:type_name -> smartcore.bos.Device.Query.StringList
 	13, // 19: smartcore.bos.Device.Query.Condition.string_in_fold:type_name -> smartcore.bos.Device.Query.StringList
-	16, // 20: smartcore.bos.DevicesMetadata.StringFieldCount.counts:type_name -> smartcore.bos.DevicesMetadata.StringFieldCount.CountsEntry
-	25, // 21: smartcore.bos.PullDevicesResponse.Change.type:type_name -> smartcore.types.ChangeType
-	0,  // 22: smartcore.bos.PullDevicesResponse.Change.new_value:type_name -> smartcore.bos.Device
-	0,  // 23: smartcore.bos.PullDevicesResponse.Change.old_value:type_name -> smartcore.bos.Device
-	24, // 24: smartcore.bos.PullDevicesResponse.Change.change_time:type_name -> google.protobuf.Timestamp
-	1,  // 25: smartcore.bos.PullDevicesMetadataResponse.Change.devices_metadata:type_name -> smartcore.bos.DevicesMetadata
-	24, // 26: smartcore.bos.PullDevicesMetadataResponse.Change.change_time:type_name -> google.protobuf.Timestamp
-	20, // 27: smartcore.bos.GetDownloadDevicesUrlRequest.Table.include_cols:type_name -> smartcore.bos.GetDownloadDevicesUrlRequest.Table.Column
-	20, // 28: smartcore.bos.GetDownloadDevicesUrlRequest.Table.exclude_cols:type_name -> smartcore.bos.GetDownloadDevicesUrlRequest.Table.Column
-	2,  // 29: smartcore.bos.DevicesApi.ListDevices:input_type -> smartcore.bos.ListDevicesRequest
-	4,  // 30: smartcore.bos.DevicesApi.PullDevices:input_type -> smartcore.bos.PullDevicesRequest
-	6,  // 31: smartcore.bos.DevicesApi.GetDevicesMetadata:input_type -> smartcore.bos.GetDevicesMetadataRequest
-	7,  // 32: smartcore.bos.DevicesApi.PullDevicesMetadata:input_type -> smartcore.bos.PullDevicesMetadataRequest
-	9,  // 33: smartcore.bos.DevicesApi.GetDownloadDevicesUrl:input_type -> smartcore.bos.GetDownloadDevicesUrlRequest
-	3,  // 34: smartcore.bos.DevicesApi.ListDevices:output_type -> smartcore.bos.ListDevicesResponse
-	5,  // 35: smartcore.bos.DevicesApi.PullDevices:output_type -> smartcore.bos.PullDevicesResponse
-	1,  // 36: smartcore.bos.DevicesApi.GetDevicesMetadata:output_type -> smartcore.bos.DevicesMetadata
-	8,  // 37: smartcore.bos.DevicesApi.PullDevicesMetadata:output_type -> smartcore.bos.PullDevicesMetadataResponse
-	10, // 38: smartcore.bos.DevicesApi.GetDownloadDevicesUrl:output_type -> smartcore.bos.DownloadDevicesUrl
-	34, // [34:39] is the sub-list for method output_type
-	29, // [29:34] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	24, // 20: smartcore.bos.Device.Query.Condition.timestamp_equal:type_name -> google.protobuf.Timestamp
+	24, // 21: smartcore.bos.Device.Query.Condition.timestamp_gt:type_name -> google.protobuf.Timestamp
+	24, // 22: smartcore.bos.Device.Query.Condition.timestamp_gte:type_name -> google.protobuf.Timestamp
+	24, // 23: smartcore.bos.Device.Query.Condition.timestamp_lt:type_name -> google.protobuf.Timestamp
+	24, // 24: smartcore.bos.Device.Query.Condition.timestamp_lte:type_name -> google.protobuf.Timestamp
+	16, // 25: smartcore.bos.DevicesMetadata.StringFieldCount.counts:type_name -> smartcore.bos.DevicesMetadata.StringFieldCount.CountsEntry
+	25, // 26: smartcore.bos.PullDevicesResponse.Change.type:type_name -> smartcore.types.ChangeType
+	0,  // 27: smartcore.bos.PullDevicesResponse.Change.new_value:type_name -> smartcore.bos.Device
+	0,  // 28: smartcore.bos.PullDevicesResponse.Change.old_value:type_name -> smartcore.bos.Device
+	24, // 29: smartcore.bos.PullDevicesResponse.Change.change_time:type_name -> google.protobuf.Timestamp
+	1,  // 30: smartcore.bos.PullDevicesMetadataResponse.Change.devices_metadata:type_name -> smartcore.bos.DevicesMetadata
+	24, // 31: smartcore.bos.PullDevicesMetadataResponse.Change.change_time:type_name -> google.protobuf.Timestamp
+	20, // 32: smartcore.bos.GetDownloadDevicesUrlRequest.Table.include_cols:type_name -> smartcore.bos.GetDownloadDevicesUrlRequest.Table.Column
+	20, // 33: smartcore.bos.GetDownloadDevicesUrlRequest.Table.exclude_cols:type_name -> smartcore.bos.GetDownloadDevicesUrlRequest.Table.Column
+	2,  // 34: smartcore.bos.DevicesApi.ListDevices:input_type -> smartcore.bos.ListDevicesRequest
+	4,  // 35: smartcore.bos.DevicesApi.PullDevices:input_type -> smartcore.bos.PullDevicesRequest
+	6,  // 36: smartcore.bos.DevicesApi.GetDevicesMetadata:input_type -> smartcore.bos.GetDevicesMetadataRequest
+	7,  // 37: smartcore.bos.DevicesApi.PullDevicesMetadata:input_type -> smartcore.bos.PullDevicesMetadataRequest
+	9,  // 38: smartcore.bos.DevicesApi.GetDownloadDevicesUrl:input_type -> smartcore.bos.GetDownloadDevicesUrlRequest
+	3,  // 39: smartcore.bos.DevicesApi.ListDevices:output_type -> smartcore.bos.ListDevicesResponse
+	5,  // 40: smartcore.bos.DevicesApi.PullDevices:output_type -> smartcore.bos.PullDevicesResponse
+	1,  // 41: smartcore.bos.DevicesApi.GetDevicesMetadata:output_type -> smartcore.bos.DevicesMetadata
+	8,  // 42: smartcore.bos.DevicesApi.PullDevicesMetadata:output_type -> smartcore.bos.PullDevicesMetadataResponse
+	10, // 43: smartcore.bos.DevicesApi.GetDownloadDevicesUrl:output_type -> smartcore.bos.DownloadDevicesUrl
+	39, // [39:44] is the sub-list for method output_type
+	34, // [34:39] is the sub-list for method input_type
+	34, // [34:34] is the sub-list for extension type_name
+	34, // [34:34] is the sub-list for extension extendee
+	0,  // [0:34] is the sub-list for field type_name
 }
 
 func init() { file_devices_proto_init() }
@@ -1512,6 +1606,11 @@ func file_devices_proto_init() {
 		(*Device_Query_Condition_StringContainsFold)(nil),
 		(*Device_Query_Condition_StringIn)(nil),
 		(*Device_Query_Condition_StringInFold)(nil),
+		(*Device_Query_Condition_TimestampEqual)(nil),
+		(*Device_Query_Condition_TimestampGt)(nil),
+		(*Device_Query_Condition_TimestampGte)(nil),
+		(*Device_Query_Condition_TimestampLt)(nil),
+		(*Device_Query_Condition_TimestampLte)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/proto/devices.proto
+++ b/proto/devices.proto
@@ -29,7 +29,6 @@ message Device {
     message Condition {
       // The name of a field relative to Device using '.' as a path separator.
       // For example "metadata.membership.group".
-      // If absent then any field may be matched against the value.
       string field = 1;
       oneof value {
         // Compare the field to this string using a case sensitive comparison
@@ -48,6 +47,17 @@ message Device {
         // Compare the field to any of these strings using a simple unicode case folding comparison.
         // The server may have limits on the number of strings that can be compared.
         StringList string_in_fold = 7;
+
+        // The condition matches if the field is equal to this timestamp.
+        google.protobuf.Timestamp timestamp_equal = 20;
+        // The condition matches if the field is greater than this timestamp.
+        google.protobuf.Timestamp timestamp_gt = 21;
+        // The condition matches if the field is greater than or equal to this timestamp.
+        google.protobuf.Timestamp timestamp_gte = 22;
+        // The condition matches if the field is less than this timestamp.
+        google.protobuf.Timestamp timestamp_lt = 23;
+        // The condition matches if the field is less than or equal to this timestamp.
+        google.protobuf.Timestamp timestamp_lte = 24;
 
         // there's room here for additional rhs values for the field, but we don't need any
       }

--- a/ui/ops/src/api/ui/devices.js
+++ b/ui/ops/src/api/ui/devices.js
@@ -1,4 +1,4 @@
-import {fieldMaskFromObject, setProperties} from '@/api/convpb.js';
+import {convertProperties, fieldMaskFromObject, setProperties, timestampFromObject} from '@/api/convpb.js';
 import {clientOptions} from '@/api/grpcweb.js';
 import {pullResource, setCollection, setValue} from '@/api/resource';
 import {trackAction} from '@/api/resource.js';
@@ -150,6 +150,8 @@ function deviceQueryConditionFromObject(obj) {
   if (obj.stringInFold) {
     dst.setStringInFold(new Device.Query.StringList().setStringsList(obj.stringInFold.stringsList));
   }
+  convertProperties(dst, obj, timestampFromObject,
+      'timestampEqual', 'timestampGt', 'timestampGte', 'timestampLt', 'timestampLte');
   return dst;
 }
 

--- a/ui/ui-gen/proto/devices_pb.d.ts
+++ b/ui/ui-gen/proto/devices_pb.d.ts
@@ -75,6 +75,31 @@ export namespace Device {
       hasStringInFold(): boolean;
       clearStringInFold(): Condition;
 
+      getTimestampEqual(): google_protobuf_timestamp_pb.Timestamp | undefined;
+      setTimestampEqual(value?: google_protobuf_timestamp_pb.Timestamp): Condition;
+      hasTimestampEqual(): boolean;
+      clearTimestampEqual(): Condition;
+
+      getTimestampGt(): google_protobuf_timestamp_pb.Timestamp | undefined;
+      setTimestampGt(value?: google_protobuf_timestamp_pb.Timestamp): Condition;
+      hasTimestampGt(): boolean;
+      clearTimestampGt(): Condition;
+
+      getTimestampGte(): google_protobuf_timestamp_pb.Timestamp | undefined;
+      setTimestampGte(value?: google_protobuf_timestamp_pb.Timestamp): Condition;
+      hasTimestampGte(): boolean;
+      clearTimestampGte(): Condition;
+
+      getTimestampLt(): google_protobuf_timestamp_pb.Timestamp | undefined;
+      setTimestampLt(value?: google_protobuf_timestamp_pb.Timestamp): Condition;
+      hasTimestampLt(): boolean;
+      clearTimestampLt(): Condition;
+
+      getTimestampLte(): google_protobuf_timestamp_pb.Timestamp | undefined;
+      setTimestampLte(value?: google_protobuf_timestamp_pb.Timestamp): Condition;
+      hasTimestampLte(): boolean;
+      clearTimestampLte(): Condition;
+
       getValueCase(): Condition.ValueCase;
 
       serializeBinary(): Uint8Array;
@@ -94,6 +119,11 @@ export namespace Device {
         stringContainsFold: string,
         stringIn?: Device.Query.StringList.AsObject,
         stringInFold?: Device.Query.StringList.AsObject,
+        timestampEqual?: google_protobuf_timestamp_pb.Timestamp.AsObject,
+        timestampGt?: google_protobuf_timestamp_pb.Timestamp.AsObject,
+        timestampGte?: google_protobuf_timestamp_pb.Timestamp.AsObject,
+        timestampLt?: google_protobuf_timestamp_pb.Timestamp.AsObject,
+        timestampLte?: google_protobuf_timestamp_pb.Timestamp.AsObject,
       }
 
       export enum ValueCase { 
@@ -104,6 +134,11 @@ export namespace Device {
         STRING_CONTAINS_FOLD = 5,
         STRING_IN = 6,
         STRING_IN_FOLD = 7,
+        TIMESTAMP_EQUAL = 20,
+        TIMESTAMP_GT = 21,
+        TIMESTAMP_GTE = 22,
+        TIMESTAMP_LT = 23,
+        TIMESTAMP_LTE = 24,
       }
     }
 

--- a/ui/ui-gen/proto/devices_pb.js
+++ b/ui/ui-gen/proto/devices_pb.js
@@ -729,7 +729,7 @@ proto.smartcore.bos.Device.Query.serializeBinaryToWriter = function(message, wri
  * @private {!Array<!Array<number>>}
  * @const
  */
-proto.smartcore.bos.Device.Query.Condition.oneofGroups_ = [[2,3,4,5,6,7]];
+proto.smartcore.bos.Device.Query.Condition.oneofGroups_ = [[2,3,4,5,6,7,20,21,22,23,24]];
 
 /**
  * @enum {number}
@@ -741,7 +741,12 @@ proto.smartcore.bos.Device.Query.Condition.ValueCase = {
   STRING_CONTAINS: 4,
   STRING_CONTAINS_FOLD: 5,
   STRING_IN: 6,
-  STRING_IN_FOLD: 7
+  STRING_IN_FOLD: 7,
+  TIMESTAMP_EQUAL: 20,
+  TIMESTAMP_GT: 21,
+  TIMESTAMP_GTE: 22,
+  TIMESTAMP_LT: 23,
+  TIMESTAMP_LTE: 24
 };
 
 /**
@@ -788,7 +793,12 @@ stringEqualFold: (f = jspb.Message.getField(msg, 3)) == null ? undefined : f,
 stringContains: (f = jspb.Message.getField(msg, 4)) == null ? undefined : f,
 stringContainsFold: (f = jspb.Message.getField(msg, 5)) == null ? undefined : f,
 stringIn: (f = msg.getStringIn()) && proto.smartcore.bos.Device.Query.StringList.toObject(includeInstance, f),
-stringInFold: (f = msg.getStringInFold()) && proto.smartcore.bos.Device.Query.StringList.toObject(includeInstance, f)
+stringInFold: (f = msg.getStringInFold()) && proto.smartcore.bos.Device.Query.StringList.toObject(includeInstance, f),
+timestampEqual: (f = msg.getTimestampEqual()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
+timestampGt: (f = msg.getTimestampGt()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
+timestampGte: (f = msg.getTimestampGte()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
+timestampLt: (f = msg.getTimestampLt()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
+timestampLte: (f = msg.getTimestampLte()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -854,6 +864,31 @@ proto.smartcore.bos.Device.Query.Condition.deserializeBinaryFromReader = functio
       var value = new proto.smartcore.bos.Device.Query.StringList;
       reader.readMessage(value,proto.smartcore.bos.Device.Query.StringList.deserializeBinaryFromReader);
       msg.setStringInFold(value);
+      break;
+    case 20:
+      var value = new google_protobuf_timestamp_pb.Timestamp;
+      reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
+      msg.setTimestampEqual(value);
+      break;
+    case 21:
+      var value = new google_protobuf_timestamp_pb.Timestamp;
+      reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
+      msg.setTimestampGt(value);
+      break;
+    case 22:
+      var value = new google_protobuf_timestamp_pb.Timestamp;
+      reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
+      msg.setTimestampGte(value);
+      break;
+    case 23:
+      var value = new google_protobuf_timestamp_pb.Timestamp;
+      reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
+      msg.setTimestampLt(value);
+      break;
+    case 24:
+      var value = new google_protobuf_timestamp_pb.Timestamp;
+      reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
+      msg.setTimestampLte(value);
       break;
     default:
       reader.skipField();
@@ -933,6 +968,46 @@ proto.smartcore.bos.Device.Query.Condition.serializeBinaryToWriter = function(me
       7,
       f,
       proto.smartcore.bos.Device.Query.StringList.serializeBinaryToWriter
+    );
+  }
+  f = message.getTimestampEqual();
+  if (f != null) {
+    writer.writeMessage(
+      20,
+      f,
+      google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
+    );
+  }
+  f = message.getTimestampGt();
+  if (f != null) {
+    writer.writeMessage(
+      21,
+      f,
+      google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
+    );
+  }
+  f = message.getTimestampGte();
+  if (f != null) {
+    writer.writeMessage(
+      22,
+      f,
+      google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
+    );
+  }
+  f = message.getTimestampLt();
+  if (f != null) {
+    writer.writeMessage(
+      23,
+      f,
+      google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
+    );
+  }
+  f = message.getTimestampLte();
+  if (f != null) {
+    writer.writeMessage(
+      24,
+      f,
+      google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
     );
   }
 };
@@ -1171,6 +1246,191 @@ proto.smartcore.bos.Device.Query.Condition.prototype.clearStringInFold = functio
  */
 proto.smartcore.bos.Device.Query.Condition.prototype.hasStringInFold = function() {
   return jspb.Message.getField(this, 7) != null;
+};
+
+
+/**
+ * optional google.protobuf.Timestamp timestamp_equal = 20;
+ * @return {?proto.google.protobuf.Timestamp}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.getTimestampEqual = function() {
+  return /** @type{?proto.google.protobuf.Timestamp} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 20));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Timestamp|undefined} value
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+*/
+proto.smartcore.bos.Device.Query.Condition.prototype.setTimestampEqual = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 20, proto.smartcore.bos.Device.Query.Condition.oneofGroups_[0], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.clearTimestampEqual = function() {
+  return this.setTimestampEqual(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.hasTimestampEqual = function() {
+  return jspb.Message.getField(this, 20) != null;
+};
+
+
+/**
+ * optional google.protobuf.Timestamp timestamp_gt = 21;
+ * @return {?proto.google.protobuf.Timestamp}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.getTimestampGt = function() {
+  return /** @type{?proto.google.protobuf.Timestamp} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 21));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Timestamp|undefined} value
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+*/
+proto.smartcore.bos.Device.Query.Condition.prototype.setTimestampGt = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 21, proto.smartcore.bos.Device.Query.Condition.oneofGroups_[0], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.clearTimestampGt = function() {
+  return this.setTimestampGt(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.hasTimestampGt = function() {
+  return jspb.Message.getField(this, 21) != null;
+};
+
+
+/**
+ * optional google.protobuf.Timestamp timestamp_gte = 22;
+ * @return {?proto.google.protobuf.Timestamp}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.getTimestampGte = function() {
+  return /** @type{?proto.google.protobuf.Timestamp} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 22));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Timestamp|undefined} value
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+*/
+proto.smartcore.bos.Device.Query.Condition.prototype.setTimestampGte = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 22, proto.smartcore.bos.Device.Query.Condition.oneofGroups_[0], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.clearTimestampGte = function() {
+  return this.setTimestampGte(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.hasTimestampGte = function() {
+  return jspb.Message.getField(this, 22) != null;
+};
+
+
+/**
+ * optional google.protobuf.Timestamp timestamp_lt = 23;
+ * @return {?proto.google.protobuf.Timestamp}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.getTimestampLt = function() {
+  return /** @type{?proto.google.protobuf.Timestamp} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 23));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Timestamp|undefined} value
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+*/
+proto.smartcore.bos.Device.Query.Condition.prototype.setTimestampLt = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 23, proto.smartcore.bos.Device.Query.Condition.oneofGroups_[0], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.clearTimestampLt = function() {
+  return this.setTimestampLt(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.hasTimestampLt = function() {
+  return jspb.Message.getField(this, 23) != null;
+};
+
+
+/**
+ * optional google.protobuf.Timestamp timestamp_lte = 24;
+ * @return {?proto.google.protobuf.Timestamp}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.getTimestampLte = function() {
+  return /** @type{?proto.google.protobuf.Timestamp} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 24));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Timestamp|undefined} value
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+*/
+proto.smartcore.bos.Device.Query.Condition.prototype.setTimestampLte = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 24, proto.smartcore.bos.Device.Query.Condition.oneofGroups_[0], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.clearTimestampLte = function() {
+  return this.setTimestampLte(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.hasTimestampLte = function() {
+  return jspb.Message.getField(this, 24) != null;
 };
 
 


### PR DESCRIPTION
Allow the usual query conditions: ==, <, >=, etc for timestamps. While metadata doesn't have many timestamps, this will allow easier querying of other data as it is added to the Device message type