### PR TITLE
ui/ops: allow customising or removing the title in EnvironmentalCard

### DIFF
--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -56,6 +56,7 @@
             {
               "component": "builtin:environmental/EnvironmentalCard",
               "props": {
+                "title": "",
                 "external": "van/uk/brum/ugs/devices/TMP-L02-01",
                 "internal": "van/uk/brum/ugs/zones/building"
               }
@@ -123,6 +124,7 @@
                 {
                   "component": "builtin:environmental/EnvironmentalCard",
                   "props": {
+                    "title": "Floor Temperature",
                     "internal": "van/uk/brum/ugs/zones/floors/basement"
                   }
                 }
@@ -321,6 +323,7 @@
                 {
                   "component": "builtin:environmental/EnvironmentalCard",
                   "props": {
+                    "title": "Floor Temperature",
                     "internal": "van/uk/brum/ugs/zones/floors/ground"
                   }
                 }
@@ -561,6 +564,7 @@
                 {
                   "component": "builtin:environmental/EnvironmentalCard",
                   "props": {
+                    "title": "Floor Temperature",
                     "internal": "van/uk/brum/ugs/zones/floors/first"
                   }
                 }

--- a/ui/ops/src/dynamic/widgets/environmental/EnvironmentalCard.vue
+++ b/ui/ops/src/dynamic/widgets/environmental/EnvironmentalCard.vue
@@ -1,6 +1,6 @@
 <template>
   <content-card class="pt-6 pb-6">
-    <v-card-title class="text-h4 mb-0">Environmental</v-card-title>
+    <v-card-title v-if="title.length > 0" class="text-h4 mb-0">{{ title }}</v-card-title>
     <v-card-text class="d-flex flex-row flex-wrap justify-center align-center pa-0 text-white">
       <circular-gauge
           v-if="!isNullOrUndef(internal)"
@@ -67,6 +67,11 @@ import {isNullOrUndef} from '@/util/types.js';
 import {computed} from 'vue';
 
 const props = defineProps({
+  // title can be hidden by setting to null
+  title: {
+    type: String,
+    default: 'Environmental'
+  },
   internal: {
     type: String,
     default: null


### PR DESCRIPTION
In some dashboards the 'Environmental' title is not the best choice for this card.

Add a prop title, defaulting to 'Environmental', to customise the title.

If the title is set to an empty string, the title is not displayed at all (so there's no blank space at the top of the card).

To demonstrate the new functionality, use it in the UGS example.