### PR TITLE
devices: add name descendant device query options

### DIFF
--- a/internal/manage/devices/tree.go
+++ b/internal/manage/devices/tree.go
@@ -1,0 +1,159 @@
+package devices
+
+import (
+	"strings"
+)
+
+// A nameNode is a node in a tree where each node represents a segment of a path.
+type nameNode struct {
+	// leaf nodes have a name associated with them
+	name *name
+
+	children mapping[string, *nameNode]
+}
+
+func newTreeFromPaths(paths ...string) *nameNode {
+	root := &nameNode{}
+	for _, p := range paths {
+		root.addName(parseName(p))
+	}
+	return root
+}
+
+// addName adds the given name to the tree.
+func (n *nameNode) addName(s *name) {
+	n.addSegments(*s, s)
+}
+
+// addSegments adds the given segments to the tree, associating the name s with the leaf node.
+func (n *nameNode) addSegments(segs []string, s *name) {
+	if len(segs) == 0 {
+		n.name = s
+		return
+	}
+	seg := segs[0]
+	n.addChild(seg).addSegments(segs[1:], s)
+}
+
+// addChild returns the child with the given key, creating it if necessary.
+func (n *nameNode) addChild(key string) *nameNode {
+	if c := n.findChild(key); c != nil {
+		return c
+	}
+	c := &nameNode{}
+	n.children.add(key, c)
+	return c
+}
+
+// findChild returns the child node with the given key, or nil if there is no such child.
+func (n *nameNode) findChild(key string) *nameNode {
+	child, _ := n.children.find(key)
+	return child
+}
+
+// matchDescendant returns a leaf node that is an ancestor of the given descendent path d.
+// The self return value will be true if d exactly matches a leaf node in the tree.
+func (n *nameNode) matchDescendant(d string) (_ *nameNode, self bool) {
+	if n == nil {
+		return nil, false
+	}
+	if d == "" {
+		if n.name == nil {
+			return nil, false
+		}
+		return n, true
+	}
+	if n.name != nil {
+		return n, false
+	}
+	seg, rest := firstSegment(d)
+	return n.findChild(seg).matchDescendant(rest)
+}
+
+// firstSegment returns the first segment of path, before the first '/'.
+// If p does not contain a '/', the entire p is returned as the segment, and rest is empty.
+func firstSegment(p string) (seg, rest string) {
+	seg, rest, _ = strings.Cut(p, "/")
+	return seg, rest
+}
+
+// name represents a parsed name.
+type name []string
+
+func parseName(s string) *name {
+	segs := name(strings.Split(s, "/"))
+	return &segs
+}
+
+func (n *name) String() string {
+	return strings.Join(*n, "/")
+}
+
+// mapping is copied from the http package to represent a k-v mapping, with optimisations for few entries.
+type mapping[K comparable, V any] struct {
+	s []entry[K, V] // for few mappings
+	m map[K]V       // for many mappings
+}
+
+type entry[K comparable, V any] struct {
+	key   K
+	value V
+}
+
+// taken from http.ServerMux impl based on benchmarks
+const maxSlice = 8
+
+func (h *mapping[K, V]) add(k K, v V) {
+	if h.m == nil && len(h.s) < maxSlice {
+		h.s = append(h.s, entry[K, V]{k, v})
+	} else {
+		if h.m == nil {
+			h.m = map[K]V{}
+			for _, e := range h.s {
+				h.m[e.key] = e.value
+			}
+			h.s = nil
+		}
+		h.m[k] = v
+	}
+}
+
+// find returns the value corresponding to the given key.
+// The second return value is false if there is no value
+// with that key.
+func (h *mapping[K, V]) find(k K) (v V, found bool) {
+	if h == nil {
+		return v, false
+	}
+	if h.m != nil {
+		v, found = h.m[k]
+		return v, found
+	}
+	for _, e := range h.s {
+		if e.key == k {
+			return e.value, true
+		}
+	}
+	return v, false
+}
+
+// eachPair calls f for each pair in the mapping.
+// If f returns false, pairs returns immediately.
+func (h *mapping[K, V]) eachPair(f func(k K, v V) bool) {
+	if h == nil {
+		return
+	}
+	if h.m != nil {
+		for k, v := range h.m {
+			if !f(k, v) {
+				return
+			}
+		}
+	} else {
+		for _, e := range h.s {
+			if !f(e.key, e.value) {
+				return
+			}
+		}
+	}
+}

