### PR TITLE
Fix/httpexport logging

### DIFF
--- a/pkg/auto/exporthttp/job/air_quality.go
+++ b/pkg/auto/exporthttp/job/air_quality.go
@@ -31,7 +31,7 @@ func (a *AirQualityJob) Do(ctx context.Context, sendFn sender) error {
 
 		cancel()
 		if err != nil {
-			a.Logger.Error("getting air quality", zap.String("sensor", sensor), zap.Error(err))
+			a.Logger.Warn("getting air quality", zap.String("sensor", sensor), zap.Error(err))
 			continue
 		}
 

--- a/pkg/auto/exporthttp/job/energy.go
+++ b/pkg/auto/exporthttp/job/energy.go
@@ -33,7 +33,7 @@ func (e *EnergyJob) Do(ctx context.Context, sendFn sender) error {
 		multiplier, err := e.getUnitMultiplier(cctx, meter)
 
 		if err != nil {
-			e.Logger.Error("getting unit multiplier", zap.String("meter", meter), zap.Error(err))
+			e.Logger.Warn("getting unit multiplier", zap.String("meter", meter), zap.Error(err))
 		}
 
 		earliest, latest, err := getRecordsByTime(cctx, e.Logger, e.client.ListMeterReadingHistory, meter, now, filterTime)
@@ -41,7 +41,7 @@ func (e *EnergyJob) Do(ctx context.Context, sendFn sender) error {
 		cancel()
 
 		if err != nil {
-			e.Logger.Error("getting records by time", zap.String("meter", meter), zap.Error(err))
+			e.Logger.Warn("getting records by time", zap.String("meter", meter), zap.Error(err))
 			continue
 		}
 

--- a/pkg/auto/exporthttp/job/job.go
+++ b/pkg/auto/exporthttp/job/job.go
@@ -42,6 +42,12 @@ type Job interface {
 	GetLogger() *zap.Logger
 
 	GetNextExecution() <-chan time.Time
+	// SetLastAttempt records when the job last ran (success or failure) and is used
+	// solely to pace the schedule. It is not persisted.
+	SetLastAttempt(t time.Time)
+	// SetPreviousExecution records a successful execution and persists the timestamp.
+	// It is used by meter-based jobs to define the data window for the next run, so
+	// it must only be called on success to preserve catch-up across outages.
 	SetPreviousExecution(t time.Time)
 
 	Do(ctx context.Context, sendFn sender) error
@@ -60,11 +66,17 @@ func ExecuteAll(ctx context.Context, sender sender, jobs ...Job) error {
 			for {
 				select {
 				case <-j.GetNextExecution():
+					// Record the attempt time before running so GetNextExecution
+					// schedules the next run correctly even if Do fails.
+					j.SetLastAttempt(time.Now())
 					if err := j.Do(ctx, sender); err != nil {
 						j.GetLogger().Warn("failed to run", zap.Error(err))
-						continue
+					} else {
+						// Only advance PreviousExecution on success: meter-based jobs
+						// use it as the start of their data window, so it must not
+						// advance during an outage or catch-up data would be lost.
+						j.SetPreviousExecution(time.Now())
 					}
-					j.SetPreviousExecution(time.Now())
 				case <-ctx.Done():
 					return ctx.Err()
 				}
@@ -100,16 +112,29 @@ type BaseJob struct {
 	PreviousExecution time.Time
 	Site              string
 	Logger            *zap.Logger
+
+	lastAttempt time.Time // in-memory only; tracks last run attempt for scheduling
 }
 
 func (b *BaseJob) GetLogger() *zap.Logger {
 	return b.Logger
 }
 
+func (b *BaseJob) SetLastAttempt(t time.Time) {
+	b.lastAttempt = t
+}
+
 func (b *BaseJob) GetNextExecution() <-chan time.Time {
 	t := time.Now().UTC()
 
+	// Use whichever is more recent: the last successful execution (persisted) or the
+	// last attempt (in-memory). This prevents a tight retry loop after a failed run
+	// while still allowing meter-based jobs to catch up across an outage on success.
 	previous := b.getPreviousExecution()
+	if b.lastAttempt.After(previous) {
+		previous = b.lastAttempt
+	}
+
 	executeImmediately := shouldExecuteImmediately(b.Schedule, t, previous.UTC())
 
 	b.Logger.Debug("previous execution time detected", zap.String("name", b.Name), zap.Time("previous", previous), zap.Time("current", t), zap.Bool("executeImmediately", executeImmediately))
@@ -242,7 +267,9 @@ func (b *BaseJob) getPreviousExecution() time.Time {
 	previous := time.Time{}
 	key := fmt.Sprintf(boltKeyTemplate, b.AutoName, b.ScName, b.Name)
 	if err := b.Db.Get(key, &previous); err != nil {
-		b.Logger.Error("failed to get previous execution time", zap.String("name", b.Name), zap.Error(err), zap.String("key", key))
+		if !errors.Is(err, bolthold.ErrNotFound) {
+			b.Logger.Warn("failed to get previous execution time", zap.String("name", b.Name), zap.Error(err), zap.String("key", key))
+		}
 		// assume the job executed successfully one interval ago if we can't retrieve the previous execution time
 		now := time.Now()
 		next := b.Schedule.Next(now)

--- a/pkg/auto/exporthttp/job/job_test.go
+++ b/pkg/auto/exporthttp/job/job_test.go
@@ -1,8 +1,14 @@
 package job
 
 import (
+	"context"
+	"errors"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/timshannon/bolthold"
+	"go.uber.org/zap"
 
 	"github.com/smart-core-os/sc-bos/pkg/util/jsontypes"
 )
@@ -118,4 +124,106 @@ func makeTime(s string) time.Time {
 	}
 	t = t.Add(time.Hour * 24 * 365) // increment by one year to avoid zero-time issues
 	return t
+}
+
+// fakeJob implements Job for testing ExecuteAll in isolation.
+// GetNextExecution fires once immediately (buffered channel) then blocks.
+// It records the times passed to SetLastAttempt and SetPreviousExecution.
+type fakeJob struct {
+	doErr          error
+	nextExecCh     chan time.Time
+	doCalled       chan struct{}
+	lastAttemptSet time.Time
+	prevExecSet    time.Time
+}
+
+func newFakeJob(doErr error) *fakeJob {
+	ch := make(chan time.Time, 1)
+	ch <- time.Now() // ready to fire immediately once, then blocks
+	return &fakeJob{
+		doErr:      doErr,
+		nextExecCh: ch,
+		doCalled:   make(chan struct{}),
+	}
+}
+
+func (f *fakeJob) GetLogger() *zap.Logger            { return zap.NewNop() }
+func (f *fakeJob) GetNextExecution() <-chan time.Time { return f.nextExecCh }
+func (f *fakeJob) SetLastAttempt(t time.Time)         { f.lastAttemptSet = t }
+func (f *fakeJob) SetPreviousExecution(t time.Time)   { f.prevExecSet = t }
+func (f *fakeJob) Do(_ context.Context, _ sender) error {
+	select {
+	case <-f.doCalled:
+	default:
+		close(f.doCalled)
+	}
+	return f.doErr
+}
+
+func noopSender(_ context.Context, _ string, _ []byte) error { return nil }
+
+// TestExecuteAll_previousExecution verifies that SetPreviousExecution is only
+// advanced on a successful Do, and that SetLastAttempt is always called.
+// This guards against the pre-fix behaviour where a failed run left
+// PreviousExecution stale, causing GetNextExecution to fire again immediately.
+func TestExecuteAll_previousExecution(t *testing.T) {
+	t.Run("called on success", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		j := newFakeJob(nil)
+		go func() { <-j.doCalled; cancel() }()
+		_ = ExecuteAll(ctx, noopSender, j)
+
+		if j.lastAttemptSet.IsZero() {
+			t.Error("SetLastAttempt should always be called before Do")
+		}
+		if j.prevExecSet.IsZero() {
+			t.Error("SetPreviousExecution should be called after a successful Do")
+		}
+	})
+
+	t.Run("not called on failure", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		j := newFakeJob(errors.New("boom"))
+		go func() { <-j.doCalled; cancel() }()
+		_ = ExecuteAll(ctx, noopSender, j)
+
+		if j.lastAttemptSet.IsZero() {
+			t.Error("SetLastAttempt should always be called before Do")
+		}
+		if !j.prevExecSet.IsZero() {
+			t.Error("SetPreviousExecution should not be called after a failed Do")
+		}
+	})
+}
+
+// TestBaseJob_GetNextExecution_pacesAfterFailure verifies that after a failed
+// run (SetLastAttempt recorded, PreviousExecution not advanced), the next call
+// to GetNextExecution does not fire immediately. Before the fix, a stale
+// PreviousExecution caused shouldExecuteImmediately to return true on every
+// loop iteration, creating a tight retry loop.
+func TestBaseJob_GetNextExecution_pacesAfterFailure(t *testing.T) {
+	db, err := bolthold.Open(filepath.Join(t.TempDir(), "test.db"), 0600, nil)
+	if err != nil {
+		t.Fatalf("open bolthold: %v", err)
+	}
+	defer db.Close()
+
+	base := &BaseJob{
+		Db:       db,
+		AutoName: "auto",
+		ScName:   "site",
+		Name:     "job",
+		Schedule: jsontypes.MustParseSchedule("@every 1m"),
+		Logger:   zap.NewNop(),
+	}
+
+	// Simulate a failed run: attempt time is recorded but PreviousExecution is not advanced.
+	base.SetLastAttempt(time.Now())
+
+	select {
+	case <-base.GetNextExecution():
+		t.Fatal("GetNextExecution fired immediately after a failed run; tight retry loop detected")
+	case <-time.After(50 * time.Millisecond):
+		// expected: the schedule interval is respected
+	}
 }

--- a/pkg/auto/exporthttp/job/meter.go
+++ b/pkg/auto/exporthttp/job/meter.go
@@ -26,7 +26,7 @@ func getRecordsByTime(ctx context.Context, logger *zap.Logger, historyFn listMet
 	}
 
 	if len(resp.GetMeterReadingRecords()) == 0 {
-		logger.Error("no records found in earliest", zap.String("meter", meter), zap.Time("start", start))
+		logger.Warn("no records found in earliest", zap.String("meter", meter), zap.Time("start", start))
 		return earliest, latest, nil
 	}
 
@@ -39,7 +39,7 @@ func getRecordsByTime(ctx context.Context, logger *zap.Logger, historyFn listMet
 	}
 
 	if len(resp.GetMeterReadingRecords()) == 0 {
-		logger.Error("no records found in latest", zap.String("meter", meter), zap.Time("end", now))
+		logger.Warn("no records found in latest", zap.String("meter", meter), zap.Time("end", now))
 		return earliest, earliest, nil // make sure this resolves consumption to 0 by returning < earliest, earliest, nil >
 	}
 

--- a/pkg/auto/exporthttp/job/occupancy.go
+++ b/pkg/auto/exporthttp/job/occupancy.go
@@ -29,7 +29,7 @@ func (o *OccupancyJob) Do(ctx context.Context, sendFn sender) error {
 		cancel()
 
 		if err != nil {
-			o.Logger.Error("getting occupancy", zap.String("sensor", sensor), zap.Error(err))
+			o.Logger.Warn("getting occupancy", zap.String("sensor", sensor), zap.Error(err))
 			continue
 		}
 

--- a/pkg/auto/exporthttp/job/temperature.go
+++ b/pkg/auto/exporthttp/job/temperature.go
@@ -31,7 +31,7 @@ func (t *TemperatureJob) Do(ctx context.Context, sendFn sender) error {
 		cancel()
 
 		if err != nil {
-			t.Logger.Error("getting air temperature", zap.String("sensor", sensor), zap.Error(err))
+			t.Logger.Warn("getting air temperature", zap.String("sensor", sensor), zap.Error(err))
 			continue
 		}
 		count++

--- a/pkg/auto/exporthttp/job/water.go
+++ b/pkg/auto/exporthttp/job/water.go
@@ -31,14 +31,14 @@ func (w *WaterJob) Do(ctx context.Context, sendFn sender) error {
 		multiplier, err := w.getUnitMultiplier(cctx, meter)
 
 		if err != nil {
-			w.Logger.Error("getting unit multiplier", zap.String("meter", meter), zap.Error(err))
+			w.Logger.Warn("getting unit multiplier", zap.String("meter", meter), zap.Error(err))
 		}
 
 		earliest, latest, err := getRecordsByTime(cctx, w.Logger, w.client.ListMeterReadingHistory, meter, now, filterTime)
 
 		cancel()
 		if err != nil {
-			w.Logger.Error("getting records by time", zap.String("meter", meter), zap.Error(err))
+			w.Logger.Warn("getting records by time", zap.String("meter", meter), zap.Error(err))
 			continue
 		}
 


### PR DESCRIPTION
[OCW-170](https://vanti.youtrack.cloud/issue/OCW-170) Main fix is in job.go where an unreachable device would cause a loop on error. Adds a `lastAttempt` time to track last attempt. Also reduced the 'error' logging to 'warning' where it makes sense.