### PR TITLE
auto/statusemail;auto/statusalerts;auto/udmi: change readPaths top level message validation type to *gen.Device

### DIFF
--- a/pkg/auto/statusalerts/statusalerts.go
+++ b/pkg/auto/statusalerts/statusalerts.go
@@ -8,7 +8,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"github.com/vanti-dev/sc-bos/pkg/auto"
 	"github.com/vanti-dev/sc-bos/pkg/auto/statusalerts/config"
@@ -91,7 +90,7 @@ func (a *autoImpl) applyConfig(ctx context.Context, cfg config.Root) error {
 					return
 				default:
 				}
-				for change := range a.Node.PullDevices(ctx, resource.WithReadPaths(&traits.Metadata{}, "metadata.traits", "metadata.location", "metadata.membership")) {
+				for change := range a.Node.PullDevices(ctx, resource.WithReadPaths(&gen.Device{}, "metadata.traits", "metadata.location", "metadata.membership")) {
 					if s := ignore.Replace(change.Name); len(s) == 0 || s[0] == '!' {
 						continue // ignore
 					}

--- a/pkg/auto/statusemail/auto.go
+++ b/pkg/auto/statusemail/auto.go
@@ -9,7 +9,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"github.com/vanti-dev/sc-bos/pkg/auto"
 	"github.com/vanti-dev/sc-bos/pkg/auto/statusemail/config"
@@ -97,7 +96,7 @@ func (a *autoImpl) applyConfig(ctx context.Context, cfg config.Root) error {
 					return
 				default:
 				}
-				for change := range a.Node.PullDevices(ctx, resource.WithReadPaths(&traits.Metadata{}, "metadata.traits", "metadata.appearance", "metadata.location", "metadata.membership")) {
+				for change := range a.Node.PullDevices(ctx, resource.WithReadPaths(&gen.Device{}, "metadata.traits", "metadata.appearance", "metadata.location", "metadata.membership")) {
 					if s := ignore.Replace(change.Name); len(s) == 0 || s[0] == '!' {
 						continue // ignore
 					}

--- a/pkg/auto/udmi/udmi.go
+++ b/pkg/auto/udmi/udmi.go
@@ -9,7 +9,6 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"github.com/vanti-dev/sc-bos/pkg/gen"
 	"github.com/vanti-dev/sc-bos/pkg/gentrait/udmipb"
@@ -103,7 +102,7 @@ func (e *udmiAuto) applyConfig(ctx context.Context, cfg config.Root) error {
 					return
 				default:
 				}
-				for change := range e.services.Node.PullDevices(ctx, resource.WithReadPaths(&traits.Metadata{}, "metadata.traits")) {
+				for change := range e.services.Node.PullDevices(ctx, resource.WithReadPaths(&gen.Device{}, "metadata.traits")) {
 					hadTrait, hasTrait := hasUDMITrait(change.OldValue), hasUDMITrait(change.NewValue)
 					if hadTrait && !hasTrait {
 						// remove


### PR DESCRIPTION
I cannot find any references to where the top level message struct name needs to be included in the fieldmask path.

I am pretty sure the string path shouldn't include the top level message name and have found the documented example doesn't either. Although, the documentation does mislead us by suggesting the top level message name is part of the field mask.

// As an example, consider the following message declarations:
//
//     message Profile {
//       User user = 1;
//       Photo photo = 2;
//     }
//     message User {
//       string display_name = 1;
//       string address = 2;
//     }
//
// In proto a field mask for `Profile` may look as such:
//
//     mask {
//       paths: "user.display_name"
//       paths: "photo"
//     }


Where it misleads us:
// `FieldMask` represents a set of symbolic field paths, for example:
//
//     paths: "f.a"
//     paths: "f.b.d"
//
// Here `f` represents a field in some root message, `a` and `b`
// fields in the message found in `f`, and `d` a field found in the
// message in `f.b`.


I am surprised this was working for so long. I will try deploying this branch to the site experiencing the panic to see if it resolves the issue.