--- a/pkg/gen/devices.pb.go
+++ b/pkg/gen/devices.pb.go
@@ -766,6 +766,10 @@ type Device_Query_Condition struct {
 	//	*Device_Query_Condition_TimestampGte
 	//	*Device_Query_Condition_TimestampLt
 	//	*Device_Query_Condition_TimestampLte
+	//	*Device_Query_Condition_NameDescendant
+	//	*Device_Query_Condition_NameDescendantInc
+	//	*Device_Query_Condition_NameDescendantIn
+	//	*Device_Query_Condition_NameDescendantIncIn
 	Value         isDevice_Query_Condition_Value `protobuf_oneof:"value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -914,6 +918,42 @@ func (x *Device_Query_Condition) GetTimestampLte() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *Device_Query_Condition) GetNameDescendant() string {
+	if x != nil {
+		if x, ok := x.Value.(*Device_Query_Condition_NameDescendant); ok {
+			return x.NameDescendant
+		}
+	}
+	return ""
+}
+
+func (x *Device_Query_Condition) GetNameDescendantInc() string {
+	if x != nil {
+		if x, ok := x.Value.(*Device_Query_Condition_NameDescendantInc); ok {
+			return x.NameDescendantInc
+		}
+	}
+	return ""
+}
+
+func (x *Device_Query_Condition) GetNameDescendantIn() *Device_Query_StringList {
+	if x != nil {
+		if x, ok := x.Value.(*Device_Query_Condition_NameDescendantIn); ok {
+			return x.NameDescendantIn
+		}
+	}
+	return nil
+}
+
+func (x *Device_Query_Condition) GetNameDescendantIncIn() *Device_Query_StringList {
+	if x != nil {
+		if x, ok := x.Value.(*Device_Query_Condition_NameDescendantIncIn); ok {
+			return x.NameDescendantIncIn
+		}
+	}
+	return nil
+}
+
 type isDevice_Query_Condition_Value interface {
 	isDevice_Query_Condition_Value()
 }
@@ -976,6 +1016,37 @@ type Device_Query_Condition_TimestampLte struct {
 	TimestampLte *timestamppb.Timestamp `protobuf:"bytes,24,opt,name=timestamp_lte,json=timestampLte,proto3,oneof"`
 }
 
+type Device_Query_Condition_NameDescendant struct {
+	// The condition matches if the field is a descendant of this name.
+	// For example "a/b" would match "a/b/c" but not "a/bc".
+	//
+	// Names are used to identify resources: devices, services, etc.
+	// Names are usually comprised of '/' separated path segments indicating a hierarchy,
+	// for example "a/b/c" is a child of "a/b".
+	// Some of the authorization claims use this hierarchy to grant access to collections of resources.
+	NameDescendant string `protobuf:"bytes,30,opt,name=name_descendant,json=nameDescendant,proto3,oneof"`
+}
+
+type Device_Query_Condition_NameDescendantInc struct {
+	// The condition matches if the field is equal to or a descendant of this name.
+	// For example "a/b" would match "a/b" and "a/b/c" but not "a/bc".
+	NameDescendantInc string `protobuf:"bytes,31,opt,name=name_descendant_inc,json=nameDescendantInc,proto3,oneof"`
+}
+
+type Device_Query_Condition_NameDescendantIn struct {
+	// The condition matches if the field is a descendant of any of these names.
+	// The server may have limits on the number of names that can be compared.
+	// See the name_descendant description for details of how descendant matching works.
+	NameDescendantIn *Device_Query_StringList `protobuf:"bytes,32,opt,name=name_descendant_in,json=nameDescendantIn,proto3,oneof"`
+}
+
+type Device_Query_Condition_NameDescendantIncIn struct {
+	// The condition matches if the field is equal to or a descendant of any of these names.
+	// The server may have limits on the number of names that can be compared.
+	// See the name_descendant_inc description for details of how descendant matching works.
+	NameDescendantIncIn *Device_Query_StringList `protobuf:"bytes,33,opt,name=name_descendant_inc_in,json=nameDescendantIncIn,proto3,oneof"`
+}
+
 func (*Device_Query_Condition_StringEqual) isDevice_Query_Condition_Value() {}
 
 func (*Device_Query_Condition_StringEqualFold) isDevice_Query_Condition_Value() {}
@@ -997,6 +1068,14 @@ func (*Device_Query_Condition_TimestampGte) isDevice_Query_Condition_Value() {}
 func (*Device_Query_Condition_TimestampLt) isDevice_Query_Condition_Value() {}
 
 func (*Device_Query_Condition_TimestampLte) isDevice_Query_Condition_Value() {}
+
+func (*Device_Query_Condition_NameDescendant) isDevice_Query_Condition_Value() {}
+
+func (*Device_Query_Condition_NameDescendantInc) isDevice_Query_Condition_Value() {}
+
+func (*Device_Query_Condition_NameDescendantIn) isDevice_Query_Condition_Value() {}
+
+func (*Device_Query_Condition_NameDescendantIncIn) isDevice_Query_Condition_Value() {}
 
 // A list of strings, because oneof can't be repeated.
 type Device_Query_StringList struct {
@@ -1399,14 +1478,14 @@ var File_devices_proto protoreflect.FileDescriptor
 
 const file_devices_proto_rawDesc = "" +
 	"\n" +
-	"\rdevices.proto\x12\rsmartcore.bos\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x15traits/metadata.proto\x1a\x12types/change.proto\x1a\x17types/time/period.proto\"\x92\a\n" +
+	"\rdevices.proto\x12\rsmartcore.bos\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x15traits/metadata.proto\x1a\x12types/change.proto\x1a\x17types/time/period.proto\"\xa6\t\n" +
 	"\x06Device\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x126\n" +
-	"\bmetadata\x18\x02 \x01(\v2\x1a.smartcore.traits.MetadataR\bmetadata\x1a\xbb\x06\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x1a.smartcore.traits.MetadataR\bmetadata\x1a\xcf\b\n" +
 	"\x05Query\x12E\n" +
 	"\n" +
 	"conditions\x18\x01 \x03(\v2%.smartcore.bos.Device.Query.ConditionR\n" +
-	"conditions\x1a\xc2\x05\n" +
+	"conditions\x1a\xd6\a\n" +
 	"\tCondition\x12\x14\n" +
 	"\x05field\x18\x01 \x01(\tR\x05field\x12#\n" +
 	"\fstring_equal\x18\x02 \x01(\tH\x00R\vstringEqual\x12,\n" +
@@ -1419,7 +1498,11 @@ const file_devices_proto_rawDesc = "" +
 	"\ftimestamp_gt\x18\x15 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\vtimestampGt\x12A\n" +
 	"\rtimestamp_gte\x18\x16 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\ftimestampGte\x12?\n" +
 	"\ftimestamp_lt\x18\x17 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\vtimestampLt\x12A\n" +
-	"\rtimestamp_lte\x18\x18 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\ftimestampLteB\a\n" +
+	"\rtimestamp_lte\x18\x18 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\ftimestampLte\x12)\n" +
+	"\x0fname_descendant\x18\x1e \x01(\tH\x00R\x0enameDescendant\x120\n" +
+	"\x13name_descendant_inc\x18\x1f \x01(\tH\x00R\x11nameDescendantInc\x12V\n" +
+	"\x12name_descendant_in\x18  \x01(\v2&.smartcore.bos.Device.Query.StringListH\x00R\x10nameDescendantIn\x12]\n" +
+	"\x16name_descendant_inc_in\x18! \x01(\v2&.smartcore.bos.Device.Query.StringListH\x00R\x13nameDescendantIncInB\a\n" +
 	"\x05value\x1a&\n" +
 	"\n" +
 	"StringList\x12\x18\n" +
@@ -1568,30 +1651,32 @@ var file_devices_proto_depIdxs = []int32{
 	24, // 22: smartcore.bos.Device.Query.Condition.timestamp_gte:type_name -> google.protobuf.Timestamp
 	24, // 23: smartcore.bos.Device.Query.Condition.timestamp_lt:type_name -> google.protobuf.Timestamp
 	24, // 24: smartcore.bos.Device.Query.Condition.timestamp_lte:type_name -> google.protobuf.Timestamp
-	16, // 25: smartcore.bos.DevicesMetadata.StringFieldCount.counts:type_name -> smartcore.bos.DevicesMetadata.StringFieldCount.CountsEntry
-	25, // 26: smartcore.bos.PullDevicesResponse.Change.type:type_name -> smartcore.types.ChangeType
-	0,  // 27: smartcore.bos.PullDevicesResponse.Change.new_value:type_name -> smartcore.bos.Device
-	0,  // 28: smartcore.bos.PullDevicesResponse.Change.old_value:type_name -> smartcore.bos.Device
-	24, // 29: smartcore.bos.PullDevicesResponse.Change.change_time:type_name -> google.protobuf.Timestamp
-	1,  // 30: smartcore.bos.PullDevicesMetadataResponse.Change.devices_metadata:type_name -> smartcore.bos.DevicesMetadata
-	24, // 31: smartcore.bos.PullDevicesMetadataResponse.Change.change_time:type_name -> google.protobuf.Timestamp
-	20, // 32: smartcore.bos.GetDownloadDevicesUrlRequest.Table.include_cols:type_name -> smartcore.bos.GetDownloadDevicesUrlRequest.Table.Column
-	20, // 33: smartcore.bos.GetDownloadDevicesUrlRequest.Table.exclude_cols:type_name -> smartcore.bos.GetDownloadDevicesUrlRequest.Table.Column
-	2,  // 34: smartcore.bos.DevicesApi.ListDevices:input_type -> smartcore.bos.ListDevicesRequest
-	4,  // 35: smartcore.bos.DevicesApi.PullDevices:input_type -> smartcore.bos.PullDevicesRequest
-	6,  // 36: smartcore.bos.DevicesApi.GetDevicesMetadata:input_type -> smartcore.bos.GetDevicesMetadataRequest
-	7,  // 37: smartcore.bos.DevicesApi.PullDevicesMetadata:input_type -> smartcore.bos.PullDevicesMetadataRequest
-	9,  // 38: smartcore.bos.DevicesApi.GetDownloadDevicesUrl:input_type -> smartcore.bos.GetDownloadDevicesUrlRequest
-	3,  // 39: smartcore.bos.DevicesApi.ListDevices:output_type -> smartcore.bos.ListDevicesResponse
-	5,  // 40: smartcore.bos.DevicesApi.PullDevices:output_type -> smartcore.bos.PullDevicesResponse
-	1,  // 41: smartcore.bos.DevicesApi.GetDevicesMetadata:output_type -> smartcore.bos.DevicesMetadata
-	8,  // 42: smartcore.bos.DevicesApi.PullDevicesMetadata:output_type -> smartcore.bos.PullDevicesMetadataResponse
-	10, // 43: smartcore.bos.DevicesApi.GetDownloadDevicesUrl:output_type -> smartcore.bos.DownloadDevicesUrl
-	39, // [39:44] is the sub-list for method output_type
-	34, // [34:39] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	13, // 25: smartcore.bos.Device.Query.Condition.name_descendant_in:type_name -> smartcore.bos.Device.Query.StringList
+	13, // 26: smartcore.bos.Device.Query.Condition.name_descendant_inc_in:type_name -> smartcore.bos.Device.Query.StringList
+	16, // 27: smartcore.bos.DevicesMetadata.StringFieldCount.counts:type_name -> smartcore.bos.DevicesMetadata.StringFieldCount.CountsEntry
+	25, // 28: smartcore.bos.PullDevicesResponse.Change.type:type_name -> smartcore.types.ChangeType
+	0,  // 29: smartcore.bos.PullDevicesResponse.Change.new_value:type_name -> smartcore.bos.Device
+	0,  // 30: smartcore.bos.PullDevicesResponse.Change.old_value:type_name -> smartcore.bos.Device
+	24, // 31: smartcore.bos.PullDevicesResponse.Change.change_time:type_name -> google.protobuf.Timestamp
+	1,  // 32: smartcore.bos.PullDevicesMetadataResponse.Change.devices_metadata:type_name -> smartcore.bos.DevicesMetadata
+	24, // 33: smartcore.bos.PullDevicesMetadataResponse.Change.change_time:type_name -> google.protobuf.Timestamp
+	20, // 34: smartcore.bos.GetDownloadDevicesUrlRequest.Table.include_cols:type_name -> smartcore.bos.GetDownloadDevicesUrlRequest.Table.Column
+	20, // 35: smartcore.bos.GetDownloadDevicesUrlRequest.Table.exclude_cols:type_name -> smartcore.bos.GetDownloadDevicesUrlRequest.Table.Column
+	2,  // 36: smartcore.bos.DevicesApi.ListDevices:input_type -> smartcore.bos.ListDevicesRequest
+	4,  // 37: smartcore.bos.DevicesApi.PullDevices:input_type -> smartcore.bos.PullDevicesRequest
+	6,  // 38: smartcore.bos.DevicesApi.GetDevicesMetadata:input_type -> smartcore.bos.GetDevicesMetadataRequest
+	7,  // 39: smartcore.bos.DevicesApi.PullDevicesMetadata:input_type -> smartcore.bos.PullDevicesMetadataRequest
+	9,  // 40: smartcore.bos.DevicesApi.GetDownloadDevicesUrl:input_type -> smartcore.bos.GetDownloadDevicesUrlRequest
+	3,  // 41: smartcore.bos.DevicesApi.ListDevices:output_type -> smartcore.bos.ListDevicesResponse
+	5,  // 42: smartcore.bos.DevicesApi.PullDevices:output_type -> smartcore.bos.PullDevicesResponse
+	1,  // 43: smartcore.bos.DevicesApi.GetDevicesMetadata:output_type -> smartcore.bos.DevicesMetadata
+	8,  // 44: smartcore.bos.DevicesApi.PullDevicesMetadata:output_type -> smartcore.bos.PullDevicesMetadataResponse
+	10, // 45: smartcore.bos.DevicesApi.GetDownloadDevicesUrl:output_type -> smartcore.bos.DownloadDevicesUrl
+	41, // [41:46] is the sub-list for method output_type
+	36, // [36:41] is the sub-list for method input_type
+	36, // [36:36] is the sub-list for extension type_name
+	36, // [36:36] is the sub-list for extension extendee
+	0,  // [0:36] is the sub-list for field type_name
 }
 
 func init() { file_devices_proto_init() }
@@ -1611,6 +1696,10 @@ func file_devices_proto_init() {
 		(*Device_Query_Condition_TimestampGte)(nil),
 		(*Device_Query_Condition_TimestampLt)(nil),
 		(*Device_Query_Condition_TimestampLte)(nil),
+		(*Device_Query_Condition_NameDescendant)(nil),
+		(*Device_Query_Condition_NameDescendantInc)(nil),
+		(*Device_Query_Condition_NameDescendantIn)(nil),
+		(*Device_Query_Condition_NameDescendantIncIn)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/proto/devices.proto
+++ b/proto/devices.proto
@@ -59,6 +59,26 @@ message Device {
         // The condition matches if the field is less than or equal to this timestamp.
         google.protobuf.Timestamp timestamp_lte = 24;
 
+        // The condition matches if the field is a descendant of this name.
+        // For example "a/b" would match "a/b/c" but not "a/bc".
+        //
+        // Names are used to identify resources: devices, services, etc.
+        // Names are usually comprised of '/' separated path segments indicating a hierarchy,
+        // for example "a/b/c" is a child of "a/b".
+        // Some of the authorization claims use this hierarchy to grant access to collections of resources.
+        string name_descendant = 30;
+        // The condition matches if the field is equal to or a descendant of this name.
+        // For example "a/b" would match "a/b" and "a/b/c" but not "a/bc".
+        string name_descendant_inc = 31;
+        // The condition matches if the field is a descendant of any of these names.
+        // The server may have limits on the number of names that can be compared.
+        // See the name_descendant description for details of how descendant matching works.
+        StringList name_descendant_in = 32;
+        // The condition matches if the field is equal to or a descendant of any of these names.
+        // The server may have limits on the number of names that can be compared.
+        // See the name_descendant_inc description for details of how descendant matching works.
+        StringList name_descendant_inc_in = 33;
+
         // there's room here for additional rhs values for the field, but we don't need any
       }
     }

--- a/ui/ui-gen/proto/devices_pb.d.ts
+++ b/ui/ui-gen/proto/devices_pb.d.ts
@@ -100,6 +100,22 @@ export namespace Device {
       hasTimestampLte(): boolean;
       clearTimestampLte(): Condition;
 
+      getNameDescendant(): string;
+      setNameDescendant(value: string): Condition;
+
+      getNameDescendantInc(): string;
+      setNameDescendantInc(value: string): Condition;
+
+      getNameDescendantIn(): Device.Query.StringList | undefined;
+      setNameDescendantIn(value?: Device.Query.StringList): Condition;
+      hasNameDescendantIn(): boolean;
+      clearNameDescendantIn(): Condition;
+
+      getNameDescendantIncIn(): Device.Query.StringList | undefined;
+      setNameDescendantIncIn(value?: Device.Query.StringList): Condition;
+      hasNameDescendantIncIn(): boolean;
+      clearNameDescendantIncIn(): Condition;
+
       getValueCase(): Condition.ValueCase;
 
       serializeBinary(): Uint8Array;
@@ -124,6 +140,10 @@ export namespace Device {
         timestampGte?: google_protobuf_timestamp_pb.Timestamp.AsObject,
         timestampLt?: google_protobuf_timestamp_pb.Timestamp.AsObject,
         timestampLte?: google_protobuf_timestamp_pb.Timestamp.AsObject,
+        nameDescendant: string,
+        nameDescendantInc: string,
+        nameDescendantIn?: Device.Query.StringList.AsObject,
+        nameDescendantIncIn?: Device.Query.StringList.AsObject,
       }
 
       export enum ValueCase { 
@@ -139,6 +159,10 @@ export namespace Device {
         TIMESTAMP_GTE = 22,
         TIMESTAMP_LT = 23,
         TIMESTAMP_LTE = 24,
+        NAME_DESCENDANT = 30,
+        NAME_DESCENDANT_INC = 31,
+        NAME_DESCENDANT_IN = 32,
+        NAME_DESCENDANT_INC_IN = 33,
       }
     }
 

--- a/ui/ui-gen/proto/devices_pb.js
+++ b/ui/ui-gen/proto/devices_pb.js
@@ -729,7 +729,7 @@ proto.smartcore.bos.Device.Query.serializeBinaryToWriter = function(message, wri
  * @private {!Array<!Array<number>>}
  * @const
  */
-proto.smartcore.bos.Device.Query.Condition.oneofGroups_ = [[2,3,4,5,6,7,20,21,22,23,24]];
+proto.smartcore.bos.Device.Query.Condition.oneofGroups_ = [[2,3,4,5,6,7,20,21,22,23,24,30,31,32,33]];
 
 /**
  * @enum {number}
@@ -746,7 +746,11 @@ proto.smartcore.bos.Device.Query.Condition.ValueCase = {
   TIMESTAMP_GT: 21,
   TIMESTAMP_GTE: 22,
   TIMESTAMP_LT: 23,
-  TIMESTAMP_LTE: 24
+  TIMESTAMP_LTE: 24,
+  NAME_DESCENDANT: 30,
+  NAME_DESCENDANT_INC: 31,
+  NAME_DESCENDANT_IN: 32,
+  NAME_DESCENDANT_INC_IN: 33
 };
 
 /**
@@ -798,7 +802,11 @@ timestampEqual: (f = msg.getTimestampEqual()) && google_protobuf_timestamp_pb.Ti
 timestampGt: (f = msg.getTimestampGt()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
 timestampGte: (f = msg.getTimestampGte()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
 timestampLt: (f = msg.getTimestampLt()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
-timestampLte: (f = msg.getTimestampLte()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f)
+timestampLte: (f = msg.getTimestampLte()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
+nameDescendant: (f = jspb.Message.getField(msg, 30)) == null ? undefined : f,
+nameDescendantInc: (f = jspb.Message.getField(msg, 31)) == null ? undefined : f,
+nameDescendantIn: (f = msg.getNameDescendantIn()) && proto.smartcore.bos.Device.Query.StringList.toObject(includeInstance, f),
+nameDescendantIncIn: (f = msg.getNameDescendantIncIn()) && proto.smartcore.bos.Device.Query.StringList.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -889,6 +897,24 @@ proto.smartcore.bos.Device.Query.Condition.deserializeBinaryFromReader = functio
       var value = new google_protobuf_timestamp_pb.Timestamp;
       reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
       msg.setTimestampLte(value);
+      break;
+    case 30:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setNameDescendant(value);
+      break;
+    case 31:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setNameDescendantInc(value);
+      break;
+    case 32:
+      var value = new proto.smartcore.bos.Device.Query.StringList;
+      reader.readMessage(value,proto.smartcore.bos.Device.Query.StringList.deserializeBinaryFromReader);
+      msg.setNameDescendantIn(value);
+      break;
+    case 33:
+      var value = new proto.smartcore.bos.Device.Query.StringList;
+      reader.readMessage(value,proto.smartcore.bos.Device.Query.StringList.deserializeBinaryFromReader);
+      msg.setNameDescendantIncIn(value);
       break;
     default:
       reader.skipField();
@@ -1008,6 +1034,36 @@ proto.smartcore.bos.Device.Query.Condition.serializeBinaryToWriter = function(me
       24,
       f,
       google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
+    );
+  }
+  f = /** @type {string} */ (jspb.Message.getField(message, 30));
+  if (f != null) {
+    writer.writeString(
+      30,
+      f
+    );
+  }
+  f = /** @type {string} */ (jspb.Message.getField(message, 31));
+  if (f != null) {
+    writer.writeString(
+      31,
+      f
+    );
+  }
+  f = message.getNameDescendantIn();
+  if (f != null) {
+    writer.writeMessage(
+      32,
+      f,
+      proto.smartcore.bos.Device.Query.StringList.serializeBinaryToWriter
+    );
+  }
+  f = message.getNameDescendantIncIn();
+  if (f != null) {
+    writer.writeMessage(
+      33,
+      f,
+      proto.smartcore.bos.Device.Query.StringList.serializeBinaryToWriter
     );
   }
 };
@@ -1431,6 +1487,152 @@ proto.smartcore.bos.Device.Query.Condition.prototype.clearTimestampLte = functio
  */
 proto.smartcore.bos.Device.Query.Condition.prototype.hasTimestampLte = function() {
   return jspb.Message.getField(this, 24) != null;
+};
+
+
+/**
+ * optional string name_descendant = 30;
+ * @return {string}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.getNameDescendant = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 30, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.setNameDescendant = function(value) {
+  return jspb.Message.setOneofField(this, 30, proto.smartcore.bos.Device.Query.Condition.oneofGroups_[0], value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.clearNameDescendant = function() {
+  return jspb.Message.setOneofField(this, 30, proto.smartcore.bos.Device.Query.Condition.oneofGroups_[0], undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.hasNameDescendant = function() {
+  return jspb.Message.getField(this, 30) != null;
+};
+
+
+/**
+ * optional string name_descendant_inc = 31;
+ * @return {string}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.getNameDescendantInc = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 31, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.setNameDescendantInc = function(value) {
+  return jspb.Message.setOneofField(this, 31, proto.smartcore.bos.Device.Query.Condition.oneofGroups_[0], value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.clearNameDescendantInc = function() {
+  return jspb.Message.setOneofField(this, 31, proto.smartcore.bos.Device.Query.Condition.oneofGroups_[0], undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.hasNameDescendantInc = function() {
+  return jspb.Message.getField(this, 31) != null;
+};
+
+
+/**
+ * optional StringList name_descendant_in = 32;
+ * @return {?proto.smartcore.bos.Device.Query.StringList}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.getNameDescendantIn = function() {
+  return /** @type{?proto.smartcore.bos.Device.Query.StringList} */ (
+    jspb.Message.getWrapperField(this, proto.smartcore.bos.Device.Query.StringList, 32));
+};
+
+
+/**
+ * @param {?proto.smartcore.bos.Device.Query.StringList|undefined} value
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+*/
+proto.smartcore.bos.Device.Query.Condition.prototype.setNameDescendantIn = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 32, proto.smartcore.bos.Device.Query.Condition.oneofGroups_[0], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.clearNameDescendantIn = function() {
+  return this.setNameDescendantIn(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.hasNameDescendantIn = function() {
+  return jspb.Message.getField(this, 32) != null;
+};
+
+
+/**
+ * optional StringList name_descendant_inc_in = 33;
+ * @return {?proto.smartcore.bos.Device.Query.StringList}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.getNameDescendantIncIn = function() {
+  return /** @type{?proto.smartcore.bos.Device.Query.StringList} */ (
+    jspb.Message.getWrapperField(this, proto.smartcore.bos.Device.Query.StringList, 33));
+};
+
+
+/**
+ * @param {?proto.smartcore.bos.Device.Query.StringList|undefined} value
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+*/
+proto.smartcore.bos.Device.Query.Condition.prototype.setNameDescendantIncIn = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 33, proto.smartcore.bos.Device.Query.Condition.oneofGroups_[0], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.smartcore.bos.Device.Query.Condition} returns this
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.clearNameDescendantIncIn = function() {
+  return this.setNameDescendantIncIn(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.Device.Query.Condition.prototype.hasNameDescendantIncIn = function() {
+  return jspb.Message.getField(this, 33) != null;
 };
 
 


### PR DESCRIPTION
These options should be useful for auth as they map almost directly to the new permission scopes for names.