### PR TITLE
history: add SQLite3-based history storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 require (
 	cloud.google.com/go/compute/metadata v0.5.2 // indirect
 	github.com/agnivade/levenshtein v1.2.1 // indirect
+	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chzyer/test v1.0.0 // indirect

--- a/internal/sqlite/database.go
+++ b/internal/sqlite/database.go
@@ -302,7 +302,7 @@ func (ft *Timestamp) Scan(v any) error {
 	if !ok {
 		return fmt.Errorf("cannot parse %T as timestamp", v)
 	}
-	t, err := time.Parse(dateTimeFormat, str)
+	t, err := time.Parse(DateTimeFormat, str)
 	if err != nil {
 		return err
 	}
@@ -317,7 +317,7 @@ func buildFileURI(path string, writer bool) string {
 	} else {
 		query.Add("mode", "ro")
 	}
-	query.Add("_timefmt", dateTimeFormat)
+	query.Add("_timefmt", DateTimeFormat)
 	query.Add("_pragma", "journal_mode(WAL)")
 	query.Add("_pragma", "synchronous(NORMAL)")
 	query.Add("_pragma", "foreign_keys(ON)")
@@ -337,7 +337,7 @@ func buildMemoryURI(name string, writer bool) string {
 	} else {
 		query.Add("mode", "ro")
 	}
-	query.Add("_timefmt", dateTimeFormat)
+	query.Add("_timefmt", DateTimeFormat)
 	query.Add("_pragma", "foreign_keys(ON)")
 	query.Add("vfs", "memdb")
 	uri := &url.URL{
@@ -348,4 +348,6 @@ func buildMemoryURI(name string, writer bool) string {
 	return uri.String()
 }
 
-const dateTimeFormat = string(sqlite3.TimeFormat4) // SQLite format with millisecconds
+// DateTimeFormat is the default format for encoding/decoding time.Time values in the database.
+// It uses the SQLite format with millisecond precision.
+const DateTimeFormat = string(sqlite3.TimeFormat4)

--- a/internal/sqlite/database.go
+++ b/internal/sqlite/database.go
@@ -55,8 +55,8 @@ func Open(ctx context.Context, path string, options ...Option) (*Database, error
 	// The database/sql.DB is a connection pool. We want to have certain PRAGMAs run at the start of each connection.
 	// By putting them in the URI, they are automatically run for each new connection.
 	// If we just ran the PRAGMAs after opening the connection, they would only be on one of the connections.
-	readerURI := buildFileURI(path, false)
-	writerURI := buildFileURI(path, true)
+	readerURI := buildFileURI(path, false, o.readerPragmas)
+	writerURI := buildFileURI(path, true, o.writerPragmas)
 	return openURI(ctx, readerURI, writerURI, &o)
 }
 
@@ -67,8 +67,8 @@ func OpenMemory(options ...Option) *Database {
 	memdb.Create(name, nil)
 	o := resolveOpts(options...)
 
-	readerURI := buildMemoryURI(name, false)
-	writerURI := buildMemoryURI(name, true)
+	readerURI := buildMemoryURI(name, false, o.readerPragmas)
+	writerURI := buildMemoryURI(name, true, o.writerPragmas)
 	db, err := openURI(context.Background(), readerURI, writerURI, &o)
 	if err != nil {
 		// opening an in-memory database doesn't access any external resources, so this should never happen
@@ -176,9 +176,38 @@ func WithApplicationID(appID ApplicationID) Option {
 	}
 }
 
+// WithReaderPragma sets a PRAGMA for the reader connections only.
+func WithReaderPragma(key, value string) Option {
+	return func(o *opts) {
+		o.readerPragmas = append(o.readerPragmas, pragma{Key: key, Value: value})
+	}
+}
+
+// WithWriterPragma sets a PRAGMA for the writer connection only.
+func WithWriterPragma(key, value string) Option {
+	return func(o *opts) {
+		o.writerPragmas = append(o.writerPragmas, pragma{Key: key, Value: value})
+	}
+}
+
+// WithPragma sets a PRAGMA for both the reader and writer connections.
+func WithPragma(key, value string) Option {
+	return func(o *opts) {
+		o.readerPragmas = append(o.readerPragmas, pragma{Key: key, Value: value})
+		o.writerPragmas = append(o.writerPragmas, pragma{Key: key, Value: value})
+	}
+}
+
 type opts struct {
 	logger        *zap.Logger
 	expectedAppID ApplicationID
+	readerPragmas []pragma
+	writerPragmas []pragma
+}
+
+type pragma struct {
+	Key   string
+	Value string
 }
 
 func (db *Database) Close() error {
@@ -310,7 +339,7 @@ func (ft *Timestamp) Scan(v any) error {
 	return nil
 }
 
-func buildFileURI(path string, writer bool) string {
+func buildFileURI(path string, writer bool, pragmas []pragma) string {
 	query := make(url.Values)
 	if writer {
 		query.Add("mode", "rwc")
@@ -321,6 +350,9 @@ func buildFileURI(path string, writer bool) string {
 	query.Add("_pragma", "journal_mode(WAL)")
 	query.Add("_pragma", "synchronous(NORMAL)")
 	query.Add("_pragma", "foreign_keys(ON)")
+	for _, p := range pragmas {
+		query.Add("_pragma", fmt.Sprintf("%s(%s)", p.Key, p.Value))
+	}
 	uri := &url.URL{
 		Scheme:   "file",
 		Path:     filepath.ToSlash(path),
@@ -330,7 +362,7 @@ func buildFileURI(path string, writer bool) string {
 	return uri.String()
 }
 
-func buildMemoryURI(name string, writer bool) string {
+func buildMemoryURI(name string, writer bool, pragmas []pragma) string {
 	query := make(url.Values)
 	if writer {
 		query.Add("mode", "rwc")
@@ -339,6 +371,9 @@ func buildMemoryURI(name string, writer bool) string {
 	}
 	query.Add("_timefmt", DateTimeFormat)
 	query.Add("_pragma", "foreign_keys(ON)")
+	for _, p := range pragmas {
+		query.Add("_pragma", fmt.Sprintf("%s(%s)", p.Key, p.Value))
+	}
 	query.Add("vfs", "memdb")
 	uri := &url.URL{
 		Scheme:   "file",

--- a/pkg/app/controller.go
+++ b/pkg/app/controller.go
@@ -114,6 +114,12 @@ func Bootstrap(ctx context.Context, config sysconf.Config) (*Controller, error) 
 	}
 
 	// configurable shared storage for more permanent data
+	storesConfig := config.Stores
+	if storesConfig == nil {
+		storesConfig = &stores.Config{}
+	}
+	storesConfig.DataDir = config.DataDir
+	storesConfig.Logger = logger.Named("stores")
 	store := stores.New(config.Stores)
 
 	certConfig := config.CertConfig

--- a/pkg/app/stores/stores.go
+++ b/pkg/app/stores/stores.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sync"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 
 	"github.com/vanti-dev/sc-bos/internal/util/pgxutil"
+	"github.com/vanti-dev/sc-bos/pkg/history/sqlitestore"
 )
 
 var (
@@ -20,29 +23,46 @@ var (
 // Config configures shared storage (dbs) for systems on this node.
 type Config struct {
 	Postgres *PostgresConfig `json:"postgres,omitempty"`
+	// Local directory for storing database files.
+	DataDir string      `json:"-"`
+	Logger  *zap.Logger `json:"-"`
 }
 
 type PostgresConfig struct {
 	pgxutil.ConnectConfig
 }
 
+// New creates a new Stores instance based on cfg, which must be non-nil.
 func New(cfg *Config) *Stores {
-	s := &Stores{}
-	if cfg != nil && cfg.Postgres != nil {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	s := &Stores{
+		sqliteHistoryStore: sqliteHistoryStore{
+			path: filepath.Join(cfg.DataDir, defaultSqliteHistoryPath),
+		},
+	}
+	if cfg.Postgres != nil {
 		s.postgresStore.cfg = cfg.Postgres
 	}
 	return s
 }
 
+const defaultSqliteHistoryPath = "data/history.sqlite3"
+
 // Stores provides access to shared storage connections/clients.
 type Stores struct {
 	postgresStore
+	sqliteHistoryStore
 }
 
 // Close closes all stores.
 func (s *Stores) Close() error {
 	return multierr.Combine(
 		s.postgresStore.close(),
+		s.sqliteHistoryStore.close(),
 	)
 }
 
@@ -97,4 +117,42 @@ func (s *postgresStore) close() error {
 	s.admin = nil
 
 	return nil
+}
+
+type sqliteHistoryStore struct {
+	path   string
+	logger *zap.Logger
+
+	mu sync.Mutex
+	db *sqlitestore.Database
+}
+
+// SqliteHistory returns a shared sqlite history database.
+// The database is lazily opened on the first call.
+// Do not close the database - it will be closed when the Stores are closed.
+func (s *sqliteHistoryStore) SqliteHistory(ctx context.Context) (*sqlitestore.Database, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		db, err := sqlitestore.Open(ctx, s.path, sqlitestore.WithLogger(s.logger))
+		if err != nil {
+			return nil, err
+		}
+		s.db = db
+	}
+
+	return s.db, nil
+}
+
+func (s *sqliteHistoryStore) close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	err := s.db.Close()
+	s.db = nil
+	return err
 }

--- a/pkg/history/sqlitestore/migrations/0001_initial_schema.sql
+++ b/pkg/history/sqlitestore/migrations/0001_initial_schema.sql
@@ -1,0 +1,23 @@
+CREATE TABLE history_meta (
+    key             TEXT PRIMARY KEY,
+    value           ANY
+);
+
+INSERT INTO history_meta (key, value) VALUES
+    ('epoch', datetime('subsec')); -- don't modify this once data is inserted, as it changes the meaning of the data
+
+CREATE TABLE history_sources (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT, -- use AUTOINCREMENT to ensure IDs are never reused
+    source          TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE history (
+    id              INTEGER PRIMARY KEY,
+    source_id       INTEGER NOT NULL,
+    epoch_offset_ms INTEGER NOT NULL,
+    payload         BLOB,
+
+    FOREIGN KEY (source_id) REFERENCES history_sources(id)
+);
+
+CREATE INDEX history_source_create_time_idx ON history (source_id, epoch_offset_ms);

--- a/pkg/history/sqlitestore/migrations/0001_initial_schema.sql
+++ b/pkg/history/sqlitestore/migrations/0001_initial_schema.sql
@@ -1,23 +1,14 @@
-CREATE TABLE history_meta (
-    key             TEXT PRIMARY KEY,
-    value           ANY
-);
-
-INSERT INTO history_meta (key, value) VALUES
-    ('epoch', datetime('subsec')); -- don't modify this once data is inserted, as it changes the meaning of the data
-
 CREATE TABLE history_sources (
     id              INTEGER PRIMARY KEY AUTOINCREMENT, -- use AUTOINCREMENT to ensure IDs are never reused
     source          TEXT NOT NULL UNIQUE
 );
 
 CREATE TABLE history (
-    id              INTEGER PRIMARY KEY,
+    id              INTEGER PRIMARY KEY, -- encodes both the timestamp and a sequence number
     source_id       INTEGER NOT NULL,
-    epoch_offset_ms INTEGER NOT NULL,
     payload         BLOB,
 
     FOREIGN KEY (source_id) REFERENCES history_sources(id)
 );
 
-CREATE INDEX history_source_create_time_idx ON history (source_id, epoch_offset_ms);
+CREATE INDEX history_source_idx ON history (source_id, id);

--- a/pkg/history/sqlitestore/migrations/0001_initial_schema.sql
+++ b/pkg/history/sqlitestore/migrations/0001_initial_schema.sql
@@ -12,3 +12,12 @@ CREATE TABLE history (
 );
 
 CREATE INDEX history_source_idx ON history (source_id, id);
+
+-- expanded view of history data, useful when manually exploring data
+CREATE VIEW history_denorm (id, timestamp, source, payload) AS
+    SELECT h.id,
+           datetime(CAST((h.id / 1000000) AS REAL) / 1000.0, 'unixepoch', 'subsec'),
+           hs.source,
+           h.payload
+    FROM history h
+    LEFT OUTER JOIN history_sources hs ON h.source_id = hs.id;

--- a/pkg/history/sqlitestore/opts.go
+++ b/pkg/history/sqlitestore/opts.go
@@ -1,0 +1,18 @@
+package sqlitestore
+
+import (
+	"go.uber.org/zap"
+)
+
+type opts struct {
+	logger *zap.Logger
+}
+
+type Option func(*opts)
+
+// WithLogger is an option to set the logger used by the store.
+func WithLogger(logger *zap.Logger) Option {
+	return func(s *opts) {
+		s.logger = logger
+	}
+}

--- a/pkg/history/sqlitestore/opts.go
+++ b/pkg/history/sqlitestore/opts.go
@@ -1,6 +1,8 @@
 package sqlitestore
 
 import (
+	"time"
+
 	"go.uber.org/zap"
 )
 
@@ -14,5 +16,56 @@ type Option func(*opts)
 func WithLogger(logger *zap.Logger) Option {
 	return func(s *opts) {
 		s.logger = logger
+	}
+}
+
+type writeOpts struct {
+	enableMaxCount bool
+	maxCount       int64
+	trimTime       time.Time
+	trimAge        time.Duration
+}
+
+type WriteOption func(*writeOpts)
+
+// WithMaxCount will automatically delete old records after the write operation is complete, so that there at most
+// maxCount records for each source involved in the write operation.
+// Like calling Database.TrimTime after each write, but happens within the same transaction.
+func WithMaxCount(maxCount int64) WriteOption {
+	if maxCount < 0 {
+		panic("maxCount must be >= 0")
+	}
+	return func(o *writeOpts) {
+		o.maxCount = maxCount
+		o.enableMaxCount = true
+	}
+}
+
+// WithNoMaxCount disables automatic deletion, cancelling a previous WithMaxCount option.
+func WithNoMaxCount() WriteOption {
+	return func(o *writeOpts) {
+		o.enableMaxCount = false
+	}
+}
+
+// WithEarliestTime will delete all records older than the given time after the write operation is complete.
+// Only sources involved in the write operation are affected.
+// Like calling Database.TrimTime after each write, but happens within the same transaction.
+// Passing a zero time disables automatic deletion, cancelling a previous WithEarliestTime or WithMaxAge option.
+func WithEarliestTime(t time.Time) WriteOption {
+	return func(o *writeOpts) {
+		o.trimAge = 0
+		o.trimTime = t
+	}
+}
+
+// WithMaxAge will delete all records older than the given duration after the write operation is complete.
+// Works the same as WithEarliestTime, but the time is calculated as time.Now().Add(-d) at the time of each write operation.
+// Overrides any previous WithEarliestTime or WithMaxAge option.
+// Passing a zero duration disables automatic deletion, cancelling a previous WithEarliestTime or WithMaxAge option.
+func WithMaxAge(d time.Duration) WriteOption {
+	return func(o *writeOpts) {
+		o.trimTime = time.Time{}
+		o.trimAge = d
 	}
 }

--- a/pkg/history/sqlitestore/store.go
+++ b/pkg/history/sqlitestore/store.go
@@ -32,9 +32,8 @@ var migrationFS embed.FS
 var schema = sqlite.MustLoadVersionedSchema(migrationFS, "migrations")
 
 type Database struct {
-	db       *sqlite.Database
-	maxCount int64
-	maxAge   time.Duration
+	db     *sqlite.Database
+	logger *zap.Logger
 }
 
 func Open(ctx context.Context, path string, options ...Option) (*Database, error) {
@@ -60,13 +59,17 @@ func Open(ctx context.Context, path string, options ...Option) (*Database, error
 		return nil, errors.Join(err, db.Close())
 	}
 
-	return &Database{db: db}, nil
+	return &Database{
+		db:     db,
+		logger: o.logger,
+	}, nil
 }
 
-func (d *Database) OpenStore(source string) *Store {
+func (d *Database) OpenStore(source string, opts ...WriteOption) *Store {
 	return &Store{
 		database: d,
 		source:   source,
+		opts:     opts,
 	}
 }
 
@@ -74,9 +77,9 @@ func (d *Database) Close() error {
 	return d.db.Close()
 }
 
-func (d *Database) Insert(ctx context.Context, record Record) (Record, error) {
+func (d *Database) Insert(ctx context.Context, record Record, opts ...WriteOption) (Record, error) {
 	toInsert := []Record{record}
-	err := d.InsertBulk(ctx, toInsert)
+	err := d.InsertBulk(ctx, toInsert, opts...)
 	if err != nil {
 		return Record{}, err
 	}
@@ -85,7 +88,13 @@ func (d *Database) Insert(ctx context.Context, record Record) (Record, error) {
 
 // InsertBulk inserts multiple records into the database in a single transaction.
 // Mutates records to set the ID field for each inserted record.
-func (d *Database) InsertBulk(ctx context.Context, records []Record) error {
+func (d *Database) InsertBulk(ctx context.Context, records []Record, opts ...WriteOption) error {
+	o := writeOpts{}
+	for _, option := range opts {
+		option(&o)
+	}
+
+	txTime := time.Now()
 	err := d.db.WriteTx(ctx, func(tx *sql.Tx) (err error) {
 		sources, err := newSourceAllocator(ctx, tx)
 		if err != nil {
@@ -104,7 +113,9 @@ func (d *Database) InsertBulk(ctx context.Context, records []Record) error {
 			err = errors.Join(err, stmt.Close())
 		}()
 
+		modifiedSources := make(map[string]struct{})
 		for i, record := range records {
+			modifiedSources[record.Source] = struct{}{}
 			srcID, err := sources.getOrInsertSource(ctx, record.Source)
 			if err != nil {
 				return err
@@ -121,7 +132,26 @@ func (d *Database) InsertBulk(ctx context.Context, records []Record) error {
 			records[i].ID = recordID
 			records[i].CreateTime = recordID.Timestamp() // truncated and without time zone
 		}
-		return stmt.Close()
+		for source := range modifiedSources {
+			if o.enableMaxCount {
+				_, err = d.trimCount(ctx, tx, source, o.maxCount)
+				if err != nil {
+					return err
+				}
+			}
+			if !o.trimTime.IsZero() {
+				_, err = d.trimTime(ctx, tx, source, o.trimTime)
+				if err != nil {
+					return err
+				}
+			} else if o.trimAge > 0 {
+				_, err = d.trimTime(ctx, tx, source, txTime.Add(-o.trimAge))
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return nil
 	})
 	return err
 }
@@ -214,6 +244,124 @@ func (d *Database) Size(ctx context.Context) (int64, error) {
 	return size, err
 }
 
+// TrimTime deletes all records with a timestamp before the specified time.
+// If source is non-empty, only deletes records from that source. If source is empty, deletes records from all sources.
+// Returns the number of records deleted.
+func (d *Database) TrimTime(ctx context.Context, source string, before time.Time) (int64, error) {
+	var deleted int64
+	err := d.db.WriteTx(ctx, func(tx *sql.Tx) (err error) {
+		deleted, err = d.trimTime(ctx, tx, source, before)
+		return
+	})
+	return deleted, err
+}
+
+func (d *Database) trimTime(ctx context.Context, tx *sql.Tx, source string, before time.Time) (deleted int64, err error) {
+	recordID := MakeRecordID(before, 0)
+	if source == "" {
+		deleted, err = d.deleteAllBefore(ctx, tx, recordID)
+	} else {
+		deleted, err = d.deleteSourceBefore(ctx, tx, source, recordID)
+	}
+	return deleted, err
+}
+
+// deletes all records with ID less than the specified ID, for all sources
+func (d *Database) deleteAllBefore(ctx context.Context, tx *sql.Tx, id RecordID) (int64, error) {
+	res, err := tx.ExecContext(ctx, "DELETE FROM history WHERE id < ?", id)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// deletes all records for the specified source name with ID less than the specified ID
+func (d *Database) deleteSourceBefore(ctx context.Context, tx *sql.Tx, source string, id RecordID) (int64, error) {
+	res, err := tx.ExecContext(ctx, `
+		DELETE FROM history WHERE id < ? AND source_id IN (
+			SELECT id FROM history_sources WHERE source = ?
+		)
+	`, id, source)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// deletes all records for the specified source name
+func (d *Database) deleteSource(ctx context.Context, tx *sql.Tx, source string) (int64, error) {
+	res, err := tx.ExecContext(ctx, `
+		DELETE FROM history WHERE source_id IN (SELECT id FROM history_sources WHERE source = ?)
+    `, source)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// get record ID for the nth newest record within the specified source
+// e.g. n=0 returns the newest record, n=1 the second newest, etc.
+// Returns sql.ErrNoRows if there are fewer than n+1 records for the source.
+func (d *Database) nthNewestRecordID(ctx context.Context, tx *sql.Tx, source string, n int64) (RecordID, error) {
+	var boundary RecordID
+	err := tx.QueryRowContext(ctx, `
+		SELECT history.id FROM history
+		INNER JOIN history_sources ON history.source_id = history_sources.id
+		WHERE history_sources.source = ?
+		ORDER BY history.id DESC LIMIT 1 OFFSET ?
+   	`, source, n).Scan(&boundary)
+	if err != nil {
+		return 0, err
+	}
+	return boundary, nil
+}
+
+// TrimCount deletes the oldest records for the specified source if the total number of records exceeds the given limit.
+// After deletion, the total number of records for that source will be at most 'limit'.
+// Source must be non-empty.
+// Returns the number of records deleted.
+func (d *Database) TrimCount(ctx context.Context, source string, limit int64) (int64, error) {
+	if source == "" {
+		return 0, errors.New("source must be non-empty")
+	}
+	if limit < 0 {
+		return 0, errors.New("limit must be non-negative")
+	}
+	var deleted int64
+	err := d.db.WriteTx(ctx, func(tx *sql.Tx) (err error) {
+		deleted, err = d.trimCount(ctx, tx, source, limit)
+		return err
+	})
+	return deleted, err
+}
+
+func (d *Database) trimCount(ctx context.Context, tx *sql.Tx, source string, limit int64) (int64, error) {
+	// we either need to delete all records older than boundary, or all records
+	var (
+		boundary  RecordID
+		deleteAll bool
+		err       error
+	)
+	if limit == 0 {
+		deleteAll = true
+	} else {
+		boundary, err = d.nthNewestRecordID(ctx, tx, source, limit-1)
+		if errors.Is(err, sql.ErrNoRows) {
+			deleteAll = true
+		} else if err != nil {
+			return 0, err
+		}
+	}
+
+	var deleted int64
+	if deleteAll {
+		deleted, err = d.deleteSource(ctx, tx, source)
+	} else {
+		deleted, err = d.deleteSourceBefore(ctx, tx, source, boundary)
+	}
+	return deleted, err
+}
+
 type Record struct {
 	ID         RecordID
 	Source     string
@@ -224,6 +372,7 @@ type Record struct {
 type Store struct {
 	database *Database
 	source   string
+	opts     []WriteOption // passed to every write operation
 
 	from, to history.Record
 }
@@ -234,7 +383,7 @@ func (s *Store) Append(ctx context.Context, payload []byte) (history.Record, err
 		Source:     s.source,
 		CreateTime: now,
 		Payload:    payload,
-	})
+	}, s.opts...)
 	if err != nil {
 		return history.Record{}, err
 	}
@@ -251,6 +400,7 @@ func (s *Store) Slice(from, to history.Record) history.Slice {
 		source:   s.source,
 		from:     from,
 		to:       to,
+		opts:     s.opts,
 	}
 }
 

--- a/pkg/history/sqlitestore/store.go
+++ b/pkg/history/sqlitestore/store.go
@@ -1,3 +1,11 @@
+// Package sqlitestore implements a history store using SQLite as the backend database.
+//
+// Implements the history.Store interface (call Database.OpenStore).
+// Many sources can share the same Database instance.
+//
+// Limitations:
+//   - Maximum of 1,000,000 records can be created within the same millisecond timestamp, due to the combined
+//     timestamp+serial RecordID format.
 package sqlitestore
 
 import (
@@ -65,91 +73,74 @@ func (d *Database) Close() error {
 	return d.db.Close()
 }
 
-func (d *Database) Insert(ctx context.Context, source string, at time.Time, payload []byte) (history.Record, error) {
-	var id int64
-	err := d.db.WriteTx(ctx, func(tx *sql.Tx) error {
-		epoch, err := readEpoch(ctx, tx)
-		if err != nil {
-			return err
-		}
-
-		srcID, err := sourceID(ctx, tx, source, true)
-		if err != nil {
-			return err
-		}
-
-		offset := at.UTC().Sub(epoch).Milliseconds()
-
-		err = tx.QueryRowContext(ctx, "INSERT INTO history (source_id, epoch_offset_ms, payload) VALUES (?, ?, ?) RETURNING id",
-			srcID, offset, payload).Scan(&id)
-		return err
-	})
-	return history.Record{
-		ID:         strconv.FormatInt(id, 10),
-		CreateTime: at,
-		Payload:    payload,
-	}, err
-}
-
-type InsertRecord struct {
-	Source     string
-	CreateTime time.Time
-	Payload    []byte
+func (d *Database) Insert(ctx context.Context, record Record) (Record, error) {
+	toInsert := []Record{record}
+	err := d.InsertBulk(ctx, toInsert)
+	if err != nil {
+		return Record{}, err
+	}
+	return toInsert[0], nil
 }
 
 // InsertBulk inserts multiple records into the database in a single transaction.
-// Returns a slice of inserted record IDs in the same order as the input records.
-func (d *Database) InsertBulk(ctx context.Context, records []InsertRecord) (ids []string, err error) {
-	err = d.db.WriteTx(ctx, func(tx *sql.Tx) error {
-		epoch, err := readEpoch(ctx, tx)
+// Mutates records to set the ID field for each inserted record.
+func (d *Database) InsertBulk(ctx context.Context, records []Record) error {
+	err := d.db.WriteTx(ctx, func(tx *sql.Tx) (err error) {
+		sources, err := newSourceAllocator(ctx, tx)
+		if err != nil {
+			return err
+		}
+		idAlloc, err := newRecordIDAllocator(ctx, tx)
 		if err != nil {
 			return err
 		}
 
-		srcIDCache := make(map[string]int64)
-		getSourceID := func(source string) (int64, error) {
-			if id, ok := srcIDCache[source]; ok {
-				return id, nil
-			}
-			srcID, err := sourceID(ctx, tx, source, true)
-			if err != nil {
-				return 0, err
-			}
-			srcIDCache[source] = srcID
-			return srcID, nil
-		}
-
-		stmt, err := tx.PrepareContext(ctx, "INSERT INTO history (source_id, epoch_offset_ms, payload) VALUES (?, ?, ?) RETURNING id")
+		stmt, err := tx.PrepareContext(ctx, "INSERT INTO history (id, source_id, payload) VALUES (?, ?, ?);")
 		if err != nil {
 			return err
 		}
-		for _, record := range records {
-			var id int64
-			offset := record.CreateTime.UTC().Sub(epoch).Milliseconds()
-			srcID, err := getSourceID(record.Source)
+		defer func() {
+			err = errors.Join(err, stmt.Close())
+		}()
+
+		for i, record := range records {
+			srcID, err := sources.getOrInsertSource(ctx, record.Source)
 			if err != nil {
 				return err
 			}
-			err = stmt.QueryRowContext(ctx, srcID, offset, record.Payload).Scan(&id)
+			recordID, err := idAlloc.allocateRecordID(ctx, record.CreateTime)
 			if err != nil {
-				return errors.Join(err, stmt.Close())
+				return err
 			}
-			ids = append(ids, strconv.FormatInt(id, 10))
+
+			_, err = stmt.ExecContext(ctx, recordID, srcID, record.Payload)
+			if err != nil {
+				return err
+			}
+			records[i].ID = recordID
+			records[i].CreateTime = recordID.Timestamp() // truncated and without time zone
 		}
 		return stmt.Close()
 	})
-	return ids, err
+	return err
 }
 
-func (d *Database) Read(ctx context.Context, source string, from, to history.Record, into []history.Record, desc bool) (int, error) {
-	var count int
-	err := d.db.ReadTx(ctx, func(tx *sql.Tx) error {
-		epoch, err := readEpoch(ctx, tx)
-		if err != nil {
-			return err
-		}
+// Read reads records from the database into the provided slice.
+// If source is non-empty, it filters records by source.
+// If from and to are non-zero, it filters records by ID range, greater-or-equal-to from, and less-than to.
+// Returns number of records read and any error encountered.
+// Size of the slice limits the number of records to read.
+func (d *Database) Read(ctx context.Context, source string, from, to RecordID, desc bool, into []Record) (n int, err error) {
+	err = d.read(ctx, source, from, to, desc, func(record Record) {
+		into[n] = record
+		n++
+	})
+	return n, err
+}
 
-		filters, args := buildFilters(source, epoch, from, to)
+func (d *Database) read(ctx context.Context, source string, from, to RecordID, desc bool, cb func(Record)) error {
+	err := d.db.ReadTx(ctx, func(tx *sql.Tx) error {
+		filters, args := buildFilters(source, from, to)
 
 		order := "ASC"
 		if desc {
@@ -157,47 +148,42 @@ func (d *Database) Read(ctx context.Context, source string, from, to history.Rec
 		}
 
 		query := fmt.Sprintf(`
-			SELECT history.id, epoch_offset_ms, payload
+			SELECT history.id, history_sources.source, payload
             FROM history
             INNER JOIN history_sources ON history.source_id = history_sources.id
 			WHERE %s
-            ORDER BY history.id %s
-			LIMIT ?;
-        `, filters, order)
-		args = append(args, len(into))
+            ORDER BY history.id %s;
+            `, filters, order)
 
 		rows, err := tx.QueryContext(ctx, query, args...)
 		if err != nil {
 			return err
 		}
+		defer func() {
+			_ = rows.Close()
+		}()
 
 		for rows.Next() {
 			var (
-				id       int64
-				offsetMS int64
-				payload  []byte
+				id      RecordID
+				src     string
+				payload []byte
 			)
-			err = rows.Scan(&id, &offsetMS, &payload)
+			err = rows.Scan(&id, &src, &payload)
 			if err != nil {
 				return err
 			}
-			into[count] = buildRecord(id, epoch, offsetMS, payload)
-			count++
+			cb(Record{ID: id, CreateTime: id.Timestamp(), Source: src, Payload: payload})
 		}
 		return rows.Err()
 	})
-	return count, err
+	return err
 }
 
-func (d *Database) Count(ctx context.Context, source string, from, to history.Record) (int, error) {
+func (d *Database) Count(ctx context.Context, source string, from, to RecordID) (int, error) {
 	var count int
 	err := d.db.ReadTx(ctx, func(tx *sql.Tx) error {
-		epoch, err := readEpoch(ctx, tx)
-		if err != nil {
-			return err
-		}
-
-		filters, args := buildFilters(source, epoch, from, to)
+		filters, args := buildFilters(source, from, to)
 
 		query := fmt.Sprintf(`
 			SELECT COUNT(*)
@@ -206,7 +192,7 @@ func (d *Database) Count(ctx context.Context, source string, from, to history.Re
 			WHERE %s;
 		`, filters)
 
-		err = tx.QueryRowContext(ctx, query, args...).Scan(&count)
+		err := tx.QueryRowContext(ctx, query, args...).Scan(&count)
 		return err
 	})
 	return count, err
@@ -220,6 +206,13 @@ func (d *Database) Size(ctx context.Context) (int64, error) {
 	return size, err
 }
 
+type Record struct {
+	ID         RecordID
+	Source     string
+	CreateTime time.Time
+	Payload    []byte
+}
+
 type Store struct {
 	database *Database
 	source   string
@@ -229,11 +222,19 @@ type Store struct {
 
 func (s *Store) Append(ctx context.Context, payload []byte) (history.Record, error) {
 	now := time.Now()
-	record, err := s.database.Insert(ctx, s.source, now, payload)
+	record, err := s.database.Insert(ctx, Record{
+		Source:     s.source,
+		CreateTime: now,
+		Payload:    payload,
+	})
 	if err != nil {
 		return history.Record{}, err
 	}
-	return record, nil
+	return history.Record{
+		ID:         record.ID.String(),
+		CreateTime: record.CreateTime,
+		Payload:    record.Payload,
+	}, nil
 }
 
 func (s *Store) Slice(from, to history.Record) history.Slice {
@@ -254,77 +255,228 @@ func (s *Store) ReadDesc(ctx context.Context, into []history.Record) (int, error
 }
 
 func (s *Store) read(ctx context.Context, into []history.Record, desc bool) (int, error) {
-	return s.database.Read(ctx, s.source, s.from, s.to, into, desc)
-}
-
-func (s *Store) Len(ctx context.Context) (int, error) {
-	return s.database.Count(ctx, s.source, s.from, s.to)
-}
-
-func readEpoch(ctx context.Context, tx *sql.Tx) (time.Time, error) {
-	var epochStr string
-	err := tx.QueryRowContext(ctx, "SELECT value FROM history_meta WHERE key = 'epoch'").Scan(&epochStr)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return time.Parse(sqlite.DateTimeFormat, epochStr)
-}
-
-func sourceID(ctx context.Context, tx *sql.Tx, source string, create bool) (int64, error) {
-	if create {
-		_, err := tx.ExecContext(ctx, "INSERT OR IGNORE INTO history_sources (source) VALUES (?)", source)
-		if err != nil {
-			return 0, err
-		}
-	}
-
-	var id int64
-	err := tx.QueryRowContext(ctx, "SELECT id FROM history_sources WHERE source = ?", source).Scan(&id)
+	fromBound, err := calcBound(s.from)
 	if err != nil {
 		return 0, err
 	}
+	toBound, err := calcBound(s.to)
+	if err != nil {
+		return 0, err
+	}
+
+	var n int
+	err = s.database.read(ctx, s.source, fromBound, toBound, desc, func(record Record) {
+		into[n] = history.Record{
+			ID:         record.ID.String(),
+			CreateTime: record.CreateTime,
+			Payload:    record.Payload,
+		}
+		n++
+	})
+	return n, err
+}
+
+func (s *Store) Len(ctx context.Context) (int, error) {
+	fromBound, err := calcBound(s.from)
+	if err != nil {
+		return 0, err
+	}
+	toBound, err := calcBound(s.to)
+	if err != nil {
+		return 0, err
+	}
+
+	return s.database.Count(ctx, s.source, fromBound, toBound)
+}
+
+func calcBound(limit history.Record) (RecordID, error) {
+	if limit.ID != "" {
+		id, err := ParseRecordID(limit.ID)
+		if err != nil {
+			return 0, err
+		}
+		return id, nil
+	}
+
+	if !limit.CreateTime.IsZero() {
+		id := MakeRecordID(limit.CreateTime, 0)
+		return id, nil
+	}
+
+	// zero value is sentinel meaning "no bound"
+	return 0, nil
+}
+
+// builds an SQL term for filtering records based on source and ID range.
+// Also returns a slice of parameters to be passed when executing the query.
+// If no filtering is to be performed, returns a dummy condition to maintain valid SQL syntax.
+func buildFilters(source string, from, to RecordID) (string, []any) {
+	var filters []string
+	var args []any
+	if source != "" {
+		filters = []string{"history_sources.source = ?"}
+		args = []any{source}
+	}
+
+	if from != 0 {
+		filters = append(filters, "history.id >= ?")
+		args = append(args, from)
+	}
+
+	if to != 0 {
+		filters = append(filters, "history.id < ?")
+		args = append(args, to)
+	}
+
+	if len(filters) > 0 {
+		return strings.Join(filters, " AND "), args
+	} else {
+		return "1 = 1", nil // no filtering, return a dummy condition
+	}
+}
+
+type RecordID int64
+
+func MakeRecordID(ts time.Time, serial int) RecordID {
+	if serial < 0 || serial >= 1_000_000 {
+		panic("serial must be in range [0, 999999]")
+	}
+	return RecordID(ts.UnixMilli()*1_000_000 + int64(serial))
+}
+
+func ParseRecordID(s string) (RecordID, error) {
+	id, err := strconv.ParseInt(s, 16, 64)
+	if err != nil {
+		return 0, ErrInvalidRecordID
+	}
+	if id < 0 {
+		return 0, ErrInvalidRecordID
+	}
+	return RecordID(id), nil
+}
+
+func (id RecordID) Timestamp() time.Time {
+	return time.UnixMilli(int64(id) / 1_000_000)
+}
+
+func (id RecordID) Serial() int {
+	return int(int64(id) % 1_000_000)
+}
+
+func (id RecordID) Next() (RecordID, bool) {
+	if id.Serial() == 1_000_000-1 {
+		// incrementing the serial number would overflow the millisecond timestamp
+		return 0, false
+	}
+	return RecordID(int64(id) + 1), true
+}
+
+func (id RecordID) String() string {
+	return fmt.Sprintf("%016X", int64(id))
+}
+
+type sourceAllocator struct {
+	sources    map[string]int64 // source name to ID mapping
+	insertStmt *sql.Stmt        // prepared statement for inserting new sources if they don't exist
+	queryStmt  *sql.Stmt        // prepared statement for querying source IDs
+}
+
+func newSourceAllocator(ctx context.Context, tx *sql.Tx) (*sourceAllocator, error) {
+	sc := &sourceAllocator{
+		sources: make(map[string]int64),
+	}
+
+	var err error
+	sc.insertStmt, err = tx.PrepareContext(ctx, "INSERT OR IGNORE INTO history_sources (source) VALUES (?)")
+	if err != nil {
+		return nil, err
+	}
+
+	sc.queryStmt, err = tx.PrepareContext(ctx, "SELECT id FROM history_sources WHERE source = ?")
+	if err != nil {
+		return nil, err
+	}
+
+	return sc, nil
+}
+
+func (sa *sourceAllocator) getOrInsertSource(ctx context.Context, source string) (int64, error) {
+	if id, ok := sa.sources[source]; ok {
+		return id, nil
+	}
+
+	// Insert the source if it doesn't exist
+	_, err := sa.insertStmt.ExecContext(ctx, source)
+	if err != nil {
+		return 0, err
+	}
+
+	// Query the ID of the source
+	var id int64
+	err = sa.queryStmt.QueryRowContext(ctx, source).Scan(&id)
+	if err != nil {
+		return 0, err
+	}
+
+	sa.sources[source] = id
 	return id, nil
 }
 
-func buildFilters(source string, epoch time.Time, from, to history.Record) (string, []any) {
-	filters := []string{"history_sources.source = ?"}
-	args := []any{source}
+type recordIDAllocator struct {
+	maxRecordIDByTS map[int64]RecordID // map from millisecond timestamp to the max record ID within that ts
+	stmt            *sql.Stmt          // prepared statement for querying the max record ID for a given millisecond timestamp
+}
 
-	if !from.IsZero() {
-		if from.ID != "" {
-			filters = append(filters, "history.id >= ?")
-			args = append(args, from.ID)
-		} else if !from.CreateTime.IsZero() {
-			filters = append(filters, "history.epoch_offset_ms >= ?")
-			args = append(args, toEpochOffset(epoch, from.CreateTime))
+func newRecordIDAllocator(ctx context.Context, tx *sql.Tx) (*recordIDAllocator, error) {
+	ra := &recordIDAllocator{
+		maxRecordIDByTS: make(map[int64]RecordID),
+	}
+
+	var err error
+	ra.stmt, err = tx.PrepareContext(ctx, "SELECT MAX(id) FROM history WHERE id >= (1000000 * ?1) AND id < (1000000 * (?1 + 1))")
+	if err != nil {
+		return nil, err
+	}
+
+	return ra, nil
+}
+
+func (ra *recordIDAllocator) allocateRecordID(ctx context.Context, ts time.Time) (RecordID, error) {
+	var (
+		anyExist bool
+		highest  RecordID
+	)
+
+	highest, ok := ra.maxRecordIDByTS[ts.UnixMilli()]
+	if ok {
+		anyExist = true
+	} else {
+		// Query the highest record ID for this millisecond timestamp
+		var id sql.NullInt64
+		err := ra.stmt.QueryRowContext(ctx, ts.UnixMilli()).Scan(&id)
+		if err != nil {
+			return 0, err
+		}
+		if id.Valid {
+			highest = RecordID(id.Int64)
+			anyExist = true
 		}
 	}
 
-	if !to.IsZero() {
-		if to.ID != "" {
-			filters = append(filters, "history.id < ?")
-			args = append(args, to.ID)
-		} else if !to.CreateTime.IsZero() {
-			filters = append(filters, "history.epoch_offset_ms < ?")
-			args = append(args, toEpochOffset(epoch, to.CreateTime))
+	var next RecordID
+	if anyExist {
+		next, ok = highest.Next()
+		if !ok {
+			return 0, ErrTooManyRecords
 		}
+	} else {
+		next = MakeRecordID(ts, 0)
 	}
-
-	return strings.Join(filters, " AND "), args
+	ra.maxRecordIDByTS[ts.UnixMilli()] = next
+	return next, nil
 }
 
-func buildRecord(id int64, epoch time.Time, offsetMS int64, payload []byte) history.Record {
-	return history.Record{
-		ID:         strconv.FormatInt(id, 10),
-		CreateTime: epoch.Add(time.Duration(offsetMS) * time.Millisecond),
-		Payload:    payload,
-	}
-}
-
-func toEpochOffset(epoch time.Time, at time.Time) int64 {
-	return at.UTC().Sub(epoch).Milliseconds()
-}
-
-func fromEpochOffset(epoch time.Time, offsetMS int64) time.Time {
-	return epoch.Add(time.Duration(offsetMS) * time.Millisecond)
-}
+var (
+	ErrTooManyRecords  = errors.New("too many records")
+	ErrInvalidRecordID = errors.New("invalid record ID format")
+)

--- a/pkg/history/sqlitestore/store.go
+++ b/pkg/history/sqlitestore/store.go
@@ -49,6 +49,7 @@ func Open(ctx context.Context, path string, options ...Option) (*Database, error
 	db, err := sqlite.Open(ctx, path,
 		sqlite.WithApplicationID(appID),
 		sqlite.WithLogger(o.logger),
+		sqlite.WithWriterPragma("auto_vacuum", "INCREMENTAL"),
 	)
 	if err != nil {
 		return nil, err
@@ -131,14 +132,18 @@ func (d *Database) InsertBulk(ctx context.Context, records []Record) error {
 // Returns number of records read and any error encountered.
 // Size of the slice limits the number of records to read.
 func (d *Database) Read(ctx context.Context, source string, from, to RecordID, desc bool, into []Record) (n int, err error) {
-	err = d.read(ctx, source, from, to, desc, func(record Record) {
+	err = d.read(ctx, source, from, to, desc, func(record Record) bool {
+		if n >= len(into) {
+			return false
+		}
 		into[n] = record
 		n++
+		return true
 	})
 	return n, err
 }
 
-func (d *Database) read(ctx context.Context, source string, from, to RecordID, desc bool, cb func(Record)) error {
+func (d *Database) read(ctx context.Context, source string, from, to RecordID, desc bool, cb func(Record) bool) error {
 	err := d.db.ReadTx(ctx, func(tx *sql.Tx) error {
 		filters, args := buildFilters(source, from, to)
 
@@ -173,7 +178,10 @@ func (d *Database) read(ctx context.Context, source string, from, to RecordID, d
 			if err != nil {
 				return err
 			}
-			cb(Record{ID: id, CreateTime: id.Timestamp(), Source: src, Payload: payload})
+			if !cb(Record{ID: id, CreateTime: id.Timestamp(), Source: src, Payload: payload}) {
+				// Callback returned false, stop reading more records
+				break
+			}
 		}
 		return rows.Err()
 	})
@@ -265,13 +273,18 @@ func (s *Store) read(ctx context.Context, into []history.Record, desc bool) (int
 	}
 
 	var n int
-	err = s.database.read(ctx, s.source, fromBound, toBound, desc, func(record Record) {
+	err = s.database.read(ctx, s.source, fromBound, toBound, desc, func(record Record) bool {
+		if n >= len(into) {
+			// No more space in the slice, stop reading
+			return false
+		}
 		into[n] = history.Record{
 			ID:         record.ID.String(),
 			CreateTime: record.CreateTime,
 			Payload:    record.Payload,
 		}
 		n++
+		return true
 	})
 	return n, err
 }

--- a/pkg/history/sqlitestore/store.go
+++ b/pkg/history/sqlitestore/store.go
@@ -1,0 +1,330 @@
+package sqlitestore
+
+import (
+	"context"
+	"database/sql"
+	"embed"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/vanti-dev/sc-bos/internal/sqlite"
+	"github.com/vanti-dev/sc-bos/pkg/history"
+)
+
+const appID = 0x5C0502
+
+//go:embed migrations/*.sql
+var migrationFS embed.FS
+
+var schema = sqlite.MustLoadVersionedSchema(migrationFS, "migrations")
+
+type Database struct {
+	db       *sqlite.Database
+	maxCount int64
+	maxAge   time.Duration
+}
+
+func Open(ctx context.Context, path string, options ...Option) (*Database, error) {
+	o := &opts{}
+	for _, option := range options {
+		option(o)
+	}
+	if o.logger == nil {
+		o.logger = zap.NewNop()
+	}
+
+	db, err := sqlite.Open(ctx, path,
+		sqlite.WithApplicationID(appID),
+		sqlite.WithLogger(o.logger),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	err = db.Migrate(ctx, schema)
+	if err != nil {
+		return nil, errors.Join(err, db.Close())
+	}
+
+	return &Database{db: db}, nil
+}
+
+func (d *Database) OpenStore(source string) *Store {
+	return &Store{
+		database: d,
+		source:   source,
+	}
+}
+
+func (d *Database) Close() error {
+	return d.db.Close()
+}
+
+func (d *Database) Insert(ctx context.Context, source string, at time.Time, payload []byte) (history.Record, error) {
+	var id int64
+	err := d.db.WriteTx(ctx, func(tx *sql.Tx) error {
+		epoch, err := readEpoch(ctx, tx)
+		if err != nil {
+			return err
+		}
+
+		srcID, err := sourceID(ctx, tx, source, true)
+		if err != nil {
+			return err
+		}
+
+		offset := at.UTC().Sub(epoch).Milliseconds()
+
+		err = tx.QueryRowContext(ctx, "INSERT INTO history (source_id, epoch_offset_ms, payload) VALUES (?, ?, ?) RETURNING id",
+			srcID, offset, payload).Scan(&id)
+		return err
+	})
+	return history.Record{
+		ID:         strconv.FormatInt(id, 10),
+		CreateTime: at,
+		Payload:    payload,
+	}, err
+}
+
+type InsertRecord struct {
+	Source     string
+	CreateTime time.Time
+	Payload    []byte
+}
+
+// InsertBulk inserts multiple records into the database in a single transaction.
+// Returns a slice of inserted record IDs in the same order as the input records.
+func (d *Database) InsertBulk(ctx context.Context, records []InsertRecord) (ids []string, err error) {
+	err = d.db.WriteTx(ctx, func(tx *sql.Tx) error {
+		epoch, err := readEpoch(ctx, tx)
+		if err != nil {
+			return err
+		}
+
+		srcIDCache := make(map[string]int64)
+		getSourceID := func(source string) (int64, error) {
+			if id, ok := srcIDCache[source]; ok {
+				return id, nil
+			}
+			srcID, err := sourceID(ctx, tx, source, true)
+			if err != nil {
+				return 0, err
+			}
+			srcIDCache[source] = srcID
+			return srcID, nil
+		}
+
+		stmt, err := tx.PrepareContext(ctx, "INSERT INTO history (source_id, epoch_offset_ms, payload) VALUES (?, ?, ?) RETURNING id")
+		if err != nil {
+			return err
+		}
+		for _, record := range records {
+			var id int64
+			offset := record.CreateTime.UTC().Sub(epoch).Milliseconds()
+			srcID, err := getSourceID(record.Source)
+			if err != nil {
+				return err
+			}
+			err = stmt.QueryRowContext(ctx, srcID, offset, record.Payload).Scan(&id)
+			if err != nil {
+				return errors.Join(err, stmt.Close())
+			}
+			ids = append(ids, strconv.FormatInt(id, 10))
+		}
+		return stmt.Close()
+	})
+	return ids, err
+}
+
+func (d *Database) Read(ctx context.Context, source string, from, to history.Record, into []history.Record, desc bool) (int, error) {
+	var count int
+	err := d.db.ReadTx(ctx, func(tx *sql.Tx) error {
+		epoch, err := readEpoch(ctx, tx)
+		if err != nil {
+			return err
+		}
+
+		filters, args := buildFilters(source, epoch, from, to)
+
+		order := "ASC"
+		if desc {
+			order = "DESC"
+		}
+
+		query := fmt.Sprintf(`
+			SELECT history.id, epoch_offset_ms, payload
+            FROM history
+            INNER JOIN history_sources ON history.source_id = history_sources.id
+			WHERE %s
+            ORDER BY history.id %s
+			LIMIT ?;
+        `, filters, order)
+		args = append(args, len(into))
+
+		rows, err := tx.QueryContext(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+
+		for rows.Next() {
+			var (
+				id       int64
+				offsetMS int64
+				payload  []byte
+			)
+			err = rows.Scan(&id, &offsetMS, &payload)
+			if err != nil {
+				return err
+			}
+			into[count] = buildRecord(id, epoch, offsetMS, payload)
+			count++
+		}
+		return rows.Err()
+	})
+	return count, err
+}
+
+func (d *Database) Count(ctx context.Context, source string, from, to history.Record) (int, error) {
+	var count int
+	err := d.db.ReadTx(ctx, func(tx *sql.Tx) error {
+		epoch, err := readEpoch(ctx, tx)
+		if err != nil {
+			return err
+		}
+
+		filters, args := buildFilters(source, epoch, from, to)
+
+		query := fmt.Sprintf(`
+			SELECT COUNT(*)
+			FROM history
+			INNER JOIN history_sources ON history.source_id = history_sources.id
+			WHERE %s;
+		`, filters)
+
+		err = tx.QueryRowContext(ctx, query, args...).Scan(&count)
+		return err
+	})
+	return count, err
+}
+
+func (d *Database) Size(ctx context.Context) (int64, error) {
+	var size int64
+	err := d.db.ReadTx(ctx, func(tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Scan(&size)
+	})
+	return size, err
+}
+
+type Store struct {
+	database *Database
+	source   string
+
+	from, to history.Record
+}
+
+func (s *Store) Append(ctx context.Context, payload []byte) (history.Record, error) {
+	now := time.Now()
+	record, err := s.database.Insert(ctx, s.source, now, payload)
+	if err != nil {
+		return history.Record{}, err
+	}
+	return record, nil
+}
+
+func (s *Store) Slice(from, to history.Record) history.Slice {
+	return &Store{
+		database: s.database,
+		source:   s.source,
+		from:     from,
+		to:       to,
+	}
+}
+
+func (s *Store) Read(ctx context.Context, into []history.Record) (int, error) {
+	return s.read(ctx, into, false)
+}
+
+func (s *Store) ReadDesc(ctx context.Context, into []history.Record) (int, error) {
+	return s.read(ctx, into, true)
+}
+
+func (s *Store) read(ctx context.Context, into []history.Record, desc bool) (int, error) {
+	return s.database.Read(ctx, s.source, s.from, s.to, into, desc)
+}
+
+func (s *Store) Len(ctx context.Context) (int, error) {
+	return s.database.Count(ctx, s.source, s.from, s.to)
+}
+
+func readEpoch(ctx context.Context, tx *sql.Tx) (time.Time, error) {
+	var epochStr string
+	err := tx.QueryRowContext(ctx, "SELECT value FROM history_meta WHERE key = 'epoch'").Scan(&epochStr)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Parse(sqlite.DateTimeFormat, epochStr)
+}
+
+func sourceID(ctx context.Context, tx *sql.Tx, source string, create bool) (int64, error) {
+	if create {
+		_, err := tx.ExecContext(ctx, "INSERT OR IGNORE INTO history_sources (source) VALUES (?)", source)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	var id int64
+	err := tx.QueryRowContext(ctx, "SELECT id FROM history_sources WHERE source = ?", source).Scan(&id)
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+func buildFilters(source string, epoch time.Time, from, to history.Record) (string, []any) {
+	filters := []string{"history_sources.source = ?"}
+	args := []any{source}
+
+	if !from.IsZero() {
+		if from.ID != "" {
+			filters = append(filters, "history.id >= ?")
+			args = append(args, from.ID)
+		} else if !from.CreateTime.IsZero() {
+			filters = append(filters, "history.epoch_offset_ms >= ?")
+			args = append(args, toEpochOffset(epoch, from.CreateTime))
+		}
+	}
+
+	if !to.IsZero() {
+		if to.ID != "" {
+			filters = append(filters, "history.id < ?")
+			args = append(args, to.ID)
+		} else if !to.CreateTime.IsZero() {
+			filters = append(filters, "history.epoch_offset_ms < ?")
+			args = append(args, toEpochOffset(epoch, to.CreateTime))
+		}
+	}
+
+	return strings.Join(filters, " AND "), args
+}
+
+func buildRecord(id int64, epoch time.Time, offsetMS int64, payload []byte) history.Record {
+	return history.Record{
+		ID:         strconv.FormatInt(id, 10),
+		CreateTime: epoch.Add(time.Duration(offsetMS) * time.Millisecond),
+		Payload:    payload,
+	}
+}
+
+func toEpochOffset(epoch time.Time, at time.Time) int64 {
+	return at.UTC().Sub(epoch).Milliseconds()
+}
+
+func fromEpochOffset(epoch time.Time, offsetMS int64) time.Time {
+	return epoch.Add(time.Duration(offsetMS) * time.Millisecond)
+}

--- a/pkg/history/sqlitestore/store_test.go
+++ b/pkg/history/sqlitestore/store_test.go
@@ -1,0 +1,235 @@
+package sqlitestore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/vanti-dev/sc-bos/pkg/history"
+)
+
+func TestDatabase_Insert(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	// Using fixed origin time for test determinism
+	originTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	source := "test-source"
+
+	// Insert multiple records sequentially
+	records := []struct {
+		payload []byte
+		at      time.Time
+	}{
+		{[]byte("test-payload-1"), originTime.Add(-2 * time.Hour)},
+		{[]byte("test-payload-2"), originTime.Add(-1 * time.Hour)},
+		{[]byte("test-payload-3"), originTime},
+	}
+
+	// Use zero-sized slice with capacity
+	insertedRecords := make([]history.Record, 0, len(records))
+
+	// Insert all records and collect the results
+	for _, r := range records {
+		record, err := db.Insert(ctx, source, r.at, r.payload)
+		if err != nil {
+			t.Fatalf("unexpected error inserting record: %v", err)
+		}
+
+		if record.ID == "" {
+			t.Errorf("expected valid record ID, got record.ID=%q", record.ID)
+		}
+
+		if record.Payload == nil || string(record.Payload) != string(r.payload) {
+			t.Errorf("expected payload to match %q, got %q", r.payload, record.Payload)
+		}
+
+		insertedRecords = append(insertedRecords, record)
+	}
+
+	// Verify all records were stored correctly
+	verifyRecords(t, db, ctx, source, records)
+}
+
+// verifyRecords retrieves all records for a source from the database and verifies they match expected records.
+func verifyRecords(t *testing.T, db *Database, ctx context.Context, source string, expected []struct {
+	payload []byte
+	at      time.Time
+}) {
+	t.Helper()
+
+	// Create a slice with capacity to hold all expected records
+	retrievedRecords := make([]history.Record, len(expected))
+
+	// Fetch all records using zero-value Records to indicate full range
+	count, err := db.Read(ctx, source, history.Record{}, history.Record{}, retrievedRecords, false)
+	if err != nil {
+		t.Fatalf("unexpected error reading records: %v", err)
+	}
+
+	if count != len(expected) {
+		t.Errorf("expected %d records, got %d", len(expected), count)
+	}
+
+	// Verify each record has correct data
+	for i := 0; i < count; i++ {
+		if retrievedRecords[i].ID == "" {
+			t.Errorf("record %d: missing ID", i)
+		}
+
+		// Verify the payload matches what we inserted
+		expectedPayload := string(expected[i].payload)
+		actualPayload := string(retrievedRecords[i].Payload)
+		if actualPayload != expectedPayload {
+			t.Errorf("record %d: expected payload %q, got %q", i, expectedPayload, actualPayload)
+		}
+
+		// Verify timestamps are close (within 1 second)
+		timeDiff := retrievedRecords[i].CreateTime.Sub(expected[i].at).Abs()
+		if timeDiff > time.Second {
+			t.Errorf("record %d: timestamp difference too large: %v", i, timeDiff)
+		}
+	}
+}
+
+func TestDatabase_InsertBulk(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	records := []InsertRecord{
+		{Source: "source-1", CreateTime: time.Now(), Payload: []byte("payload-1")},
+		{Source: "source-2", CreateTime: time.Now(), Payload: []byte("payload-2")},
+	}
+
+	ids, err := db.InsertBulk(ctx, records)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(ids) != len(records) {
+		t.Errorf("expected %d IDs, got %d", len(records), len(ids))
+	}
+
+	for i, id := range ids {
+		if id == "" {
+			t.Errorf("expected valid ID for record %d, got empty string", i)
+		}
+	}
+}
+
+func TestDatabase_InsertBulk_DuplicateSources(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	records := []InsertRecord{
+		{Source: "duplicate-source", CreateTime: time.Now(), Payload: []byte("payload-1")},
+		{Source: "duplicate-source", CreateTime: time.Now(), Payload: []byte("payload-2")},
+	}
+
+	ids, err := db.InsertBulk(ctx, records)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(ids) != len(records) {
+		t.Errorf("expected %d IDs, got %d", len(records), len(ids))
+	}
+}
+
+func TestDatabase_Read(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	source := "test-source"
+	payload := []byte("test-payload")
+	at := time.Now()
+
+	_, err := db.Insert(ctx, source, at, payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Using zero-value Records to read the entire dataset
+	from := history.Record{} // zero value = beginning of dataset
+	to := history.Record{}   // zero value = end of dataset
+	into := make([]history.Record, 1)
+
+	count, err := db.Read(ctx, source, from, to, into, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if count != 1 {
+		t.Errorf("expected 1 record, got %d", count)
+	}
+}
+
+func TestDatabase_Count(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	source := "test-source"
+	payload := []byte("test-payload")
+	at := time.Now()
+
+	_, err := db.Insert(ctx, source, at, payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Using zero-value Records to count the entire dataset
+	count, err := db.Count(ctx, source, history.Record{}, history.Record{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if count != 1 {
+		t.Errorf("expected 1 record, got %d", count)
+	}
+}
+
+func TestDatabase_Size(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	size, err := db.Size(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if size <= 0 {
+		t.Errorf("expected database size to be greater than 0, got %d", size)
+	}
+}
+
+func newTestDB(t *testing.T) *Database {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	ctx := context.Background()
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	db, err := Open(ctx, dbPath, WithLogger(logger))
+	if err != nil {
+		t.Fatalf("failed to open test database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("failed to close test database: %v", err)
+		}
+		stat, err := os.Stat(dbPath)
+		if err != nil {
+			t.Logf("failed to stat test database file: %v", err)
+		} else {
+			t.Logf("database file size: %d bytes", stat.Size())
+		}
+	})
+	return db
+}

--- a/pkg/history/sqlitestore/store_test.go
+++ b/pkg/history/sqlitestore/store_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
@@ -76,17 +78,12 @@ func verifyRecords(t *testing.T, db *Database, ctx context.Context, expected []R
 			t.Errorf("record %d: missing ID", i)
 		}
 
-		// Verify the payload matches what we inserted
-		expectedPayload := string(expected[i].Payload)
-		actualPayload := string(retrievedRecords[i].Payload)
-		if actualPayload != expectedPayload {
-			t.Errorf("record %d: expected payload %q, got %q", i, expectedPayload, actualPayload)
-		}
-
-		// Verify timestamps are close (within 1 second)
-		timeDiff := retrievedRecords[i].CreateTime.Sub(expected[i].CreateTime).Abs()
-		if timeDiff > time.Millisecond {
-			t.Errorf("record %d: timestamp difference too large: %v", i, timeDiff)
+		diff := cmp.Diff(expected[i], retrievedRecords[i],
+			cmpopts.IgnoreFields(Record{}, "ID"),
+			cmpopts.EquateApproxTime(time.Millisecond),
+		)
+		if diff != "" {
+			t.Errorf("record %d: data mismatch (-want +got):\n%s", i, diff)
 		}
 	}
 }
@@ -126,6 +123,132 @@ func TestDatabase_InsertBulk_DuplicateSources(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+}
+
+func TestDatabase_TrimCount(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	originTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	records := []Record{
+		{Source: "source-1", CreateTime: originTime.Add(-3 * time.Hour), Payload: []byte("-3h")},
+		{Source: "source-2", CreateTime: originTime.Add(-3 * time.Hour), Payload: []byte("-3h")},
+		{Source: "source-1", CreateTime: originTime.Add(-2 * time.Hour), Payload: []byte("-2h")},
+		{Source: "source-2", CreateTime: originTime.Add(-2 * time.Hour), Payload: []byte("-2h")},
+		{Source: "source-1", CreateTime: originTime.Add(-1 * time.Hour), Payload: []byte("-1h")},
+		{Source: "source-2", CreateTime: originTime.Add(-1 * time.Hour), Payload: []byte("-1h")},
+	}
+	err := db.InsertBulk(ctx, records)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Trim to 2 records for source-1, should delete the oldest record
+	// source-2 should remain unaffected
+	deleted, err := db.TrimCount(ctx, "source-1", 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 record deleted, got %d", deleted)
+	}
+	expect := []Record{
+		{Source: "source-2", CreateTime: originTime.Add(-3 * time.Hour), Payload: []byte("-3h")},
+		{Source: "source-1", CreateTime: originTime.Add(-2 * time.Hour), Payload: []byte("-2h")},
+		{Source: "source-2", CreateTime: originTime.Add(-2 * time.Hour), Payload: []byte("-2h")},
+		{Source: "source-1", CreateTime: originTime.Add(-1 * time.Hour), Payload: []byte("-1h")},
+		{Source: "source-2", CreateTime: originTime.Add(-1 * time.Hour), Payload: []byte("-1h")},
+	}
+	verifyRecords(t, db, ctx, expect)
+}
+
+func TestDatabase_TrimTime(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	originTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	records := []Record{
+		{Source: "other-source", CreateTime: originTime.Add(-3 * time.Hour), Payload: []byte("other-3h")},
+		{Source: "time-source", CreateTime: originTime.Add(-3 * time.Hour), Payload: []byte("-3h")},
+		{Source: "time-source", CreateTime: originTime.Add(-2 * time.Hour), Payload: []byte("-2h")},
+		{Source: "time-source", CreateTime: originTime.Add(-1 * time.Hour), Payload: []byte("-1h")},
+		{Source: "time-source", CreateTime: originTime, Payload: []byte("now")},
+	}
+	err := db.InsertBulk(ctx, records)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Trim records older than -90 minutes
+	cutoff := originTime.Add(-90 * time.Minute)
+	deleted, err := db.TrimTime(ctx, "time-source", cutoff)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("expected 2 records deleted, got %d", deleted)
+	}
+	expect := []Record{
+		{Source: "other-source", CreateTime: originTime.Add(-3 * time.Hour), Payload: []byte("other-3h")},
+		{Source: "time-source", CreateTime: originTime.Add(-1 * time.Hour), Payload: []byte("-1h")},
+		{Source: "time-source", CreateTime: originTime, Payload: []byte("now")},
+	}
+	verifyRecords(t, db, ctx, expect)
+}
+
+func TestDatabase_InsertBulk_WithMaxCount(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	source := "trim-source"
+	originTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	records := []Record{
+		{Source: source, CreateTime: originTime.Add(-3 * time.Hour), Payload: []byte("old-payload-1")},
+		{Source: source, CreateTime: originTime.Add(-2 * time.Hour), Payload: []byte("old-payload-2")},
+		{Source: source, CreateTime: originTime.Add(-1 * time.Hour), Payload: []byte("old-payload-3")},
+		{Source: source, CreateTime: originTime, Payload: []byte("new-payload")},
+	}
+
+	err := db.InsertBulk(ctx, records, WithMaxCount(2))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expect := []Record{
+		{Source: source, CreateTime: originTime.Add(-1 * time.Hour), Payload: []byte("old-payload-3")},
+		{Source: source, CreateTime: originTime, Payload: []byte("new-payload")},
+	}
+	verifyRecords(t, db, ctx, expect)
+}
+
+func TestDatabase_InsertBulk_WithEarliestTime(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	source := "time-trim-source"
+	records := []Record{
+		{Source: source, CreateTime: now.Add(-3 * time.Hour), Payload: []byte("old-payload-1")},
+		{Source: source, CreateTime: now.Add(-2 * time.Hour), Payload: []byte("old-payload-2")},
+		{Source: source, CreateTime: now.Add(-1 * time.Hour), Payload: []byte("old-payload-3")},
+		{Source: source, CreateTime: now, Payload: []byte("new-payload")},
+	}
+
+	trimBefore := now.Add(-90 * time.Minute) // Trim records older than 90 minutes
+
+	err := db.InsertBulk(ctx, records, WithEarliestTime(trimBefore))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	count, err := db.Count(ctx, source, 0, 0)
+	if err != nil {
+		t.Fatalf("unexpected error counting records: %v", err)
+	}
+
+	if count != 2 {
+		t.Errorf("expected 2 records after time-based trim, got %d", count)
+	}
 }
 
 func TestDatabase_Read(t *testing.T) {

--- a/pkg/history/sqlitestore/store_test.go
+++ b/pkg/history/sqlitestore/store_test.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-
-	"github.com/vanti-dev/sc-bos/pkg/history"
 )
 
 func TestDatabase_Insert(t *testing.T) {
@@ -21,52 +19,46 @@ func TestDatabase_Insert(t *testing.T) {
 	source := "test-source"
 
 	// Insert multiple records sequentially
-	records := []struct {
-		payload []byte
-		at      time.Time
-	}{
-		{[]byte("test-payload-1"), originTime.Add(-2 * time.Hour)},
-		{[]byte("test-payload-2"), originTime.Add(-1 * time.Hour)},
-		{[]byte("test-payload-3"), originTime},
+	records := []Record{
+		{Source: source, Payload: []byte("test-payload-1"), CreateTime: originTime.Add(-2 * time.Hour)},
+		{Source: source, Payload: []byte("test-payload-2"), CreateTime: originTime.Add(-1 * time.Hour)},
+		{Source: source, Payload: []byte("test-payload-3"), CreateTime: originTime},
 	}
 
 	// Use zero-sized slice with capacity
-	insertedRecords := make([]history.Record, 0, len(records))
+	insertedRecords := make([]Record, 0, len(records))
 
 	// Insert all records and collect the results
 	for _, r := range records {
-		record, err := db.Insert(ctx, source, r.at, r.payload)
+		record, err := db.Insert(ctx, r)
 		if err != nil {
 			t.Fatalf("unexpected error inserting record: %v", err)
 		}
 
-		if record.ID == "" {
+		if record.ID == 0 {
 			t.Errorf("expected valid record ID, got record.ID=%q", record.ID)
 		}
 
-		if record.Payload == nil || string(record.Payload) != string(r.payload) {
-			t.Errorf("expected payload to match %q, got %q", r.payload, record.Payload)
+		if record.Payload == nil || string(record.Payload) != string(r.Payload) {
+			t.Errorf("expected payload to match %q, got %q", r.Payload, record.Payload)
 		}
 
 		insertedRecords = append(insertedRecords, record)
 	}
 
 	// Verify all records were stored correctly
-	verifyRecords(t, db, ctx, source, records)
+	verifyRecords(t, db, ctx, records)
 }
 
 // verifyRecords retrieves all records for a source from the database and verifies they match expected records.
-func verifyRecords(t *testing.T, db *Database, ctx context.Context, source string, expected []struct {
-	payload []byte
-	at      time.Time
-}) {
+func verifyRecords(t *testing.T, db *Database, ctx context.Context, expected []Record) {
 	t.Helper()
 
 	// Create a slice with capacity to hold all expected records
-	retrievedRecords := make([]history.Record, len(expected))
+	retrievedRecords := make([]Record, len(expected)+1)
 
 	// Fetch all records using zero-value Records to indicate full range
-	count, err := db.Read(ctx, source, history.Record{}, history.Record{}, retrievedRecords, false)
+	count, err := db.Read(ctx, "", 0, 0, false, retrievedRecords)
 	if err != nil {
 		t.Fatalf("unexpected error reading records: %v", err)
 	}
@@ -76,21 +68,21 @@ func verifyRecords(t *testing.T, db *Database, ctx context.Context, source strin
 	}
 
 	// Verify each record has correct data
-	for i := 0; i < count; i++ {
-		if retrievedRecords[i].ID == "" {
+	for i := range count {
+		if retrievedRecords[i].ID == 0 {
 			t.Errorf("record %d: missing ID", i)
 		}
 
 		// Verify the payload matches what we inserted
-		expectedPayload := string(expected[i].payload)
+		expectedPayload := string(expected[i].Payload)
 		actualPayload := string(retrievedRecords[i].Payload)
 		if actualPayload != expectedPayload {
 			t.Errorf("record %d: expected payload %q, got %q", i, expectedPayload, actualPayload)
 		}
 
 		// Verify timestamps are close (within 1 second)
-		timeDiff := retrievedRecords[i].CreateTime.Sub(expected[i].at).Abs()
-		if timeDiff > time.Second {
+		timeDiff := retrievedRecords[i].CreateTime.Sub(expected[i].CreateTime).Abs()
+		if timeDiff > time.Millisecond {
 			t.Errorf("record %d: timestamp difference too large: %v", i, timeDiff)
 		}
 	}
@@ -100,23 +92,19 @@ func TestDatabase_InsertBulk(t *testing.T) {
 	db := newTestDB(t)
 	ctx := context.Background()
 
-	records := []InsertRecord{
+	records := []Record{
 		{Source: "source-1", CreateTime: time.Now(), Payload: []byte("payload-1")},
 		{Source: "source-2", CreateTime: time.Now(), Payload: []byte("payload-2")},
 	}
 
-	ids, err := db.InsertBulk(ctx, records)
+	err := db.InsertBulk(ctx, records)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(ids) != len(records) {
-		t.Errorf("expected %d IDs, got %d", len(records), len(ids))
-	}
-
-	for i, id := range ids {
-		if id == "" {
-			t.Errorf("expected valid ID for record %d, got empty string", i)
+	for i, record := range records {
+		if record.ID == 0 {
+			t.Errorf("expected valid ID for record %d, got zero", i)
 		}
 	}
 }
@@ -125,19 +113,16 @@ func TestDatabase_InsertBulk_DuplicateSources(t *testing.T) {
 	db := newTestDB(t)
 	ctx := context.Background()
 
-	records := []InsertRecord{
+	records := []Record{
 		{Source: "duplicate-source", CreateTime: time.Now(), Payload: []byte("payload-1")},
 		{Source: "duplicate-source", CreateTime: time.Now(), Payload: []byte("payload-2")},
 	}
 
-	ids, err := db.InsertBulk(ctx, records)
+	err := db.InsertBulk(ctx, records)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(ids) != len(records) {
-		t.Errorf("expected %d IDs, got %d", len(records), len(ids))
-	}
 }
 
 func TestDatabase_Read(t *testing.T) {
@@ -148,17 +133,21 @@ func TestDatabase_Read(t *testing.T) {
 	payload := []byte("test-payload")
 	at := time.Now()
 
-	_, err := db.Insert(ctx, source, at, payload)
+	_, err := db.Insert(ctx, Record{
+		Source:     source,
+		CreateTime: at,
+		Payload:    payload,
+	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Using zero-value Records to read the entire dataset
-	from := history.Record{} // zero value = beginning of dataset
-	to := history.Record{}   // zero value = end of dataset
-	into := make([]history.Record, 1)
+	from := RecordID(0) // zero value = beginning of dataset
+	to := RecordID(0)   // zero value = end of dataset
+	into := make([]Record, 1)
 
-	count, err := db.Read(ctx, source, from, to, into, false)
+	count, err := db.Read(ctx, source, from, to, false, into)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -176,13 +165,17 @@ func TestDatabase_Count(t *testing.T) {
 	payload := []byte("test-payload")
 	at := time.Now()
 
-	_, err := db.Insert(ctx, source, at, payload)
+	_, err := db.Insert(ctx, Record{
+		Source:     source,
+		CreateTime: at,
+		Payload:    payload,
+	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Using zero-value Records to count the entire dataset
-	count, err := db.Count(ctx, source, history.Record{}, history.Record{})
+	count, err := db.Count(ctx, source, 0, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/history/sqlitestore/store_test.go
+++ b/pkg/history/sqlitestore/store_test.go
@@ -2,12 +2,15 @@ package sqlitestore
 
 import (
 	"context"
+	"crypto/rand"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestDatabase_Insert(t *testing.T) {
@@ -199,7 +202,122 @@ func TestDatabase_Size(t *testing.T) {
 	}
 }
 
-func newTestDB(t *testing.T) *Database {
+func TestDatabase_LargeScale(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping large scale test in short mode")
+	}
+
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	const (
+		totalRecords = 1_000_000
+		numSources   = 50
+		batchSize    = 10_000 // insert in batches for efficiency
+		payloadSize  = 100    // size of each payload in bytes
+	)
+
+	logger := zaptest.NewLogger(t)
+
+	logger.Info("Starting large scale database test",
+		zap.Int("total_records", totalRecords),
+		zap.Int("num_sources", numSources),
+		zap.Int("batch_size", batchSize))
+
+	start := time.Now()
+	baseTime := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Insert records in batches
+	var expected []Record
+	for batch := 0; batch < totalRecords/batchSize; batch++ {
+		records := make([]Record, batchSize)
+
+		for i := 0; i < batchSize; i++ {
+			recordNum := batch*batchSize + i
+			sourceID := recordNum % numSources
+			record := Record{
+				Source:     fmt.Sprintf("source-%d", sourceID),
+				CreateTime: baseTime.Add(time.Duration(recordNum) * time.Millisecond),
+				Payload:    generateRandomPayload(200),
+			}
+			records[i] = record
+			expected = append(expected, record)
+		}
+
+		err := db.InsertBulk(ctx, records)
+		if err != nil {
+			t.Fatalf("failed to insert batch %d: %v", batch, err)
+		}
+
+		// Log progress every 20 batches
+		if batch%20 == 0 {
+			elapsed := time.Since(start)
+			recordsInserted := (batch + 1) * batchSize
+			rate := float64(recordsInserted) / elapsed.Seconds()
+			logger.Info("Insertion progress",
+				zap.Int("records_inserted", recordsInserted),
+				zap.Duration("elapsed", elapsed),
+				zap.Float64("records_per_second", rate))
+		}
+	}
+
+	insertDuration := time.Since(start)
+	logger.Info("Insertion completed",
+		zap.Duration("total_time", insertDuration),
+		zap.Float64("avg_records_per_second", float64(totalRecords)/insertDuration.Seconds()))
+
+	// Verify record count
+	count, err := db.Count(ctx, "", 0, 0)
+	if err != nil {
+		t.Fatalf("failed to count records: %v", err)
+	}
+
+	if count != totalRecords {
+		t.Errorf("expected %d records, got %d", totalRecords, count)
+	}
+
+	// Measure database size
+	dbSize, err := db.Size(ctx)
+	if err != nil {
+		t.Fatalf("failed to get database size: %v", err)
+	}
+
+	avgSizePerRecord := float64(dbSize) / float64(totalRecords)
+	overheadPerRecord := avgSizePerRecord - float64(payloadSize)
+
+	logger.Info("Database size analysis",
+		zap.Int64("total_size_bytes", dbSize),
+		zap.Float64("total_size_mb", float64(dbSize)/(1024*1024)),
+		zap.Float64("avg_bytes_per_record", avgSizePerRecord),
+		zap.Float64("overhead_bytes_per_record", overheadPerRecord),
+		zap.Int("total_records", count))
+
+	// Verify we can still read records efficiently
+	readStart := time.Now()
+	into := make([]Record, 1000)
+	readCount, err := db.Read(ctx, "source-0", 0, 0, false, into)
+	if err != nil {
+		t.Fatalf("failed to read records: %v", err)
+	}
+	readDuration := time.Since(readStart)
+
+	logger.Info("Read performance test",
+		zap.Int("records_read", readCount),
+		zap.Duration("read_time", readDuration))
+
+	verifyRecords(t, db, ctx, expected)
+}
+
+func generateRandomPayload(size int) []byte {
+	payload := make([]byte, size)
+	_, err := rand.Read(payload)
+	if err != nil {
+		panic(fmt.Sprintf("failed to generate random payload: %v", err))
+	}
+	return payload
+}
+
+func newTestDB(t testing.TB) *Database {
 	t.Helper()
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
@@ -213,6 +331,7 @@ func newTestDB(t *testing.T) *Database {
 	if err != nil {
 		t.Fatalf("failed to open test database: %v", err)
 	}
+	t.Logf("created test database %s", dbPath)
 	t.Cleanup(func() {
 		if err := db.Close(); err != nil {
 			t.Errorf("failed to close test database: %v", err)

--- a/pkg/system/history/config/root.go
+++ b/pkg/system/history/config/root.go
@@ -16,6 +16,7 @@ type StorageType string
 const (
 	StorageTypePostgres StorageType = "postgres"
 	StorageTypeBolt     StorageType = "bolt"
+	StorageTypeSqlite   StorageType = "sqlite"
 )
 
 type Storage struct {


### PR DESCRIPTION
Add a `history.Store` implementation using SQLite3. Features:
- Local storage, no server required
- Source names normalised to reduce storage space
- ID and timestamp stored combined for small record size and fast queries

Limitations:
- Max of 1,000,000 records with the same timestamp (millisecond precision) due to how IDs and timestamps are handled.
