### PR TITLE
driver/helvarnet: use emergency light trait

### DIFF
--- a/pkg/driver/helvarnet/config/root.go
+++ b/pkg/driver/helvarnet/config/root.go
@@ -67,6 +67,8 @@ type Device struct {
 	GroupNumber *int             `json:"groupNumber,omitempty"`
 	IpAddress   string           `json:"ipAddress,omitempty"`
 	Meta        *traits.Metadata `json:"meta,omitempty"`
+	// The length of the duration test for emergency lights, if known
+	DurationTestLength *jsontypes.Duration `json:"durationTestLength,omitempty,omitzero"`
 }
 
 // Scene represents a HelvarNet lighting scene, which is a combination of a block (address), scene, and title.

--- a/pkg/driver/helvarnet/driver.go
+++ b/pkg/driver/helvarnet/driver.go
@@ -14,7 +14,7 @@ import (
 	"github.com/vanti-dev/sc-bos/pkg/driver"
 	"github.com/vanti-dev/sc-bos/pkg/driver/helvarnet/config"
 	"github.com/vanti-dev/sc-bos/pkg/gen"
-	"github.com/vanti-dev/sc-bos/pkg/gentrait/dalipb"
+	"github.com/vanti-dev/sc-bos/pkg/gentrait/emergencylightpb"
 	"github.com/vanti-dev/sc-bos/pkg/gentrait/statuspb"
 	"github.com/vanti-dev/sc-bos/pkg/node"
 	"github.com/vanti-dev/sc-bos/pkg/task/service"
@@ -140,8 +140,8 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 				node.WithClients(lightpb.WrapApi(emergencyLight))),
 			node.HasTrait(statuspb.TraitName,
 				node.WithClients(gen.WrapStatusApi(emergencyLight))),
-			node.HasTrait(dalipb.TraitName,
-				node.WithClients(gen.WrapDaliApi(emergencyLight))),
+			node.HasTrait(emergencylightpb.TraitName,
+				node.WithClients(gen.WrapEmergencyLightApi(emergencyLight))),
 			node.HasMetadata(em.Meta))
 		grp.Go(func() error {
 			return emergencyLight.runHealthCheck(ctx, cfg.RefreshStatus.Duration)


### PR DESCRIPTION
use the new emergency light trait instead of dali in Helvarnet driver .

this commit on it's own will mean the Emergency Light page will no longer be able to invoke tests for this driver as that page still uses DALI. Plan is to update that page next to invoke tests using `emergency_light` and then update downstream projects. I will leave the `lighting_test` changes until last