### PR TITLE
auto/exporthttp: fix initializing previous execution time and when the previous execution time is updated

### DIFF
--- a/pkg/auto/exporthttp/auto.go
+++ b/pkg/auto/exporthttp/auto.go
@@ -10,6 +10,7 @@ package exporthttp
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -39,7 +40,7 @@ func (f factory) New(services auto.Services) service.Lifecycle {
 }
 
 func (a *autoImpl) applyConfig(ctx context.Context, cfg config.Root) error {
-	logger := a.Logger.Named(cfg.Name).With(zap.String("baseUrl", cfg.BaseUrl))
+	logger := a.Logger.Named(cfg.Name)
 
 	jobs := job.FromConfig(cfg, a.Database, AutoName, cfg.Name, logger, a.Node)
 
@@ -71,6 +72,7 @@ func (a *autoImpl) applyConfig(ctx context.Context, cfg config.Root) error {
 						logger.Warn(fmt.Sprintf("failed to run %s", jb.GetName()), zap.Error(err))
 						return
 					}
+					jb.SetPreviousExecution(time.Now())
 				}()
 			case <-ctx.Done():
 				return


### PR DESCRIPTION
There was an issue where the `PreviousExecutionTime` was updated immediately. When used to look back for meter reading histories, this was returning 0 meter reading records as the look back was too short.

I also changed the way `PreviousExecutionTime` is initialized to mitigate this happening if SmartCore is rebooted too frequently.