### PR TITLE
ui/ops: make table headers fixed when scrolling

### DIFF
--- a/ui/ops/src/dynamic/widgets/security/SecurityEventsCard.vue
+++ b/ui/ops/src/dynamic/widgets/security/SecurityEventsCard.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card :class="props.class" :style="props.style">
-    <security-events-table v-bind="$attrs"/>
+    <security-events-table v-bind="$attrs" :fixed-header="false"/>
   </v-card>
 </template>
 

--- a/ui/ops/src/routes/devices/components/DeviceTable.vue
+++ b/ui/ops/src/routes/devices/components/DeviceTable.vue
@@ -29,6 +29,8 @@
         :show-select="showSelect"
         item-value="name"
         :class="tableClasses"
+        :fixed-header="props.fixedHeader"
+        :style="tableStyles"
         @click:row="showDevice">
       <template #item.metadata.membership.subsystem="{ item }">
         <subsystem-icon size="20px" :subsystem="item.metadata?.membership?.subsystem" no-default/>
@@ -87,6 +89,14 @@ const props = defineProps({
   forceQuery: {
     type: Object, // keys are condition properties, values are stringEqualFold values
     default: () => ({})
+  },
+  fixedHeader: {
+    type: Boolean,
+    default: true
+  },
+  height: {
+    type: [String, Number],
+    default: undefined
   }
 });
 const emit = defineEmits(['update:selectedDevices']);
@@ -134,6 +144,16 @@ const tableClasses = computed(() => {
   if (props.showSelect) c.push('selectable');
   if (props.rowSelect) c.push('rowSelectable');
   return c.join(' ');
+});
+
+const tableStyles = computed(() => {
+  if (!props.fixedHeader) {
+    return {};
+  }
+  if (props.height) {
+    return {height: typeof props.height === 'number' ? `${props.height}px` : props.height};
+  }
+  return {height: '80vh'};
 });
 
 const selectedDevicesComp = computed({

--- a/ui/ops/src/routes/ops/emergency-lighting/EmergencyLightingV2.vue
+++ b/ui/ops/src/routes/ops/emergency-lighting/EmergencyLightingV2.vue
@@ -31,10 +31,10 @@
           <filter-btn :ctx="filterCtx" flat/>
         </template>
         <v-tooltip text="Download data as CSV..." location="bottom">
-          <template #activator="{ props }">
+          <template #activator="{ props: tooltipProps }">
             <v-btn
-                v-bind="props"
-                flat
+                v-bind="tooltipProps"
+                color="primary"
                 class="ml-2"
                 :disabled="loadedResults < totalDevices"
                 @click="downloadCSV">
@@ -51,7 +51,9 @@
         show-select
         item-value="name"
         v-model="selectedLights"
-        item-key="name">
+        item-key="name"
+        :fixed-header="props.fixedHeader"
+        :style="tableStyles">
       <template #top>
         <span v-if="selectedLights.length > 0">
           <v-btn
@@ -105,6 +107,17 @@ import FilterChoiceChips from '@/components/filter/FilterChoiceChips.vue';
 import {useDeviceFilters} from '@/composables/devices';
 import {ref, onMounted, computed, watch} from 'vue';
 
+const props = defineProps({
+  fixedHeader: {
+    type: Boolean,
+    default: true
+  },
+  height: {
+    type: [String, Number],
+    default: undefined
+  }
+});
+
 const forcedFilters = ref({
   'metadata.traits.name': 'smartcore.bos.EmergencyLight'
 });
@@ -134,6 +147,16 @@ const findEmLightsQuery = computed(() => {
 
 const filteredTestResults = computed(() => {
   return testResults.value;
+});
+
+const tableStyles = computed(() => {
+  if (!props.fixedHeader) {
+    return {};
+  }
+  if (props.height) {
+    return {height: typeof props.height === 'number' ? `${props.height}px` : props.height};
+  }
+  return {height: '80vh'};
 });
 
 const getDeviceTestResults = async () => {

--- a/ui/ops/src/routes/ops/security-events/SecurityEventsTable.vue
+++ b/ui/ops/src/routes/ops/security-events/SecurityEventsTable.vue
@@ -10,7 +10,9 @@
         :hide-default-footer="_hidePaging"
         v-bind="tableAttrs"
         disable-sort
-        :items-length="queryTotalCount">
+        :items-length="queryTotalCount"
+        :fixed-header="props.fixedHeader"
+        :style="tableStyles">
       <template #top v-if="showCardHeader">
         <v-toolbar color="transparent">
           <v-toolbar-title v-if="showCardHeader" class="text-h4">{{ props.title }}</v-toolbar-title>
@@ -57,6 +59,14 @@ const props = defineProps({
   fixedRowCount: {
     type: Number,
     default: null
+  },
+  fixedHeader: {
+    type: Boolean,
+    default: true
+  },
+  height: {
+    type: [String, Number],
+    default: undefined
   }
 });
 
@@ -108,6 +118,17 @@ const allHeaders = [
   {title: 'Priority', value: 'priority', width: '10em', align: 'end'},
   {title: 'Source', value: 'source.name', width: '30%'}
 ];
+
+const tableStyles = computed(() => {
+  if (!props.fixedHeader) {
+    return {};
+  }
+  if (props.height) {
+    return {height: typeof props.height === 'number' ? `${props.height}px` : props.height};
+  }
+  return {height: '80vh'};
+});
+
 
 </script>
 

--- a/ui/ops/src/routes/ops/waste/WasteTable.vue
+++ b/ui/ops/src/routes/ops/waste/WasteTable.vue
@@ -11,6 +11,8 @@
           v-bind="tableAttrs"
           disable-sort
           :items-length="queryTotalCount"
+          :fixed-header="props.fixedHeader"
+          :style="tableStyles"
           class="pt-4">
         <template #item.createTime="{ item }">
           {{ timestampToDate(item.wasteCreateTime).toLocaleString() }}
@@ -69,6 +71,14 @@ const props = defineProps({
   landSavedUnit: {
     type: String,
     default: 'km²'
+  },
+  fixedHeader: {
+    type: Boolean,
+    default: true
+  },
+  height: {
+    type: [String, Number],
+    default: undefined
   }
 })
 
@@ -106,6 +116,16 @@ const allHeaders = [
   {title: 'Land Saved', value: 'landSaved', width: '10em', align: 'end'},
   {title: 'Trees Saved', value: 'treesSaved', width: '10em', align: 'end'},
 ];
+
+const tableStyles = computed(() => {
+  if (!props.fixedHeader) {
+    return {};
+  }
+  if (props.height) {
+    return {height: typeof props.height === 'number' ? `${props.height}px` : props.height};
+  }
+  return {height: '80vh'};
+});
 
 const getDisposalMethod = (disposalMethod) => {
   switch (disposalMethod) {


### PR DESCRIPTION
[SCB-1166](https://vanti.youtrack.cloud/issue/SCB-1166) Fix the table header so we can always see column headers, search bar, filters etc when scrolling down the table.