### PR TITLE
soundsensorpb: add missing Model.UpdateSoundLevel

### DIFF
--- a/pkg/gentrait/soundsensorpb/model.go
+++ b/pkg/gentrait/soundsensorpb/model.go
@@ -29,4 +29,12 @@ func (m *Model) PullSoundLevel(ctx context.Context, opts ...resource.ReadOption)
 	return resources.PullValue[*gen.SoundLevel](ctx, m.soundLevel.Pull(ctx, opts...))
 }
 
+func (m *Model) UpdateSoundLevel(soundLevel *gen.SoundLevel, opts ...resource.WriteOption) (*gen.SoundLevel, error) {
+	res, err := m.soundLevel.Set(soundLevel, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*gen.SoundLevel), nil
+}
+
 type PullSoundLevelChange = resources.ValueChange[*gen.SoundLevel]


### PR DESCRIPTION
The model couldn't be used because there was no way to update the data after creation.

Add a simple mutator function for the model.