### PR TITLE
ui/ops: fix total count for collections drifting after pull

### DIFF
--- a/ui/ops/src/composables/collection.js
+++ b/ui/ops/src/composables/collection.js
@@ -294,7 +294,7 @@ export default function useCollection(request, client, options) {
   function processChanges() {
     const _items = items.value;
     const _changes = unprocessedChanges.value;
-    if (!_changes.length) return; // no changes, nothing to do
+    if (!_changes.length) return 0; // no changes, nothing to do
     const opts = toValue(options);
     const transform = opts?.transform ?? (v => v);
     const filterFn = opts?.filterFn;


### PR DESCRIPTION
The total count was not taking the items added or deleted after the initial list request into account when reporting the total item count. Now it does.