### PR TITLE
Fix flaky Go tests causing spurious CI failures

### DIFF
--- a/internal/router/stream_test.go
+++ b/internal/router/stream_test.go
@@ -282,7 +282,7 @@ func nodeServer(name string) *grpc.Server {
 }
 
 func bufConn(buf *bufconn.Listener) (*grpc.ClientConn, error) {
-	return grpc.NewClient("localhost:0",
+	return grpc.NewClient("passthrough://localhost:0",
 		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 			return buf.Dial()
 		}),

--- a/pkg/auto/history/factory_test.go
+++ b/pkg/auto/history/factory_test.go
@@ -2,13 +2,13 @@ package history
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
-	"math/rand/v2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -29,200 +29,183 @@ import (
 )
 
 func Test_automation_applyConfig(t *testing.T) {
-	ctx := context.Background()
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithCancel(ctx)
-	t.Cleanup(cancel)
+	synctest.Test(t, func(t *testing.T) {
+		logger := zap.NewNop()
+		occupancy := occupancysensorpb.NewModel()
+		airQuality := airqualitysensorpb.NewModel()
+		airTemperature := airtemperaturepb.NewModel()
+		electric := electricpb.NewModel()
+		meter := meterpb.NewModel()
+		status := statuspb.NewModel()
 
-	logger := zap.NewNop()
-	occupancy := occupancysensorpb.NewModel()
-	airQuality := airqualitysensorpb.NewModel()
-	airTemperature := airtemperaturepb.NewModel()
-	electric := electricpb.NewModel()
-	meter := meterpb.NewModel()
-	status := statuspb.NewModel()
+		announcer := node.New("test")
+		announcer.Logger = logger
 
-	announcer := node.New("test")
+		announcer.Announce("occupancy",
+			node.HasTrait(trait.OccupancySensor),
+			node.HasServer(
+				occupancysensorpb.RegisterOccupancySensorApiServer,
+				occupancysensorpb.OccupancySensorApiServer(occupancysensorpb.NewModelServer(occupancy)),
+			),
+		)
+		announcer.Announce("airquality",
+			node.HasTrait(trait.AirQualitySensor),
+			node.HasServer(
+				airqualitysensorpb.RegisterAirQualitySensorApiServer,
+				airqualitysensorpb.AirQualitySensorApiServer(airqualitysensorpb.NewModelServer(airQuality)),
+			),
+		)
+		announcer.Announce("airtemperature",
+			node.HasTrait(trait.AirTemperature),
+			node.HasServer(
+				airtemperaturepb.RegisterAirTemperatureApiServer,
+				airtemperaturepb.AirTemperatureApiServer(airtemperaturepb.NewModelServer(airTemperature)),
+			),
+		)
+		announcer.Announce("electric",
+			node.HasTrait(trait.Electric),
+			node.HasServer(
+				electricpb.RegisterElectricApiServer,
+				electricpb.ElectricApiServer(electricpb.NewModelServer(electric)),
+			),
+		)
+		announcer.Announce("meter",
+			node.HasTrait(meterpb.TraitName),
+			node.HasServer(
+				meterpb.RegisterMeterApiServer,
+				meterpb.MeterApiServer(meterpb.NewModelServer(meter)),
+			),
+		)
+		announcer.Announce("status",
+			node.HasTrait(statuspb.TraitName),
+			node.HasServer(
+				statuspb.RegisterStatusApiServer,
+				statuspb.StatusApiServer(statuspb.NewModelServer(status)),
+			),
+		)
 
-	announcer.Logger = logger
-
-	announcer.Announce("occupancy",
-		node.HasTrait(trait.OccupancySensor),
-		node.HasServer(
-			occupancysensorpb.RegisterOccupancySensorApiServer,
-			occupancysensorpb.OccupancySensorApiServer(occupancysensorpb.NewModelServer(occupancy)),
-		),
-	)
-
-	announcer.Announce("airquality",
-		node.HasTrait(trait.AirQualitySensor),
-		node.HasServer(
-			airqualitysensorpb.RegisterAirQualitySensorApiServer,
-			airqualitysensorpb.AirQualitySensorApiServer(airqualitysensorpb.NewModelServer(airQuality)),
-		),
-	)
-
-	announcer.Announce("airtemperature",
-		node.HasTrait(trait.AirTemperature),
-		node.HasServer(
-			airtemperaturepb.RegisterAirTemperatureApiServer,
-			airtemperaturepb.AirTemperatureApiServer(airtemperaturepb.NewModelServer(airTemperature)),
-		),
-	)
-
-	announcer.Announce("electric",
-		node.HasTrait(trait.Electric),
-		node.HasServer(
-			electricpb.RegisterElectricApiServer,
-			electricpb.ElectricApiServer(electricpb.NewModelServer(electric)),
-		),
-	)
-
-	announcer.Announce("meter",
-		node.HasTrait(meterpb.TraitName),
-		node.HasServer(
-			meterpb.RegisterMeterApiServer,
-			meterpb.MeterApiServer(meterpb.NewModelServer(meter)),
-		),
-	)
-
-	announcer.Announce("status",
-		node.HasTrait(statuspb.TraitName),
-		node.HasServer(
-			statuspb.RegisterStatusApiServer,
-			statuspb.StatusApiServer(statuspb.NewModelServer(status)),
-		),
-	)
-
-	for _, cfg := range cfgs {
-		a := &automation{
-			clients:   announcer,
-			announcer: node.NewReplaceAnnouncer(announcer),
-			logger:    logger,
+		for _, cfg := range cfgs {
+			a := &automation{
+				clients:   announcer,
+				announcer: node.NewReplaceAnnouncer(announcer),
+				logger:    logger,
+			}
+			if err := a.applyConfig(t.Context(), cfg); err != nil {
+				t.Fatal(err)
+			}
 		}
 
-		err := a.applyConfig(ctx, cfg)
+		// Let all collector goroutines settle into their first time.After wait.
+		synctest.Wait()
 
+		// Many events to each model server; synctest.Wait after each sleep ensures any
+		// poll that fires on that second completes before the next iteration's updates.
+		for i := range 10 {
+			v := float32(i + 1)
+			if _, err := occupancy.SetOccupancy(&occupancysensorpb.Occupancy{
+				State:       occupancysensorpb.Occupancy_OCCUPIED,
+				PeopleCount: int32(i + 1),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := airQuality.UpdateAirQuality(&airqualitysensorpb.AirQuality{
+				CarbonDioxideLevel:       new(v),
+				VolatileOrganicCompounds: new(v),
+				AirPressure:              new(v),
+				InfectionRisk:            new(v),
+				Score:                    new(v),
+				ParticulateMatter_1:      new(v),
+				ParticulateMatter_25:     new(v),
+				ParticulateMatter_10:     new(v),
+				AirChangePerHour:         new(v),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := airTemperature.UpdateAirTemperature(&airtemperaturepb.AirTemperature{
+				AmbientTemperature: &typespb.Temperature{ValueCelsius: float64(i + 1)},
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := electric.UpdateDemand(&electricpb.ElectricDemand{
+				Voltage:       new(v),
+				Current:       v,
+				ReactivePower: new(v),
+				ApparentPower: new(v),
+				PowerFactor:   new(v),
+				RealPower:     new(v),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := meter.UpdateMeterReading(&meterpb.MeterReading{
+				Usage:    v,
+				Produced: v,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := status.UpdateProblem(&statuspb.StatusLog_Problem{
+				Name: fmt.Sprintf("problem-%d", i+1),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			time.Sleep(time.Second)
+			synctest.Wait()
+		}
+
+		aqCli := airqualitysensorpb.NewAirQualitySensorHistoryClient(announcer.ClientConn())
+		occupancyCli := occupancysensorpb.NewOccupancySensorHistoryClient(announcer.ClientConn())
+		airTempCli := airtemperaturepb.NewAirTemperatureHistoryClient(announcer.ClientConn())
+		electricCli := electricpb.NewElectricHistoryClient(announcer.ClientConn())
+		meterCli := meterpb.NewMeterHistoryClient(announcer.ClientConn())
+		statusCli := statuspb.NewStatusHistoryClient(announcer.ClientConn())
+
+		aqHist, err := aqCli.ListAirQualityHistory(t.Context(), &airqualitysensorpb.ListAirQualityHistoryRequest{Name: "airquality", PageSize: 10})
 		if err != nil {
 			t.Fatal(err)
 		}
-	}
-
-	// many events to each model server
-	for range 10 {
-		if _, err := occupancy.SetOccupancy(&occupancysensorpb.Occupancy{
-			State:       occupancysensorpb.Occupancy_OCCUPIED,
-			PeopleCount: int32(rand.IntN(10)),
-		}); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := airQuality.UpdateAirQuality(&airqualitysensorpb.AirQuality{
-			CarbonDioxideLevel:       new(rand.Float32()),
-			VolatileOrganicCompounds: new(rand.Float32()),
-			AirPressure:              new(rand.Float32()),
-			InfectionRisk:            new(rand.Float32()),
-			Score:                    new(rand.Float32()),
-			ParticulateMatter_1:      new(rand.Float32()),
-			ParticulateMatter_25:     new(rand.Float32()),
-			ParticulateMatter_10:     new(rand.Float32()),
-			AirChangePerHour:         new(rand.Float32()),
-		}); err != nil {
-			t.Fatal(err)
+		if diff := cmp.Diff(int32(2), aqHist.GetTotalSize()); diff != "" {
+			t.Fatal(diff, "airquality")
 		}
 
-		if _, err := airTemperature.UpdateAirTemperature(&airtemperaturepb.AirTemperature{
-			AmbientTemperature: &typespb.Temperature{ValueCelsius: rand.Float64()},
-		}); err != nil {
+		occHist, err := occupancyCli.ListOccupancyHistory(t.Context(), &occupancysensorpb.ListOccupancyHistoryRequest{Name: "occupancy", PageSize: 10})
+		if err != nil {
 			t.Fatal(err)
 		}
-
-		if _, err := electric.UpdateDemand(&electricpb.ElectricDemand{
-			Voltage:       new(rand.Float32()),
-			Current:       rand.Float32(),
-			ReactivePower: new(rand.Float32()),
-			ApparentPower: new(rand.Float32()),
-			PowerFactor:   new(rand.Float32()),
-			RealPower:     new(rand.Float32()),
-		}); err != nil {
-			t.Fatal(err)
+		if diff := cmp.Diff(int32(2), occHist.GetTotalSize()); diff != "" {
+			t.Fatal(diff, "occupancy")
 		}
 
-		if _, err := meter.UpdateMeterReading(&meterpb.MeterReading{
-			Usage:    rand.Float32(),
-			Produced: rand.Float32(),
-		}); err != nil {
+		airTempHist, err := airTempCli.ListAirTemperatureHistory(t.Context(), &airtemperaturepb.ListAirTemperatureHistoryRequest{Name: "airtemperature", PageSize: 10})
+		if err != nil {
 			t.Fatal(err)
 		}
-
-		if _, err := status.UpdateProblem(&statuspb.StatusLog_Problem{
-			Name: randString(16),
-		}); err != nil {
-			t.Fatal(err)
+		if diff := cmp.Diff(int32(2), airTempHist.GetTotalSize()); diff != "" {
+			t.Fatal(diff, "airtemperature")
 		}
 
-		time.Sleep(time.Second)
-	}
+		electricHist, err := electricCli.ListElectricDemandHistory(t.Context(), &electricpb.ListElectricDemandHistoryRequest{Name: "electric", PageSize: 10})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(int32(2), electricHist.GetTotalSize()); diff != "" {
+			t.Fatal(diff, "electric")
+		}
 
-	aqCli := airqualitysensorpb.NewAirQualitySensorHistoryClient(announcer.ClientConn())
-	occupancyCli := occupancysensorpb.NewOccupancySensorHistoryClient(announcer.ClientConn())
-	airTempCli := airtemperaturepb.NewAirTemperatureHistoryClient(announcer.ClientConn())
-	electricCli := electricpb.NewElectricHistoryClient(announcer.ClientConn())
-	meterCli := meterpb.NewMeterHistoryClient(announcer.ClientConn())
-	statusCli := statuspb.NewStatusHistoryClient(announcer.ClientConn())
+		meterHist, err := meterCli.ListMeterReadingHistory(t.Context(), &meterpb.ListMeterReadingHistoryRequest{Name: "meter", PageSize: 10})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(int32(2), meterHist.GetTotalSize()); diff != "" {
+			t.Fatal(diff, "meter")
+		}
 
-	aqHist, err := aqCli.ListAirQualityHistory(ctx, &airqualitysensorpb.ListAirQualityHistoryRequest{Name: "airquality", PageSize: 10})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if diff := cmp.Diff(int32(2), aqHist.GetTotalSize()); diff != "" {
-		t.Fatal(diff, "airquality")
-	}
-
-	occHist, err := occupancyCli.ListOccupancyHistory(ctx, &occupancysensorpb.ListOccupancyHistoryRequest{Name: "occupancy", PageSize: 10})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if diff := cmp.Diff(int32(2), occHist.GetTotalSize()); diff != "" {
-		t.Fatal(diff, "occupancy")
-	}
-
-	airTempHist, err := airTempCli.ListAirTemperatureHistory(ctx, &airtemperaturepb.ListAirTemperatureHistoryRequest{Name: "airtemperature", PageSize: 10})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if diff := cmp.Diff(int32(2), airTempHist.GetTotalSize()); diff != "" {
-		t.Fatal(diff, "airtemperature")
-	}
-
-	electricHist, err := electricCli.ListElectricDemandHistory(ctx, &electricpb.ListElectricDemandHistoryRequest{Name: "electric", PageSize: 10})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if diff := cmp.Diff(int32(2), electricHist.GetTotalSize()); diff != "" {
-		t.Fatal(diff, "electric")
-	}
-
-	meterHist, err := meterCli.ListMeterReadingHistory(ctx, &meterpb.ListMeterReadingHistoryRequest{Name: "meter", PageSize: 10})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if diff := cmp.Diff(int32(2), meterHist.GetTotalSize()); diff != "" {
-		t.Fatal(diff, "meter")
-	}
-
-	statusHist, err := statusCli.ListCurrentStatusHistory(ctx, &statuspb.ListCurrentStatusHistoryRequest{Name: "status", PageSize: 10})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(int32(2), statusHist.GetTotalSize()); diff != "" {
-		t.Fatal(diff, "status")
-	}
-
+		statusHist, err := statusCli.ListCurrentStatusHistory(t.Context(), &statuspb.ListCurrentStatusHistoryRequest{Name: "status", PageSize: 10})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(int32(2), statusHist.GetTotalSize()); diff != "" {
+			t.Fatal(diff, "status")
+		}
+	})
 }
 
 var cfgs = []config.Root{
@@ -310,16 +293,6 @@ var cfgs = []config.Root{
 			},
 		},
 	},
-}
-
-const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
-func randString(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = letterBytes[rand.IntN(len(letterBytes))]
-	}
-	return string(b)
 }
 
 func Test_automation_applyConfigDevices(t *testing.T) {

--- a/pkg/driver/proxy/devices_test.go
+++ b/pkg/driver/proxy/devices_test.go
@@ -128,7 +128,7 @@ func TestDeviceFetcher_Poll(t *testing.T) {
 				known:  initial,
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			changes := make(chan *devicespb.PullDevicesResponse_Change, 10)
 
 			err := fetcher.Poll(ctx, changes)
@@ -178,7 +178,7 @@ func TestDeviceFetcher_Poll(t *testing.T) {
 }
 
 func TestDeviceFetcher_Poll_Error(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	n := node.New("test")
@@ -206,14 +206,23 @@ func TestDeviceFetcher_Pull(t *testing.T) {
 				client: client,
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
-			changes := make(chan *devicespb.PullDevicesResponse_Change, 10)
+			changes := make(chan *devicespb.PullDevicesResponse_Change)
 
 			errCh := make(chan error, 1)
 			go func() {
 				errCh <- fetcher.Pull(ctx, changes)
 			}()
+
+			// Drain the initial "test" node state before making any announcements.
+			// resource.Collection.Pull sends the current state sorted by name, so with just
+			// the root node "test" in the collection this is always the first and only change.
+			synctest.Wait()
+			initial := <-changes
+			if initial.Type != typespb.ChangeType_ADD || initial.NewValue.Name != "test" {
+				t.Fatalf("expected initial ADD for test node, got type=%v name=%v", initial.Type, initial.NewValue.GetName())
+			}
 
 			n.Announce("device1", node.HasMetadata(&metadatapb.Metadata{}))
 			synctest.Wait()
@@ -240,7 +249,7 @@ func TestDeviceFetcher_Pull(t *testing.T) {
 	})
 
 	t.Run("handles context cancellation", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 
 		n := node.New("test")

--- a/pkg/task/serviceapi/api.go
+++ b/pkg/task/serviceapi/api.go
@@ -4,7 +4,6 @@ package serviceapi
 import (
 	"context"
 	"errors"
-	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/exp/constraints"
@@ -23,8 +22,7 @@ import (
 // Api implements a servicespb.ServicesApiServer backed by service.Map.
 type Api struct {
 	servicespb.UnimplementedServicesApiServer
-	m   *service.Map
-	now func() time.Time
+	m *service.Map
 
 	knownTypes []string
 	store      Store
@@ -32,7 +30,7 @@ type Api struct {
 }
 
 func NewApi(m *service.Map, opts ...Option) *Api {
-	a := &Api{m: m, now: time.Now}
+	a := &Api{m: m}
 	for _, opt := range opts {
 		opt(a)
 	}
@@ -217,7 +215,7 @@ func (a *Api) pullServices(ctx context.Context, request *servicespb.PullServices
 			last = stateToProto(record.Id, record.Kind, state)
 			change := &servicespb.PullServicesResponse_Change{
 				Name:       request.Name,
-				ChangeTime: timestamppb.New(a.now()),
+				ChangeTime: timestamppb.Now(),
 				Type:       typespb.ChangeType_ADD,
 				NewValue:   last,
 			}
@@ -231,7 +229,7 @@ func (a *Api) pullServices(ctx context.Context, request *servicespb.PullServices
 			last = stateToProto(record.Id, record.Kind, state)
 			change := &servicespb.PullServicesResponse_Change{
 				Name:       request.Name,
-				ChangeTime: timestamppb.New(a.now()),
+				ChangeTime: timestamppb.Now(),
 				Type:       typespb.ChangeType_UPDATE,
 				OldValue:   old,
 				NewValue:   last,

--- a/pkg/task/serviceapi/api_test.go
+++ b/pkg/task/serviceapi/api_test.go
@@ -3,6 +3,7 @@ package serviceapi
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -14,102 +15,89 @@ import (
 )
 
 func TestApi_PullServices(t *testing.T) {
-	assertNoErr := func(tag string, err error) {
-		t.Helper()
-		if err != nil {
-			t.Fatalf("%s: Unexpected error %v", tag, err)
+	synctest.Test(t, func(t *testing.T) {
+		assertNoErr := func(tag string, err error) {
+			t.Helper()
+			if err != nil {
+				t.Fatalf("%s: Unexpected error %v", tag, err)
+			}
 		}
-	}
 
-	m := service.NewMap(createTestLifecycle, service.IdIsUUID)
-	api := NewApi(m)
-	now := time.UnixMilli(0)
-	api.now = func() time.Time {
-		return now
-	}
-	t.Cleanup(service.MapSetNow(m, api.now))
+		m := service.NewMap(createTestLifecycle, service.IdIsUUID)
+		api := NewApi(m)
+		now := time.Now()
 
-	ctx, stop := context.WithCancel(context.Background())
-	t.Cleanup(stop)
-	responses := api.pullServices(ctx, &servicespb.PullServicesRequest{UpdatesOnly: true})
+		ctx := t.Context()
+		responses := api.pullServices(ctx, &servicespb.PullServicesRequest{UpdatesOnly: true})
 
-	_, state1, err := m.Create("id1", "k1", service.State{})
-	assertNoErr("Create", err)
+		_, state1, err := m.Create("id1", "k1", service.State{})
+		assertNoErr("Create", err)
 
-	got, err := receiveWithin(responses, time.Second)
-	assertNoErr("Receive", err)
+		synctest.Wait()
+		got := <-responses
 
-	want := &servicespb.PullServicesResponse_Change{
-		Type:       typespb.ChangeType_ADD,
-		ChangeTime: timeToTimestamp(now),
-		NewValue:   stateToProto("id1", "k1", state1),
-	}
-	if diff := cmpProto(want, got); diff != "" {
-		t.Fatalf("Change1: (-want,+got)\n%s", diff)
-	}
-
-	id1 := m.Get("id1")
-	state2, err := id1.Service.Start()
-	assertNoErr("id1.Start", err)
-	got, err = receiveWithin(responses, time.Millisecond)
-	assertNoErr("Receive", err)
-
-	want = &servicespb.PullServicesResponse_Change{
-		Type: typespb.ChangeType_UPDATE, ChangeTime: timeToTimestamp(now),
-		OldValue: stateToProto("id1", "k1", state1),
-		NewValue: stateToProto("id1", "k1", state2),
-	}
-	if diff := cmpProto(want, got); diff != "" {
-		t.Fatalf("Change2: (-want,+got)\n%s", diff)
-	}
-
-	state3, err := m.Delete("id1")
-	assertNoErr("Delete", err)
-	got, err = receiveWithin(responses, time.Millisecond)
-	assertNoErr("Receive", err)
-
-	// there's a race here between the map removing the record and the service being stopped.
-	// We don't know which will win, if the record is removed first then we'll get one event, the removal
-	// If the stop wins then we'll get two events, an update to Stopped and then the removal.
-	// It doesn't actually matter which one wins, but we do need to check in our test.
-	if got.Type == typespb.ChangeType_UPDATE {
-		want = &servicespb.PullServicesResponse_Change{
-			Type:       typespb.ChangeType_UPDATE,
+		want := &servicespb.PullServicesResponse_Change{
+			Type:       typespb.ChangeType_ADD,
 			ChangeTime: timeToTimestamp(now),
-			OldValue:   stateToProto("id1", "k1", state2),
-			NewValue:   stateToProto("id1", "k1", state3),
+			NewValue:   stateToProto("id1", "k1", state1),
 		}
 		if diff := cmpProto(want, got); diff != "" {
-			t.Fatalf("Change3 race: (-want,+got)\n%s", diff)
+			t.Fatalf("Change1: (-want,+got)\n%s", diff)
 		}
 
-		got, err = receiveWithin(responses, time.Millisecond)
-		assertNoErr("Receive race", err)
-	}
+		id1 := m.Get("id1")
+		state2, err := id1.Service.Start()
+		assertNoErr("id1.Start", err)
 
-	want = &servicespb.PullServicesResponse_Change{
-		Type: typespb.ChangeType_REMOVE, ChangeTime: timeToTimestamp(now),
-		OldValue: stateToProto("id1", "k1", state3),
-	}
-	if diff := cmpProto(want, got); diff != "" {
-		t.Fatalf("Change2: (-want,+got)\n%s", diff)
-	}
+		synctest.Wait()
+		got = <-responses
+
+		want = &servicespb.PullServicesResponse_Change{
+			Type: typespb.ChangeType_UPDATE, ChangeTime: timeToTimestamp(now),
+			OldValue: stateToProto("id1", "k1", state1),
+			NewValue: stateToProto("id1", "k1", state2),
+		}
+		if diff := cmpProto(want, got); diff != "" {
+			t.Fatalf("Change2: (-want,+got)\n%s", diff)
+		}
+
+		state3, err := m.Delete("id1")
+		assertNoErr("Delete", err)
+
+		synctest.Wait()
+		got = <-responses
+
+		// there's a race here between the map removing the record and the service being stopped.
+		// We don't know which will win, if the record is removed first then we'll get one event, the removal
+		// If the stop wins then we'll get two events, an update to Stopped and then the removal.
+		// It doesn't actually matter which one wins, but we do need to check in our test.
+		if got.Type == typespb.ChangeType_UPDATE {
+			want = &servicespb.PullServicesResponse_Change{
+				Type:       typespb.ChangeType_UPDATE,
+				ChangeTime: timeToTimestamp(now),
+				OldValue:   stateToProto("id1", "k1", state2),
+				NewValue:   stateToProto("id1", "k1", state3),
+			}
+			if diff := cmpProto(want, got); diff != "" {
+				t.Fatalf("Change3 race: (-want,+got)\n%s", diff)
+			}
+
+			synctest.Wait()
+			got = <-responses
+		}
+
+		want = &servicespb.PullServicesResponse_Change{
+			Type: typespb.ChangeType_REMOVE, ChangeTime: timeToTimestamp(now),
+			OldValue: stateToProto("id1", "k1", state3),
+		}
+		if diff := cmpProto(want, got); diff != "" {
+			t.Fatalf("Change4: (-want,+got)\n%s", diff)
+		}
+	})
 }
 
 func cmpProto(want, got any) string {
 	return cmp.Diff(want, got, protocmp.Transform())
-}
-
-func receiveWithin[T any](c <-chan T, wait time.Duration) (T, error) {
-	timer := time.NewTimer(wait)
-	defer timer.Stop()
-	select {
-	case v := <-c:
-		return v, nil
-	case <-timer.C:
-		var zero T
-		return zero, context.DeadlineExceeded
-	}
 }
 
 var createTestLifecycle = func(id, kind string) (service.Lifecycle, error) {


### PR DESCRIPTION
There's 2 tests that sometimes fail, causing spurious Go Test fails in Github Actions and locally:
- In `auto/history` - `Test_automation_applyConfig` occasionally failed with an incorrect number of detected changes. Make this deterministic.
- In `internal/router` - `TestStreamHandler/downstream` - fix tests failing with a timeout on some platforms. This was due to accidentally invoking gRPC's name resolution when we're using a fake in-memory dialler.