### PR TITLE
node: allow Node to have its backing store configured externally

### DIFF
--- a/internal/node/nodeopts/options.go
+++ b/internal/node/nodeopts/options.go
@@ -1,0 +1,57 @@
+// Package nodeopts provides common and private options for the node package.
+package nodeopts
+
+import (
+	"context"
+
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+	"github.com/vanti-dev/sc-bos/pkg/gen"
+	"github.com/vanti-dev/sc-bos/pkg/gentrait/devicespb"
+)
+
+type Option interface {
+	apply(*Struct)
+}
+
+type optionFunc func(*Struct)
+
+func (f optionFunc) apply(o *Struct) {
+	f(o)
+}
+
+// WithStore sets the Store used by the Node to Store its announced devices.
+func WithStore(store Store) Option {
+	return optionFunc(func(o *Struct) {
+		o.Store = store
+	})
+}
+
+// Join combines multiple options into a single struct.
+func Join(opts ...Option) Struct {
+	var o Struct
+	for _, opt := range opts {
+		opt.apply(&o)
+	}
+	return o
+}
+
+// Struct contains all options for a Node as a struct for easy access.
+type Struct struct {
+	Store Store
+}
+
+func (s Struct) apply(o *Struct) {
+	if s.Store != nil {
+		o.Store = s.Store
+	}
+}
+
+// Store describes how a node stores its announced devices.
+type Store interface {
+	GetDevice(name string, opts ...resource.ReadOption) (*gen.Device, error)
+	PullDevice(ctx context.Context, name string, opts ...resource.ReadOption) <-chan devicespb.DeviceChange
+	ListDevices(opts ...resource.ReadOption) []*gen.Device
+	PullDevices(ctx context.Context, opts ...resource.ReadOption) <-chan devicespb.DevicesChange
+	Update(d *gen.Device, opts ...resource.WriteOption) (*gen.Device, error)
+	Delete(name string, opts ...resource.WriteOption) (*gen.Device, error)
+}

--- a/pkg/node/metadata.go
+++ b/pkg/node/metadata.go
@@ -10,8 +10,8 @@ import (
 	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"github.com/smart-core-os/sc-golang/pkg/trait/metadatapb"
+	"github.com/vanti-dev/sc-bos/internal/node/nodeopts"
 	"github.com/vanti-dev/sc-bos/pkg/gen"
-	"github.com/vanti-dev/sc-bos/pkg/gentrait/devicespb"
 )
 
 // mergeAllMetadata uses the metadatapb.Merge algorithm to merge multiple metadata objects into one.
@@ -98,7 +98,7 @@ func (ml *metadataList) isEmpty() bool {
 	return len(*ml) == 0
 }
 
-func (ml *metadataList) updateCollection(c *devicespb.Collection, opts ...resource.WriteOption) error {
+func (ml *metadataList) updateCollection(c nodeopts.Store, opts ...resource.WriteOption) error {
 	if ml.isEmpty() {
 		return fmt.Errorf("no name: empty metadata list")
 	}

--- a/pkg/node/options.go
+++ b/pkg/node/options.go
@@ -1,0 +1,7 @@
+package node
+
+import (
+	"github.com/vanti-dev/sc-bos/internal/node/nodeopts"
+)
+
+type Option = nodeopts.Option


### PR DESCRIPTION
This capability is internal only (for now), it will be used by the app controller to add other uses to the backing devicespb.Collection.

The structure is slightly strange because I wanted the sc-bos package to be able to specify the option without exporting the option generally.