### PR TITLE
app,auto: expose a DevicesApiClient to automations

### DIFF
--- a/pkg/app/controller.go
+++ b/pkg/app/controller.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/smart-core-os/sc-golang/pkg/wrap"
 	"github.com/vanti-dev/sc-bos/internal/account"
 	"github.com/vanti-dev/sc-bos/internal/manage/devices"
 	"github.com/vanti-dev/sc-bos/internal/util/grpc/interceptors"
@@ -336,6 +337,7 @@ func Bootstrap(ctx context.Context, config sysconf.Config) (*Controller, error) 
 		Enrollment:       enrollServer,
 		Logger:           logger,
 		Node:             rootNode,
+		Devices:          gen.NewDevicesApiClient(wrap.ServerToClient(gen.DevicesApi_ServiceDesc, devicesApi)),
 		Tasks:            &task.Group{},
 		Database:         db,
 		Stores:           store,
@@ -409,6 +411,7 @@ type Controller struct {
 	// services for drivers/automations
 	Logger          *zap.Logger
 	Node            *node.Node
+	Devices         gen.DevicesApiClient
 	Tasks           *task.Group
 	Database        *bolthold.Store
 	TokenValidators *token.ValidatorSet

--- a/pkg/app/services.go
+++ b/pkg/app/services.go
@@ -51,6 +51,7 @@ func (c *Controller) startAutomations(configs []auto.RawConfig) (*service.Map, e
 	ctxServices := auto.Services{
 		Logger:          c.Logger.Named("auto"),
 		Node:            c.Node,
+		Devices:         c.Devices,
 		Database:        c.Database,
 		Stores:          c.Stores,
 		GRPCServices:    c.GRPC,

--- a/pkg/auto/factory.go
+++ b/pkg/auto/factory.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/vanti-dev/sc-bos/pkg/app/stores"
+	"github.com/vanti-dev/sc-bos/pkg/gen"
 	"github.com/vanti-dev/sc-bos/pkg/node"
 	"github.com/vanti-dev/sc-bos/pkg/task/service"
 )
@@ -16,6 +17,7 @@ import (
 type Services struct {
 	Logger          *zap.Logger
 	Node            *node.Node // for advertising devices
+	Devices         gen.DevicesApiClient
 	Database        *bolthold.Store
 	Stores          *stores.Stores
 	GRPCServices    grpc.ServiceRegistrar // for registering non-routed services


### PR DESCRIPTION
This can be used to, for example, configure autos that target a device query instead of a list of device names.