### PR TITLE
feat/driver health

### DIFF
--- a/example/config/vanti-ugs-cohort/ac-01/app.conf.json
+++ b/example/config/vanti-ugs-cohort/ac-01/app.conf.json
@@ -7,885 +7,2676 @@
   },
   "drivers": [
     {
-      "name": "van/uk/brum/ugs/ac-01/driver/basement",
+      "name": "van/uk/brum/ugs/floor-b1/driver/lighting-ctrl-a",
       "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
       "devices": [
         {
           "name": "van/uk/brum/ugs/devices/LTF-LN1-01",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Bar Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Bar"}
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Bar Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Bar"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/LTF-LN1-02",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement"}
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/LTF-LN1-03",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Stairwell Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Stairwell"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-LN1-04",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-LN1-05",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ring Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-LN1-06",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-LN1-07",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ring Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-LN1-08",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-LN1-09",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ring Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Stairwell Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Stairwell"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/ELT-LN1-01",
           "traits": [
-            {"name": "smartcore.traits.Light"},
-            {"name": "smartcore.bos.Status"},
-            {"name": "smartcore.bos.EmergencyLight"},
-            {"name": "smartcore.traits.EnergyStorage"}
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.bos.EmergencyLight"
+            },
+            {
+              "name": "smartcore.traits.EnergyStorage"
+            }
           ],
-          "appearance": {"title": "Stairwell Emergency Light"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Stairwell"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-LN1-01",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Basement"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-LN1-02",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-LN1-03",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-LN1-04",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/EMT-LN1-01",
-          "traits": [
-            {"name": "smartcore.bos.Meter"}, {"name": "smartcore.traits.Electric"}, {"name": "smartcore.bos.Status"}
-          ],
-          "appearance": {"title": "DN1-001"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Basement", "description": "In the riser room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-LN1-01",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Bar"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-LN1-02",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-LN1-03",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-LN1-04",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-LN1-05",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Stairwell"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-LN1-01",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-LN1-02",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-LN1-03",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-LN1-04",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Bar"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-LN1-01",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Cotswold Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-LN1-02",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Cotswold Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-LN1-03",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Copper Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-LN1-04",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Copper Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-LN1-05",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Kaolin Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-LN1-06",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Kaolin Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L00-01",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Copper Room"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L00-02",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Cotswold Room"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L00-03",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Kaolin Sound Sensor"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/CHW-L00-01",
-          "traits": [{"name":  "smartcore.bos.Temperature"}],
-          "appearance": {"title": "Main Chilled Water"},
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Basement"}
+          "appearance": {
+            "title": "Stairwell Emergency Light"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Stairwell"
+          }
         }
       ]
     },
     {
-      "name": "van/uk/brum/ugs/ac-01/driver/ground",
+      "name": "van/uk/brum/ugs/floor-b1/driver/lighting-ctrl-b",
       "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.2
+      },
       "devices": [
         {
-          "name": "van/uk/brum/ugs/devices/LOK-L00-01",
-          "traits": [{"name": "smartcore.bos.Allocation"}],
-          "membership": {"subsystem": "lockers"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-01",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Entrance Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-02",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Spiral Stair Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-03",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Meeting Room Corridor Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-04",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Kitchen Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Kitchen"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-05",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-06",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-07",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-08",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Project Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-09",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-10",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Tool Station Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-11",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Warehouse"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-12",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Workshop"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-13",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Bench Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Workshop"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-14",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Secure Store"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-15",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Goods In"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-16",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Comms Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-17",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Loading Bay"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/ELT-L00-01",
-          "traits": [
-            {"name": "smartcore.traits.Light"},
-            {"name": "smartcore.bos.Status"},
-            {"name": "smartcore.bos.EmergencyLight"},
-            {"name": "smartcore.traits.EnergyStorage"}
-          ],
-          "appearance": {"title": "Reception Emergency Light"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L00-01",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L00-02",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L00-03",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L00-04",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L00-05",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Ground Floor", "zone": "Project Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L00-06",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/EMT-L00-01",
-          "traits": [
-            {"name": "smartcore.bos.Meter"}, {"name": "smartcore.traits.Electric"}, {"name": "smartcore.bos.Status"}
-          ],
-          "appearance": {"title": "D00-001", "description": "Incomer"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Ground Floor", "zone": "Loading Bay"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/EMT-L00-02",
-          "traits": [
-            {"name": "smartcore.bos.Meter"}, {"name": "smartcore.traits.Electric"}, {"name": "smartcore.bos.Status"}
-          ],
-          "appearance": {"title": "D00-002"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Ground Floor", "zone": "Comms Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/EMT-L00-03",
-          "traits": [
-            {"name": "smartcore.bos.Meter"}, {"name": "smartcore.traits.Electric"}, {"name": "smartcore.bos.Status"}
-          ],
-          "appearance": {"title": "D00-003"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/WMT-L00-01",
+          "name": "van/uk/brum/ugs/devices/LTF-LN1-04",
           "traits": [
             {
-              "name": "smartcore.bos.Meter",
-              "more": {"unit": "m³"}
+              "name": "smartcore.traits.Light"
             },
-            {"name": "smartcore.bos.Status"}
+            {
+              "name": "smartcore.bos.Status"
+            }
           ],
-          "appearance": {"title": "BCWS Meter 01"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Ground Floor", "zone": "Loading Bay"}
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-LN1-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ring Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-LN1-06",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-LN1-07",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ring Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-LN1-08",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-LN1-09",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ring Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-b1/driver/hvac",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.15
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-LN1-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Basement"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-LN1-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-LN1-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-LN1-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/CHW-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.Temperature"
+            }
+          ],
+          "appearance": {
+            "title": "Main Chilled Water"
+          },
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Basement"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-b1/driver/metering",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.05
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/EMT-LN1-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.Meter"
+            },
+            {
+              "name": "smartcore.traits.Electric"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "DN1-001"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Basement",
+            "description": "In the riser room"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/WMT-L00-02",
           "traits": [
             {
               "name": "smartcore.bos.Meter",
-              "more": {"unit": "m³"}
+              "more": {
+                "unit": "m\u00b3"
+              }
             },
-            {"name": "smartcore.bos.Status"}
+            {
+              "name": "smartcore.bos.Status"
+            }
           ],
-          "appearance": {"title": "BCWS Meter 02"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Basement", "zone": "Stairwell"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-01",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-02",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-03",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-04",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-05",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Project Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-06",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-07",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/ACR-L00-01",
-          "traits": [
-            {"name": "smartcore.bos.Access"}, {"name": "smartcore.traits.EnterLeaveSensor"}, {"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}
-          ],
-          "appearance": {"title": "Main Door"},
-          "membership": {"subsystem": "acs"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/ACR-L00-02",
-          "traits": [{"name": "smartcore.bos.Access"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Secure Store Door"},
-          "membership": {"subsystem": "acs"},
-          "location": {"floor": "Ground Floor", "zone": "Secure Store"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/DOR-L00-01",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Shutter"},
-          "membership": {"subsystem": "acs"},
-          "location": {"floor": "Ground Floor", "zone": "Loading Bay"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/DOR-L00-02",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Fire Door"},
-          "membership": {"subsystem": "acs"},
-          "location": {"floor": "Ground Floor", "zone": "Warehouse"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L00-01",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L00-02",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L00-03",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L00-04",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Workshop"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L00-05",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-01",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Main Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-02",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Teal Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-03",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Teal Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-04",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Green Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-05",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Green Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-06",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Yellow Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-07",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Yellow Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-08",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Project Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Project Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-09",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Project Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Project Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L01-01",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Reception"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L01-02",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Teal Room"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L01-03",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Green Room"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L01-04",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Yellow Room"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
+          "appearance": {
+            "title": "BCWS Meter 02"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Stairwell"
+          }
         }
       ]
     },
     {
-      "name": "van/uk/brum/ugs/ac-01/driver/first",
+      "name": "van/uk/brum/ugs/floor-b1/driver/sensors",
       "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-LN1-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Bar"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-LN1-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-LN1-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-LN1-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-LN1-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Stairwell"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-LN1-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-LN1-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-LN1-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-LN1-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Bar"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Copper Room"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Cotswold Room"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Kaolin Sound Sensor"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/BRT-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.BrightnessSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Copper Room Brightness Sensor"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/BRT-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.BrightnessSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Cotswold Room Brightness Sensor"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/BRT-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.BrightnessSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Kaolin Room Brightness Sensor"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-b1/driver/shades",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-LN1-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Cotswold Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-LN1-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Cotswold Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-LN1-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Copper Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-LN1-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Copper Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-LN1-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Kaolin Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-LN1-06",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Kaolin Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/lighting-ctrl-a",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Entrance Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Spiral Stair Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Meeting Room Corridor Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Kitchen Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Kitchen"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-06",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-07",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-08",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Project Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-09",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-10",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Tool Station Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/ELT-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.bos.EmergencyLight"
+            },
+            {
+              "name": "smartcore.traits.EnergyStorage"
+            }
+          ],
+          "appearance": {
+            "title": "Reception Emergency Light"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/lighting-ctrl-b",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.15
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-11",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Warehouse"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-12",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Workshop"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-13",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Bench Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Workshop"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-14",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Secure Store"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-15",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Goods In"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-16",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Comms Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-17",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Loading Bay"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/hvac",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.15
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L00-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L00-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Project Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L00-06",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/metering",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.05
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/EMT-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.Meter"
+            },
+            {
+              "name": "smartcore.traits.Electric"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "D00-001",
+            "description": "Incomer"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Loading Bay"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/EMT-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.bos.Meter"
+            },
+            {
+              "name": "smartcore.traits.Electric"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "D00-002"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Comms Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/EMT-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.bos.Meter"
+            },
+            {
+              "name": "smartcore.traits.Electric"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "D00-003"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/WMT-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.Meter",
+              "more": {
+                "unit": "m\u00b3"
+              }
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "BCWS Meter 01"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Loading Bay"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/sensors",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Project Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-06",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-07",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L00-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Workshop"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L00-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L01-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Reception"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L01-02",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Teal Room"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L01-03",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Green Room"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L01-04",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Yellow Room"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/shades",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Main Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Teal Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Teal Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Green Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Green Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-06",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Yellow Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-07",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Yellow Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-08",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Project Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Project Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-09",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Project Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Project Room"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/acs",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.2
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/ACR-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.Access"
+            },
+            {
+              "name": "smartcore.traits.EnterLeaveSensor"
+            },
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Main Door"
+          },
+          "membership": {
+            "subsystem": "acs"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/ACR-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.bos.Access"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Secure Store Door"
+          },
+          "membership": {
+            "subsystem": "acs"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Secure Store"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/DOR-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Shutter"
+          },
+          "membership": {
+            "subsystem": "acs"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Loading Bay"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/DOR-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Fire Door"
+          },
+          "membership": {
+            "subsystem": "acs"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Warehouse"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/lockers",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.05
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/LOK-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.Allocation"
+            }
+          ],
+          "membership": {
+            "subsystem": "lockers"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-01/driver/lighting-ctrl-a",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
       "devices": [
         {
           "name": "van/uk/brum/ugs/devices/LTF-L01-01",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "First Floor", "zone": "The Bank"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L01-02",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "First Floor", "zone": "Service"}
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "The Bank"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/LTF-L01-03",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "First Floor", "zone": "Open Plan"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L01-04",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "First Floor", "zone": "Printer Room"}
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/ELT-L01-01",
           "traits": [
-            {"name": "smartcore.traits.Light"},
-            {"name": "smartcore.bos.Status"},
-            {"name": "smartcore.bos.EmergencyLight"},
-            {"name": "smartcore.traits.EnergyStorage"}
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.bos.EmergencyLight"
+            },
+            {
+              "name": "smartcore.traits.EnergyStorage"
+            }
           ],
-          "appearance": {"title": "Open Plan Emergency Light"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "First Floor", "zone": "Open Plan"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L01-01",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "First Floor", "zone": "The Bank"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L01-02",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Near the toilets"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L01-03",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Near the back stairs"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L01-04",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "First Floor", "zone": "Service"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L01-01",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "The Bank"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L01-02",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "Service"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L01-03",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Near the toilets"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L01-04",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Near the back stairs"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L01-01",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "The Bank"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L01-02",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "Printer Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L01-03",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "Open Plan"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L01-04",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "Service"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L01-01",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Open Plan Window 1"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Left to right"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L01-02",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Open Plan Window 2"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Left to right"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L01-03",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Open Plan Window 3"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Left to right"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L01-04",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Open Plan Window 4"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Left to right"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L02-01",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "The Bank"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "The Bank"}
+          "appearance": {
+            "title": "Open Plan Emergency Light"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan"
+          }
         }
       ]
     },
     {
-      "name": "van/uk/brum/ugs/ac-01/driver/roof",
+      "name": "van/uk/brum/ugs/floor-01/driver/lighting-ctrl-b",
       "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.2
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L01-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Service"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L01-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Printer Room"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-01/driver/hvac",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.15
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L01-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "The Bank"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L01-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Near the toilets"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L01-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Near the back stairs"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L01-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Service"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-01/driver/sensors",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L01-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "The Bank"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L01-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Service"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L01-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Near the toilets"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L01-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Near the back stairs"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L01-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "The Bank"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L01-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Printer Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L01-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L01-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Service"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L02-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "The Bank"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "The Bank"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-01/driver/shades",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L01-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Open Plan Window 1"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Left to right"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L01-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Open Plan Window 2"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Left to right"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L01-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Open Plan Window 3"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Left to right"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L01-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Open Plan Window 4"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Left to right"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-rf/driver/hvac",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.15
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/TMP-L02-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Outside Air Temperature"
+          },
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Roof"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-rf/driver/metering",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.05
+      },
       "devices": [
         {
           "name": "van/uk/brum/ugs/devices/PV-L02-01",
           "traits": [
-            {"name": "smartcore.bos.Meter"}, {"name": "smartcore.traits.Electric"}, {"name": "smartcore.bos.Status"}
+            {
+              "name": "smartcore.bos.Meter"
+            },
+            {
+              "name": "smartcore.traits.Electric"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
           ],
-          "appearance": {"title": "Solar PV"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Roof"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/TMP-L02-01",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}
-          ],
-          "appearance": {"title": "Outside Air Temperature"},
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Roof"}
+          "appearance": {
+            "title": "Solar PV"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Roof"
+          }
         }
       ]
     },
@@ -900,7 +2691,9 @@
               "name": "smartcore.bos.SecurityEvent"
             }
           ],
-          "appearance": {"title": "Security Events"}
+          "appearance": {
+            "title": "Security Events"
+          }
         }
       ]
     },
@@ -915,7 +2708,9 @@
               "name": "smartcore.bos.Waste"
             }
           ],
-          "appearance": {"title": "Waste"}
+          "appearance": {
+            "title": "Waste"
+          }
         }
       ]
     },
@@ -933,8 +2728,12 @@
               }
             }
           ],
-          "appearance": {"title": "Lift 1"},
-          "membership": {"subsystem": "vt"}
+          "appearance": {
+            "title": "Lift 1"
+          },
+          "membership": {
+            "subsystem": "vt"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/lift-02",
@@ -946,22 +2745,41 @@
               }
             }
           ],
-          "appearance": {"title": "Lift 2"},
-          "membership": {"subsystem": "vt"}
+          "appearance": {
+            "title": "Lift 2"
+          },
+          "membership": {
+            "subsystem": "vt"
+          }
         }
       ]
     },
     {
-      "name": "van/uk/brum/ugs/eg-bc-01/driver/external", "type": "mock", "devices": [
-      {
-        "name": "van/uk/brum/ugs/devices/EVD-EXT-01",
-        "traits": [
-          {"name": "smartcore.traits.EnergyStorage", "more": {"type": "ev"}}, {"name": "smartcore.bos.Status"}
-        ],
-        "appearance": {"title": "EV Delivery Car", "description": "Delivers AV equipment to sites"},
-        "membership": {"subsystem": "fleet"}
-      }
-    ]
+      "name": "van/uk/brum/ugs/eg-bc-01/driver/external",
+      "type": "mock",
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/EVD-EXT-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.EnergyStorage",
+              "more": {
+                "type": "ev"
+              }
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "EV Delivery Car",
+            "description": "Delivers AV equipment to sites"
+          },
+          "membership": {
+            "subsystem": "fleet"
+          }
+        }
+      ]
     }
   ],
   "zones": [
@@ -969,9 +2787,17 @@
       "name": "van/uk/brum/ugs/zones/building",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Vanti HQ"},
-        "location": {"more": {"address": "44 Upper Gough Street, Birmingham, B1 1JL"}},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Vanti HQ"
+        },
+        "location": {
+          "more": {
+            "address": "44 Upper Gough Street, Birmingham, B1 1JL"
+          }
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
       "lights": [
         "van/uk/brum/ugs/zones/floors/basement",
@@ -988,7 +2814,9 @@
         "van/uk/brum/ugs/zones/floors/ground"
       ],
       "meterGroups": {
-        "generated": ["van/uk/brum/ugs/devices/PV-L02-01"],
+        "generated": [
+          "van/uk/brum/ugs/devices/PV-L02-01"
+        ],
         "water": [
           "van/uk/brum/ugs/devices/WMT-L00-01",
           "van/uk/brum/ugs/devices/WMT-L00-02"
@@ -999,7 +2827,9 @@
         "van/uk/brum/ugs/zones/floors/ground"
       ],
       "electricGroups": {
-        "generated": ["van/uk/brum/ugs/devices/PV-L02-01"]
+        "generated": [
+          "van/uk/brum/ugs/devices/PV-L02-01"
+        ]
       },
       "occupancySensors": [
         "van/uk/brum/ugs/zones/floors/basement",
@@ -1015,18 +2845,29 @@
         "van/uk/brum/ugs/zones/floors/first"
       ],
       "soundSensors": [
-        "van/uk/brum/ugs/zones/floors/basement",
-        "van/uk/brum/ugs/zones/floors/ground",
-        "van/uk/brum/ugs/zones/floors/first"
+        "van/uk/brum/ugs/devices/SND-L00-01",
+        "van/uk/brum/ugs/devices/SND-L00-02",
+        "van/uk/brum/ugs/devices/SND-L00-03",
+        "van/uk/brum/ugs/devices/SND-L01-01",
+        "van/uk/brum/ugs/devices/SND-L01-02",
+        "van/uk/brum/ugs/devices/SND-L01-03",
+        "van/uk/brum/ugs/devices/SND-L01-04",
+        "van/uk/brum/ugs/devices/SND-L02-01"
       ]
     },
     {
       "name": "van/uk/brum/ugs/zones/floors/basement",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Basement"},
-        "location": {"floor": "Basement"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Basement"
+        },
+        "location": {
+          "floor": "Basement"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
       "lights": [
         "van/uk/brum/ugs/devices/LTF-LN1-01",
@@ -1042,8 +2883,12 @@
         "van/uk/brum/ugs/zones/rooms/cotswold",
         "van/uk/brum/ugs/zones/rooms/kaolin"
       ],
-      "meters": ["van/uk/brum/ugs/devices/EMT-LN1-01"],
-      "electrics": ["van/uk/brum/ugs/devices/EMT-LN1-01"],
+      "meters": [
+        "van/uk/brum/ugs/devices/EMT-LN1-01"
+      ],
+      "electrics": [
+        "van/uk/brum/ugs/devices/EMT-LN1-01"
+      ],
       "occupancySensors": [
         "van/uk/brum/ugs/devices/PIR-LN1-01",
         "van/uk/brum/ugs/zones/rooms/copper",
@@ -1072,9 +2917,15 @@
       "name": "van/uk/brum/ugs/zones/floors/ground",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Ground Floor"},
-        "location": {"floor": "Ground Floor"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Ground Floor"
+        },
+        "location": {
+          "floor": "Ground Floor"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
       "lights": [
         "van/uk/brum/ugs/zones/areas/reception",
@@ -1143,9 +2994,15 @@
       "name": "van/uk/brum/ugs/zones/floors/first",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "First Floor"},
-        "location": {"floor": "First Floor"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "First Floor"
+        },
+        "location": {
+          "floor": "First Floor"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
       "lights": [
         "van/uk/brum/ugs/zones/rooms/bank",
@@ -1183,138 +3040,289 @@
       "name": "van/uk/brum/ugs/zones/rooms/copper",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Copper Room"},
-        "location": {"floor": "Basement", "zone": "Copper Room", "description": "Near the bar"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Copper Room"
+        },
+        "location": {
+          "floor": "Basement",
+          "zone": "Copper Room",
+          "description": "Near the bar"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-LN1-04", "van/uk/brum/ugs/devices/LTF-LN1-05"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-LN1-04",
+        "van/uk/brum/ugs/devices/LTF-LN1-05"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-LN1-01"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-LN1-02"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-LN1-01"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-LN1-02"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-LN1-02"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-LN1-02"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-LN1-01"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L00-01"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-LN1-02"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-LN1-02"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-LN1-01"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L00-01"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/cotswold",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Cotswold Room"},
-        "location": {"floor": "Basement", "zone": "Cotswold Room", "description": "Far corner"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Cotswold Room"
+        },
+        "location": {
+          "floor": "Basement",
+          "zone": "Cotswold Room",
+          "description": "Far corner"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-LN1-06", "van/uk/brum/ugs/devices/LTF-LN1-07"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-LN1-06",
+        "van/uk/brum/ugs/devices/LTF-LN1-07"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-LN1-03"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-LN1-04"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-LN1-03"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-LN1-04"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-LN1-03"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-LN1-03"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-LN1-02"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L00-02"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-LN1-03"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-LN1-03"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-LN1-02"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L00-02"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/kaolin",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Kaolin Room"},
-        "location": {"floor": "Basement", "zone": "Kaolin Room", "description": "Near the pool table"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Kaolin Room"
+        },
+        "location": {
+          "floor": "Basement",
+          "zone": "Kaolin Room",
+          "description": "Near the pool table"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-LN1-08", "van/uk/brum/ugs/devices/LTF-LN1-09"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-LN1-08",
+        "van/uk/brum/ugs/devices/LTF-LN1-09"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-LN1-05"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-LN1-06"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-LN1-05"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-LN1-06"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-LN1-04"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-LN1-04"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-LN1-03"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L00-03"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-LN1-04"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-LN1-04"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-LN1-03"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L00-03"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/teal",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Teal Room"},
-        "location": {"floor": "Ground Floor", "zone": "Teal Room"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Teal Room"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Teal Room"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-05"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-05"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-L00-02"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-L00-03"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-L00-02"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-L00-03"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L00-02"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L00-02"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L00-01"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L01-02"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L00-02"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L00-02"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L00-01"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L01-02"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/green",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Green Room"},
-        "location": {"floor": "Ground Floor", "zone": "Green Room"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Green Room"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Green Room"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-06"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-06"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-L00-04"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-L00-05"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-L00-04"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-L00-05"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L00-03"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L00-03"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L00-02"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L01-03"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L00-03"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L00-03"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L00-02"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L01-03"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/yellow",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Yellow Room"},
-        "location": {"floor": "Ground Floor", "zone": "Yellow Room"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Yellow Room"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Yellow Room"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-07"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-07"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-L00-06"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-L00-07"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-L00-06"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-L00-07"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L00-04"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L00-04"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L00-03"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L01-04"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L00-04"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L00-04"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L00-03"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L01-04"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/project",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Project Room"},
-        "location": {"floor": "Ground Floor", "zone": "Project Room"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Project Room"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Project Room"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-08"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-08"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-L00-08"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-L00-09"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-L00-08"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-L00-09"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L00-05"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L00-05"],
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L00-05"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L00-05"
+      ],
       "drivers": [
         {
-          "type": "mock", "name": "van/uk/brum/ugs/zones/areas/project/driver-mock",
+          "type": "mock",
+          "name": "van/uk/brum/ugs/zones/areas/project/driver-mock",
           "devices": [
             {
-              "name": "van/uk/brum/ugs/zones/areas/project", "traits": [
-              {
-                "name": "smartcore.traits.Mode",
-                "more": {
-                  "modes": "{\"modes\": [{\"name\":\"lighting.mode\",\"values\":[{\"name\":\"auto\"},{\"name\":\"manual\"}]},{\"name\":\"hvac.mode\",\"values\":[{\"name\":\"auto\"},{\"name\":\"manual\"}]}]}"
+              "name": "van/uk/brum/ugs/zones/areas/project",
+              "traits": [
+                {
+                  "name": "smartcore.traits.Mode",
+                  "more": {
+                    "modes": "{\"modes\": [{\"name\":\"lighting.mode\",\"values\":[{\"name\":\"auto\"},{\"name\":\"manual\"}]},{\"name\":\"hvac.mode\",\"values\":[{\"name\":\"auto\"},{\"name\":\"manual\"}]}]}"
+                  }
                 }
-              }
-            ]
+              ]
             }
           ]
         }
@@ -1324,151 +3332,304 @@
       "name": "van/uk/brum/ugs/zones/areas/lab",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Lab"},
-        "location": {"floor": "Ground Floor", "zone": "Lab"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Lab"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Lab"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-09", "van/uk/brum/ugs/devices/LTF-L00-10"],
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L00-06"],
-      "meters": ["van/uk/brum/ugs/devices/EMT-L00-03"],
-      "electrics": ["van/uk/brum/ugs/devices/EMT-L00-03"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L00-06", "van/uk/brum/ugs/devices/PIR-L00-07"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L00-05"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-09",
+        "van/uk/brum/ugs/devices/LTF-L00-10"
+      ],
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L00-06"
+      ],
+      "meters": [
+        "van/uk/brum/ugs/devices/EMT-L00-03"
+      ],
+      "electrics": [
+        "van/uk/brum/ugs/devices/EMT-L00-03"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L00-06",
+        "van/uk/brum/ugs/devices/PIR-L00-07"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L00-05"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/warehouse",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Warehouse"},
-        "location": {"floor": "Ground Floor", "zone": "Warehouse"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Warehouse"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Warehouse"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-11"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-11"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/workshop",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Workshop"},
-        "location": {"floor": "Ground Floor", "zone": "Workshop"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Workshop"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Workshop"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-12", "van/uk/brum/ugs/devices/LTF-L00-13"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L00-04"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-12",
+        "van/uk/brum/ugs/devices/LTF-L00-13"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L00-04"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/kitchen",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Kitchen"},
-        "location": {"floor": "Ground Floor", "zone": "Kitchen"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Kitchen"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Kitchen"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-04"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-04"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/goods-in",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Goods In"},
-        "location": {"floor": "Ground Floor", "zone": "Goods In"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Goods In"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Goods In"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-15"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-15"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/secure-store",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Secure Store"},
-        "location": {"floor": "Ground Floor", "zone": "Secure Store"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Secure Store"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Secure Store"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-14"],
-      "enterLeaveSensors": ["van/uk/brum/ugs/devices/ACR-L00-02"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-14"
+      ],
+      "enterLeaveSensors": [
+        "van/uk/brum/ugs/devices/ACR-L00-02"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/comms-room",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Comms Room"},
-        "location": {"floor": "Ground Floor", "zone": "Comms Room"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Comms Room"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Comms Room"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-16"],
-      "meters": ["van/uk/brum/ugs/devices/EMT-L00-02"],
-      "electrics": ["van/uk/brum/ugs/devices/EMT-L00-02"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-16"
+      ],
+      "meters": [
+        "van/uk/brum/ugs/devices/EMT-L00-02"
+      ],
+      "electrics": [
+        "van/uk/brum/ugs/devices/EMT-L00-02"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/reception",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Reception"},
-        "location": {"floor": "Ground Floor", "zone": "Reception"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Reception"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Reception"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "enterLeaveSensors": ["van/uk/brum/ugs/devices/ACR-L00-01"],
+      "enterLeaveSensors": [
+        "van/uk/brum/ugs/devices/ACR-L00-01"
+      ],
       "lights": [
         "van/uk/brum/ugs/devices/LTF-L00-01",
         "van/uk/brum/ugs/devices/LTF-L00-02",
         "van/uk/brum/ugs/devices/LTF-L00-03"
       ],
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L00-01"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L00-01"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L01-01"],
-      "openClose": ["van/uk/brum/ugs/devices/ACR-L00-01"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L00-01"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L00-01"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L01-01"
+      ],
+      "openClose": [
+        "van/uk/brum/ugs/devices/ACR-L00-01"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/l00-wc",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "WC"},
-        "location": {"floor": "Ground Floor", "zone": "WC"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "WC"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "WC"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       }
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/loading-bay",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Loading Bay"},
-        "location": {"floor": "Ground Floor", "zone": "Loading Bay"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Loading Bay"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Loading Bay"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "enterLeaveSensors": ["van/uk/brum/ugs/devices/DOR-L00-01"],
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-17"],
-      "openClose": ["van/uk/brum/ugs/devices/DOR-L00-01"]
+      "enterLeaveSensors": [
+        "van/uk/brum/ugs/devices/DOR-L00-01"
+      ],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-17"
+      ],
+      "openClose": [
+        "van/uk/brum/ugs/devices/DOR-L00-01"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/bank",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "The Bank"},
-        "location": {"floor": "First Floor", "zone": "The Bank"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "The Bank"
+        },
+        "location": {
+          "floor": "First Floor",
+          "zone": "The Bank"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L01-01"],
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L01-01"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L01-01"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L01-01"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L02-01"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L01-01"
+      ],
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L01-01"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L01-01"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L01-01"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L02-01"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/open-plan",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Open Plan"},
-        "location": {"floor": "First Floor", "zone": "Open Plan"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Open Plan"
+        },
+        "location": {
+          "floor": "First Floor",
+          "zone": "Open Plan"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
       "lights": [
         "van/uk/brum/ugs/devices/LTF-L01-03"
       ],
       "openCloseGroups": {
-        "window1": ["van/uk/brum/ugs/devices/SHD-L01-01"],
-        "window2": ["van/uk/brum/ugs/devices/SHD-L01-02"],
-        "window3": ["van/uk/brum/ugs/devices/SHD-L01-03"],
-        "window4": ["van/uk/brum/ugs/devices/SHD-L01-04"]
+        "window1": [
+          "van/uk/brum/ugs/devices/SHD-L01-01"
+        ],
+        "window2": [
+          "van/uk/brum/ugs/devices/SHD-L01-02"
+        ],
+        "window3": [
+          "van/uk/brum/ugs/devices/SHD-L01-03"
+        ],
+        "window4": [
+          "van/uk/brum/ugs/devices/SHD-L01-04"
+        ]
       },
       "thermostats": [
         "van/uk/brum/ugs/devices/FCU-L01-02",
@@ -1478,39 +3639,74 @@
         "van/uk/brum/ugs/devices/PIR-L01-03",
         "van/uk/brum/ugs/devices/PIR-L01-04"
       ],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L01-03"]
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L01-03"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/printer-room",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Printer Room"},
-        "location": {"floor": "First Floor", "zone": "Printer Room"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Printer Room"
+        },
+        "location": {
+          "floor": "First Floor",
+          "zone": "Printer Room"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L01-04"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L01-02"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L01-04"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L01-02"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/service",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Service"},
-        "location": {"floor": "First Floor", "zone": "Service"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Service"
+        },
+        "location": {
+          "floor": "First Floor",
+          "zone": "Service"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L01-02"],
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L01-04"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L01-02"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L01-04"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L01-02"
+      ],
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L01-04"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L01-02"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L01-04"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/l01-wc",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "WC"},
-        "location": {"floor": "First Floor", "zone": "WC"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "WC"
+        },
+        "location": {
+          "floor": "First Floor",
+          "zone": "WC"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       }
     }
   ],
@@ -1518,611 +3714,1121 @@
     {
       "name": "van/uk/brum/ugs/automation/electric-history/EMT-LN1-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-LN1-01", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-LN1-01",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/EMT-L00-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-L00-01", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-L00-01",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/EMT-L00-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-L00-02", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-L00-02",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/EMT-L00-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-L00-03", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-L00-03",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/allocation-history/LOK-L00-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/LOK-L00-01", "trait": "smartcore.bos.Allocation"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/LOK-L00-01",
+        "trait": "smartcore.bos.Allocation"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/building",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/building/generated",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building/generated", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building/generated",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/basement",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/basement", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/basement",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/ground",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/ground", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/ground",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/lab",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/lab", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/lab",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
-
     {
       "name": "van/uk/brum/ugs/automation/electric-history/comms-room",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/comms-room", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/comms-room",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/EMT-LN1-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-LN1-01", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-LN1-01",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/EMT-L00-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-L00-01", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-L00-01",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/EMT-L00-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-L00-02", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-L00-02",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/EMT-L00-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-L00-03", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-L00-03",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/WMT-L00-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/WMT-L00-01", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/WMT-L00-01",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/WMT-L00-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/WMT-L00-02", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/WMT-L00-02",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/building",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/building/generated",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building/generated", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building/generated",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/building/water",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building/water", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building/water",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/basement",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/basement", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/basement",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/ground",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/ground", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/ground",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/lab",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/lab", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/lab",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/comms-room",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/comms-room", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/comms-room",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/lab",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/lab", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/lab",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/open-plan",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/open-plan", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/open-plan",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/service",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/service", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/service",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/floors/basement",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/basement", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/basement",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/floors/first",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/first", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/first",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/floors/ground",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/ground", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/ground",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/rooms/bank",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/bank", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/bank",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/rooms/printer-room",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/printer-room", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/printer-room",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/rooms/bank",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/bank", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/bank",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/building",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/copper",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/copper", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/copper",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/cotswold",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/cotswold", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/cotswold",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/kaolin",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/kaolin", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/kaolin",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/teal",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/teal", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/teal",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/green",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/green", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/green",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/yellow",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/yellow", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/yellow",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/project",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/project", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/project",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/lab",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/lab", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/lab",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/building",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/copper",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/copper", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/copper",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/cotswold",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/cotswold", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/cotswold",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/kaolin",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/kaolin", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/kaolin",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/teal",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/teal", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/teal",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/green",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/green", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/green",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/yellow",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/yellow", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/yellow",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/workshop",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/workshop", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/workshop",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-LN1-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-LN1-01", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-LN1-01",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-LN1-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-LN1-02", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-LN1-02",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-LN1-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-LN1-03", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-LN1-03",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-LN1-04",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-LN1-04", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-LN1-04",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L00-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L00-01", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L00-01",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L00-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L00-02", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L00-02",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L00-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L00-03", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L00-03",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L00-04",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L00-04", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L00-04",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L00-05",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L00-05", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L00-05",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L01-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L01-01", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L01-01",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L01-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L01-02", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L01-02",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L01-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L01-03", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L01-03",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L01-04",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L01-04", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L01-04",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/lift-history/lift-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/lift-01", "trait": "smartcore.bos.Transport"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/lift-01",
+        "trait": "smartcore.bos.Transport"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/lift-history/lift-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/lift-02", "trait": "smartcore.bos.Transport"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/lift-02",
+        "trait": "smartcore.bos.Transport"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L00-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L00-01", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L00-01",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L00-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L00-02", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L00-02",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L00-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L00-03", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L00-03",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L01-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L01-01", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L01-01",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L01-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L01-02", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L01-02",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L01-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L01-03", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L01-03",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L01-04",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L01-04", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L01-04",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L02-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L02-01", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L02-01",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/building",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/floors/basement",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/basement", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/basement",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/floors/ground",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/ground", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/ground",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/floors/first",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/first", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/first",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/copper",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/copper", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/copper",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/cotswold",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/cotswold", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/cotswold",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/kaolin",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/kaolin", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/kaolin",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/teal",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/teal", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/teal",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/green",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/green", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/green",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/yellow",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/yellow", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/yellow",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/areas/reception",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/reception", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/reception",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/areas/project",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/project", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/project",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/areas/lab",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/lab", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/lab",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/bank",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/bank", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/bank",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/areas/open-plan",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/open-plan", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/open-plan",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/areas/service",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/service", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/service",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/health/air-temperature-range",
       "type": "healthbounds",
-      "devices": [{"field": "metadata.traits.name", "stringEqual": "smartcore.traits.AirTemperature"}],
-      "source": {"trait": "smartcore.traits.AirTemperature", "value": "ambientTemperature.valueCelsius"},
+      "devices": [
+        {
+          "field": "metadata.traits.name",
+          "stringEqual": "smartcore.traits.AirTemperature"
+        }
+      ],
+      "source": {
+        "trait": "smartcore.traits.AirTemperature",
+        "value": "ambientTemperature.valueCelsius"
+      },
       "check": {
         "displayName": "Comfortable Air Temperature",
         "description": "Checks that the air temperature is within a comfortable range",
         "occupantImpact": "COMFORT",
         "bounds": {
           "normalRange": {
-            "low": {"floatValue": 18},
-            "high": {"floatValue": 24},
-            "deadband": {"floatValue": 1}
+            "low": {
+              "floatValue": 18
+            },
+            "high": {
+              "floatValue": 24
+            },
+            "deadband": {
+              "floatValue": 1
+            }
           },
-          "displayUnit": "°C"
+          "displayUnit": "\u00b0C"
         }
       }
     },
     {
       "name": "van/uk/brum/ugs/automation/health/air-temperature-manufacturer-range",
       "type": "healthbounds",
-      "devices": [{"field": "metadata.traits.name", "stringEqual": "smartcore.traits.AirTemperature"}],
-      "source": {"trait": "smartcore.traits.AirTemperature", "value": "ambientTemperature.valueCelsius"},
+      "devices": [
+        {
+          "field": "metadata.traits.name",
+          "stringEqual": "smartcore.traits.AirTemperature"
+        }
+      ],
+      "source": {
+        "trait": "smartcore.traits.AirTemperature",
+        "value": "ambientTemperature.valueCelsius"
+      },
       "check": {
         "displayName": "Manufacturer Air Temperature Range",
         "description": "Checks that the air temperature is within the manufacturer's recommended range",
         "equipmentImpact": "LIFESPAN",
         "bounds": {
           "normalRange": {
-            "low": {"floatValue": 10},
-            "high": {"floatValue": 35},
-            "deadband": {"floatValue": 2}
+            "low": {
+              "floatValue": 10
+            },
+            "high": {
+              "floatValue": 35
+            },
+            "deadband": {
+              "floatValue": 2
+            }
           },
-          "displayUnit": "°C"
+          "displayUnit": "\u00b0C"
         }
       }
     },
     {
       "name": "van/uk/brum/ugs/automation/health/emergency-light-function-test",
       "type": "healthbounds",
-      "devices": [{"field": "metadata.traits.name", "stringEqual": "smartcore.bos.EmergencyLight"}],
-      "source": {"trait": "smartcore.bos.EmergencyLight", "value": "functionTest.result"},
+      "devices": [
+        {
+          "field": "metadata.traits.name",
+          "stringEqual": "smartcore.bos.EmergencyLight"
+        }
+      ],
+      "source": {
+        "trait": "smartcore.bos.EmergencyLight",
+        "value": "functionTest.result"
+      },
       "check": {
         "displayName": "Emergency Light Function Test",
         "description": "Checks that an emergency lights function test is passing without error",
         "complianceImpacts": [
           {
-            "standard": {"displayName": "BS 5266"},
+            "standard": {
+              "displayName": "BS 5266"
+            },
             "contribution": "FAIL"
           }
         ],
         "bounds": {
-          "normalValues": {"values": [{"stringValue": "TEST_RESULT_PENDING"}, {"stringValue": "TEST_PASSED"}]}
+          "normalValues": {
+            "values": [
+              {
+                "stringValue": "TEST_RESULT_PENDING"
+              },
+              {
+                "stringValue": "TEST_PASSED"
+              }
+            ]
+          }
         }
       }
     },
     {
       "name": "van/uk/brum/ugs/automation/health/emergency-light-duration-test",
       "type": "healthbounds",
-      "devices": [{"field": "metadata.traits.name", "stringEqual": "smartcore.bos.EmergencyLight"}],
-      "source": {"trait": "smartcore.bos.EmergencyLight", "value": "durationTest.result"},
+      "devices": [
+        {
+          "field": "metadata.traits.name",
+          "stringEqual": "smartcore.bos.EmergencyLight"
+        }
+      ],
+      "source": {
+        "trait": "smartcore.bos.EmergencyLight",
+        "value": "durationTest.result"
+      },
       "check": {
         "displayName": "Emergency Light Duration Test",
         "description": "Checks that an emergency lights duration test is passing without error",
         "complianceImpacts": [
           {
-            "standard": {"displayName": "BS 5266"},
+            "standard": {
+              "displayName": "BS 5266"
+            },
             "contribution": "FAIL"
           }
         ],
         "bounds": {
-          "normalValues": {"values": [{"stringValue": "TEST_RESULT_PENDING"}, {"stringValue": "TEST_PASSED"}]}
+          "normalValues": {
+            "values": [
+              {
+                "stringValue": "TEST_RESULT_PENDING"
+              },
+              {
+                "stringValue": "TEST_PASSED"
+              }
+            ]
+          }
         }
       }
     }

--- a/example/config/vanti-ugs-cohort/ui-config.json
+++ b/example/config/vanti-ugs-cohort/ui-config.json
@@ -1279,6 +1279,69 @@
           }
         }
       }
+    },
+    "system": {
+      "subsystemHealth": {
+        "subsystems": [
+          {
+            "title": "Lighting",
+            "icon": "mdi-lightbulb-group-outline",
+            "description": "Lighting control",
+            "checks": [
+              {
+                "displayName": "Basement",
+                "checks": [
+                  {"name": "van/uk/brum/ugs/floor-b1/driver/lighting-ctrl-a", "displayName": "Panel A – Bar & Common"},
+                  {"name": "van/uk/brum/ugs/floor-b1/driver/lighting-ctrl-b", "displayName": "Panel B – Meeting Rooms"}
+                ]
+              },
+              {
+                "displayName": "Ground Floor",
+                "checks": [
+                  {"name": "van/uk/brum/ugs/floor-gf/driver/lighting-ctrl-a", "displayName": "Panel A – Office"},
+                  {"name": "van/uk/brum/ugs/floor-gf/driver/lighting-ctrl-b", "displayName": "Panel B – Industrial"}
+                ]
+              },
+              {
+                "displayName": "First Floor",
+                "checks": [
+                  {"name": "van/uk/brum/ugs/floor-01/driver/lighting-ctrl-a", "displayName": "Panel A – Open Plan"},
+                  {"name": "van/uk/brum/ugs/floor-01/driver/lighting-ctrl-b", "displayName": "Panel B – Service"}
+                ]
+              }
+            ]
+          },
+          {
+            "title": "HVAC",
+            "icon": "mdi-hvac",
+            "description": "Heating, ventilation and air conditioning",
+            "checks": [
+              {"name": "van/uk/brum/ugs/floor-b1/driver/hvac", "displayName": "Basement"},
+              {"name": "van/uk/brum/ugs/floor-gf/driver/hvac", "displayName": "Ground Floor"},
+              {"name": "van/uk/brum/ugs/floor-01/driver/hvac", "displayName": "First Floor"},
+              {"name": "van/uk/brum/ugs/floor-rf/driver/hvac", "displayName": "Roof"}
+            ]
+          },
+          {
+            "title": "Access Control",
+            "icon": "mdi-shield-key-outline",
+            "description": "Door access readers",
+            "checks": [
+              {"name": "van/uk/brum/ugs/floor-gf/driver/acs", "displayName": "Ground Floor"}
+            ]
+          },
+          {
+            "title": "Sensors",
+            "icon": "mdi-leak",
+            "description": "Environmental and occupancy sensors",
+            "checks": [
+              {"name": "van/uk/brum/ugs/floor-b1/driver/sensors", "displayName": "Basement"},
+              {"name": "van/uk/brum/ugs/floor-gf/driver/sensors", "displayName": "Ground Floor"},
+              {"name": "van/uk/brum/ugs/floor-01/driver/sensors", "displayName": "First Floor"}
+            ]
+          }
+        ]
+      }
     }
   },
   "experiments": {

--- a/example/config/vanti-ugs/app.conf.json
+++ b/example/config/vanti-ugs/app.conf.json
@@ -7,906 +7,2676 @@
   },
   "drivers": [
     {
-      "name": "van/uk/brum/ugs/eg-ac-01/driver/basement",
+      "name": "van/uk/brum/ugs/floor-b1/driver/lighting-ctrl-a",
       "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
       "devices": [
         {
           "name": "van/uk/brum/ugs/devices/LTF-LN1-01",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Bar Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Bar"}
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Bar Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Bar"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/LTF-LN1-02",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement"}
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/LTF-LN1-03",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Stairwell Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Stairwell"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-LN1-04",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-LN1-05",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ring Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-LN1-06",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-LN1-07",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ring Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-LN1-08",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-LN1-09",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ring Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Stairwell Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Stairwell"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/ELT-LN1-01",
           "traits": [
-            {"name": "smartcore.traits.Light"},
-            {"name": "smartcore.bos.Status"},
-            {"name": "smartcore.bos.EmergencyLight"},
-            {"name": "smartcore.traits.EnergyStorage"}
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.bos.EmergencyLight"
+            },
+            {
+              "name": "smartcore.traits.EnergyStorage"
+            }
           ],
-          "appearance": {"title": "Stairwell Emergency Light"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Basement", "zone": "Stairwell"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-LN1-01",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Basement"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-LN1-02",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-LN1-03",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-LN1-04",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/EMT-LN1-01",
-          "traits": [
-            {"name": "smartcore.bos.Meter"}, {"name": "smartcore.traits.Electric"}, {"name": "smartcore.bos.Status"}
-          ],
-          "appearance": {"title": "DN1-001"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Basement", "description": "In the riser room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-LN1-01",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Bar"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-LN1-02",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-LN1-03",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-LN1-04",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-LN1-05",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Stairwell"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-LN1-01",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-LN1-02",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-LN1-03",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-LN1-04",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Bar"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-LN1-01",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Cotswold Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-LN1-02",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Cotswold Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-LN1-03",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Copper Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-LN1-04",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Copper Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-LN1-05",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Kaolin Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-LN1-06",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Kaolin Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L00-01",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Copper Room"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L00-02",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Cotswold Room"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L00-03",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Kaolin Sound Sensor"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/BRT-L00-01",
-          "traits": [{"name":  "smartcore.traits.BrightnessSensor"}],
-          "appearance": {"title": "Copper Room Brightness Sensor"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Copper Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/BRT-L00-02",
-          "traits": [{"name":  "smartcore.traits.BrightnessSensor"}],
-          "appearance": {"title": "Cotswold Room Brightness Sensor"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Cotswold Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/BRT-L00-03",
-          "traits": [{"name":  "smartcore.traits.BrightnessSensor"}],
-          "appearance": {"title": "Kaolin Room Brightness Sensor"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Basement", "zone": "Kaolin Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/CHW-L00-01",
-          "traits": [{"name":  "smartcore.bos.Temperature"}],
-          "appearance": {"title": "Main Chilled Water"},
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Basement"}
+          "appearance": {
+            "title": "Stairwell Emergency Light"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Stairwell"
+          }
         }
       ]
     },
     {
-      "name": "van/uk/brum/ugs/eg-ac-01/driver/ground",
+      "name": "van/uk/brum/ugs/floor-b1/driver/lighting-ctrl-b",
       "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.2
+      },
       "devices": [
         {
-          "name": "van/uk/brum/ugs/devices/LOK-L00-01",
-          "traits": [{"name": "smartcore.bos.Allocation"}],
-          "membership": {"subsystem": "lockers"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-01",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Entrance Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-02",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Spiral Stair Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-03",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Meeting Room Corridor Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-04",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Kitchen Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Kitchen"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-05",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-06",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-07",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-08",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Project Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-09",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-10",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Tool Station Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-11",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Warehouse"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-12",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Workshop"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-13",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Bench Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Workshop"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-14",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Secure Store"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-15",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Goods In"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-16",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Comms Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L00-17",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Loading Bay"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/ELT-L00-01",
-          "traits": [
-            {"name": "smartcore.traits.Light"},
-            {"name": "smartcore.bos.Status"},
-            {"name": "smartcore.bos.EmergencyLight"},
-            {"name": "smartcore.traits.EnergyStorage"}
-          ],
-          "appearance": {"title": "Reception Emergency Light"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L00-01",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L00-02",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L00-03",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L00-04",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L00-05",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Ground Floor", "zone": "Project Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L00-06",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/EMT-L00-01",
-          "traits": [
-            {"name": "smartcore.bos.Meter"}, {"name": "smartcore.traits.Electric"}, {"name": "smartcore.bos.Status"}
-          ],
-          "appearance": {"title": "D00-001", "description": "Incomer"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Ground Floor", "zone": "Loading Bay"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/EMT-L00-02",
-          "traits": [
-            {"name": "smartcore.bos.Meter"}, {"name": "smartcore.traits.Electric"}, {"name": "smartcore.bos.Status"}
-          ],
-          "appearance": {"title": "D00-002"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Ground Floor", "zone": "Comms Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/EMT-L00-03",
-          "traits": [
-            {"name": "smartcore.bos.Meter"}, {"name": "smartcore.traits.Electric"}, {"name": "smartcore.bos.Status"}
-          ],
-          "appearance": {"title": "D00-003"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/WMT-L00-01",
+          "name": "van/uk/brum/ugs/devices/LTF-LN1-04",
           "traits": [
             {
-              "name": "smartcore.bos.Meter",
-              "more": {"unit": "m³"}
+              "name": "smartcore.traits.Light"
             },
-            {"name": "smartcore.bos.Status"}
+            {
+              "name": "smartcore.bos.Status"
+            }
           ],
-          "appearance": {"title": "BCWS Meter 01"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Ground Floor", "zone": "Loading Bay"}
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-LN1-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ring Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-LN1-06",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-LN1-07",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ring Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-LN1-08",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-LN1-09",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ring Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-b1/driver/hvac",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.15
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-LN1-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Basement"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-LN1-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-LN1-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-LN1-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/CHW-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.Temperature"
+            }
+          ],
+          "appearance": {
+            "title": "Main Chilled Water"
+          },
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Basement"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-b1/driver/metering",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.05
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/EMT-LN1-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.Meter"
+            },
+            {
+              "name": "smartcore.traits.Electric"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "DN1-001"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Basement",
+            "description": "In the riser room"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/WMT-L00-02",
           "traits": [
             {
               "name": "smartcore.bos.Meter",
-              "more": {"unit": "m³"}
+              "more": {
+                "unit": "m\u00b3"
+              }
             },
-            {"name": "smartcore.bos.Status"}
+            {
+              "name": "smartcore.bos.Status"
+            }
           ],
-          "appearance": {"title": "BCWS Meter 02"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Basement", "zone": "Stairwell"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-01",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-02",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-03",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-04",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-05",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Project Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-06",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L00-07",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/ACR-L00-01",
-          "traits": [
-            {"name": "smartcore.bos.Access"}, {"name": "smartcore.traits.EnterLeaveSensor"}, {"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}
-          ],
-          "appearance": {"title": "Main Door"},
-          "membership": {"subsystem": "acs"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/ACR-L00-02",
-          "traits": [{"name": "smartcore.bos.Access"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Secure Store Door"},
-          "membership": {"subsystem": "acs"},
-          "location": {"floor": "Ground Floor", "zone": "Secure Store"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/DOR-L00-01",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Shutter"},
-          "membership": {"subsystem": "acs"},
-          "location": {"floor": "Ground Floor", "zone": "Loading Bay"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/DOR-L00-02",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Fire Door"},
-          "membership": {"subsystem": "acs"},
-          "location": {"floor": "Ground Floor", "zone": "Warehouse"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L00-01",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L00-02",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L00-03",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L00-04",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Workshop"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L00-05",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Lab"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-01",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Main Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-02",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Teal Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-03",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Teal Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-04",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Green Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-05",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Green Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-06",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Yellow Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-07",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Yellow Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-08",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Project Door Privacy"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Project Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L00-09",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Project Door Blackout"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "Ground Floor", "zone": "Project Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L01-01",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Reception"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Reception"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L01-02",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Teal Room"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Teal Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L01-03",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Green Room"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Green Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L01-04",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "Yellow Room"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "Ground Floor", "zone": "Yellow Room"}
+          "appearance": {
+            "title": "BCWS Meter 02"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Stairwell"
+          }
         }
       ]
     },
     {
-      "name": "van/uk/brum/ugs/eg-ac-01/driver/first",
+      "name": "van/uk/brum/ugs/floor-b1/driver/sensors",
       "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-LN1-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Bar"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-LN1-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-LN1-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-LN1-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-LN1-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Stairwell"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-LN1-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-LN1-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-LN1-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-LN1-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Bar"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Copper Room"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Cotswold Room"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Kaolin Sound Sensor"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/BRT-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.BrightnessSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Copper Room Brightness Sensor"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/BRT-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.BrightnessSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Cotswold Room Brightness Sensor"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/BRT-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.BrightnessSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Kaolin Room Brightness Sensor"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-b1/driver/shades",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-LN1-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Cotswold Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-LN1-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Cotswold Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Cotswold Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-LN1-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Copper Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-LN1-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Copper Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Copper Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-LN1-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Kaolin Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-LN1-06",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Kaolin Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Basement",
+            "zone": "Kaolin Room"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/lighting-ctrl-a",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Entrance Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Spiral Stair Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Meeting Room Corridor Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Kitchen Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Kitchen"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-06",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-07",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-08",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Project Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-09",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-10",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Tool Station Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/ELT-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.bos.EmergencyLight"
+            },
+            {
+              "name": "smartcore.traits.EnergyStorage"
+            }
+          ],
+          "appearance": {
+            "title": "Reception Emergency Light"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/lighting-ctrl-b",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.15
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-11",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Warehouse"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-12",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Workshop"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-13",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Bench Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Workshop"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-14",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Secure Store"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-15",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Goods In"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-16",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Comms Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L00-17",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Loading Bay"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/hvac",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.15
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L00-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L00-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Project Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L00-06",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/metering",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.05
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/EMT-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.Meter"
+            },
+            {
+              "name": "smartcore.traits.Electric"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "D00-001",
+            "description": "Incomer"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Loading Bay"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/EMT-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.bos.Meter"
+            },
+            {
+              "name": "smartcore.traits.Electric"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "D00-002"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Comms Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/EMT-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.bos.Meter"
+            },
+            {
+              "name": "smartcore.traits.Electric"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "D00-003"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/WMT-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.Meter",
+              "more": {
+                "unit": "m\u00b3"
+              }
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "BCWS Meter 01"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Loading Bay"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/sensors",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Project Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-06",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L00-07",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L00-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Workshop"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L00-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Lab"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L01-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Reception"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L01-02",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Teal Room"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L01-03",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Green Room"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L01-04",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "Yellow Room"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/shades",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Main Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Teal Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Teal Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Teal Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Green Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-05",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Green Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Green Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-06",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Yellow Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-07",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Yellow Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Yellow Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-08",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Project Door Privacy"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Project Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L00-09",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Project Door Blackout"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Project Room"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/acs",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.2
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/ACR-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.Access"
+            },
+            {
+              "name": "smartcore.traits.EnterLeaveSensor"
+            },
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Main Door"
+          },
+          "membership": {
+            "subsystem": "acs"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/ACR-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.bos.Access"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Secure Store Door"
+          },
+          "membership": {
+            "subsystem": "acs"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Secure Store"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/DOR-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Shutter"
+          },
+          "membership": {
+            "subsystem": "acs"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Loading Bay"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/DOR-L00-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Fire Door"
+          },
+          "membership": {
+            "subsystem": "acs"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Warehouse"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-gf/driver/lockers",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.05
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/LOK-L00-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.Allocation"
+            }
+          ],
+          "membership": {
+            "subsystem": "lockers"
+          },
+          "location": {
+            "floor": "Ground Floor",
+            "zone": "Reception"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-01/driver/lighting-ctrl-a",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
       "devices": [
         {
           "name": "van/uk/brum/ugs/devices/LTF-L01-01",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "First Floor", "zone": "The Bank"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L01-02",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "First Floor", "zone": "Service"}
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "The Bank"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/LTF-L01-03",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "First Floor", "zone": "Open Plan"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/LTF-L01-04",
-          "traits": [{"name": "smartcore.traits.Light"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Ceiling Lights"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "First Floor", "zone": "Printer Room"}
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/ELT-L01-01",
           "traits": [
-            {"name": "smartcore.traits.Light"},
-            {"name": "smartcore.bos.Status"},
-            {"name": "smartcore.bos.EmergencyLight"},
-            {"name": "smartcore.traits.EnergyStorage"}
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.bos.EmergencyLight"
+            },
+            {
+              "name": "smartcore.traits.EnergyStorage"
+            }
           ],
-          "appearance": {"title": "Open Plan Emergency Light"},
-          "membership": {"subsystem": "lighting"},
-          "location": {"floor": "First Floor", "zone": "Open Plan"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L01-01",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "First Floor", "zone": "The Bank"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L01-02",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Near the toilets"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L01-03",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Near the back stairs"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/FCU-L01-04",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}, {"name": "smartcore.traits.OnOff"}
-          ],
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "First Floor", "zone": "Service"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L01-01",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "The Bank"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L01-02",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "Service"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L01-03",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Near the toilets"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/PIR-L01-04",
-          "traits": [{"name": "smartcore.traits.OccupancySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Near the back stairs"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L01-01",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "The Bank"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L01-02",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "Printer Room"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L01-03",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "Open Plan"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/IAQ-L01-04",
-          "traits": [{"name": "smartcore.traits.AirQualitySensor"}, {"name": "smartcore.bos.Status"}],
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "Service"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L01-01",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Open Plan Window 1"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Left to right"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L01-02",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Open Plan Window 2"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Left to right"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L01-03",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Open Plan Window 3"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Left to right"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SHD-L01-04",
-          "traits": [{"name": "smartcore.traits.OpenClose"}, {"name": "smartcore.bos.Status"}],
-          "appearance": {"title": "Open Plan Window 4"},
-          "membership": {"subsystem": "shades"},
-          "location": {"floor": "First Floor", "zone": "Open Plan", "description": "Left to right"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/SND-L02-01",
-          "traits": [{"name":  "smartcore.bos.SoundSensor"}],
-          "appearance": {"title": "The Bank"},
-          "membership": {"subsystem": "sensors"},
-          "location": {"floor": "First Floor", "zone": "The Bank"}
+          "appearance": {
+            "title": "Open Plan Emergency Light"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan"
+          }
         }
       ]
     },
     {
-      "name": "van/uk/brum/ugs/eg-ac-01/driver/roof",
+      "name": "van/uk/brum/ugs/floor-01/driver/lighting-ctrl-b",
       "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.2
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L01-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Service"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/LTF-L01-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.Light"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Ceiling Lights"
+          },
+          "membership": {
+            "subsystem": "lighting"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Printer Room"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-01/driver/hvac",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.15
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L01-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "The Bank"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L01-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Near the toilets"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L01-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Near the back stairs"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/FCU-L01-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            },
+            {
+              "name": "smartcore.traits.OnOff"
+            }
+          ],
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Service"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-01/driver/sensors",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L01-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "The Bank"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L01-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Service"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L01-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Near the toilets"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/PIR-L01-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.OccupancySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Near the back stairs"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L01-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "The Bank"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L01-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Printer Room"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L01-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/IAQ-L01-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirQualitySensor"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Service"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SND-L02-01",
+          "traits": [
+            {
+              "name": "smartcore.bos.SoundSensor"
+            }
+          ],
+          "appearance": {
+            "title": "The Bank"
+          },
+          "membership": {
+            "subsystem": "sensors"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "The Bank"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-01/driver/shades",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.1
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L01-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Open Plan Window 1"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Left to right"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L01-02",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Open Plan Window 2"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Left to right"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L01-03",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Open Plan Window 3"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Left to right"
+          }
+        },
+        {
+          "name": "van/uk/brum/ugs/devices/SHD-L01-04",
+          "traits": [
+            {
+              "name": "smartcore.traits.OpenClose"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Open Plan Window 4"
+          },
+          "membership": {
+            "subsystem": "shades"
+          },
+          "location": {
+            "floor": "First Floor",
+            "zone": "Open Plan",
+            "description": "Left to right"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-rf/driver/hvac",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.15
+      },
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/TMP-L02-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.AirTemperature"
+            },
+            {
+              "name": "smartcore.traits.FanSpeed"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "Outside Air Temperature"
+          },
+          "membership": {
+            "subsystem": "hvac"
+          },
+          "location": {
+            "floor": "Roof"
+          }
+        }
+      ]
+    },
+    {
+      "name": "van/uk/brum/ugs/floor-rf/driver/metering",
+      "type": "mock",
+      "healthCheck": {
+        "faultProbability": 0.05
+      },
       "devices": [
         {
           "name": "van/uk/brum/ugs/devices/PV-L02-01",
           "traits": [
-            {"name": "smartcore.bos.Meter"}, {"name": "smartcore.traits.Electric"}, {"name": "smartcore.bos.Status"}
+            {
+              "name": "smartcore.bos.Meter"
+            },
+            {
+              "name": "smartcore.traits.Electric"
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
           ],
-          "appearance": {"title": "Solar PV"},
-          "membership": {"subsystem": "metering"},
-          "location": {"floor": "Roof"}
-        },
-        {
-          "name": "van/uk/brum/ugs/devices/TMP-L02-01",
-          "traits": [
-            {"name": "smartcore.traits.AirTemperature"}, {"name": "smartcore.traits.FanSpeed"},
-            {"name": "smartcore.bos.Status"}
-          ],
-          "appearance": {"title": "Outside Air Temperature"},
-          "membership": {"subsystem": "hvac"},
-          "location": {"floor": "Roof"}
+          "appearance": {
+            "title": "Solar PV"
+          },
+          "membership": {
+            "subsystem": "metering"
+          },
+          "location": {
+            "floor": "Roof"
+          }
         }
       ]
     },
@@ -921,7 +2691,9 @@
               "name": "smartcore.bos.SecurityEvent"
             }
           ],
-          "appearance": {"title": "Security Events"}
+          "appearance": {
+            "title": "Security Events"
+          }
         }
       ]
     },
@@ -936,7 +2708,9 @@
               "name": "smartcore.bos.Waste"
             }
           ],
-          "appearance": {"title": "Waste"}
+          "appearance": {
+            "title": "Waste"
+          }
         }
       ]
     },
@@ -954,8 +2728,12 @@
               }
             }
           ],
-          "appearance": {"title": "Lift 1"},
-          "membership": {"subsystem": "vt"}
+          "appearance": {
+            "title": "Lift 1"
+          },
+          "membership": {
+            "subsystem": "vt"
+          }
         },
         {
           "name": "van/uk/brum/ugs/devices/lift-02",
@@ -967,22 +2745,41 @@
               }
             }
           ],
-          "appearance": {"title": "Lift 2"},
-          "membership": {"subsystem": "vt"}
+          "appearance": {
+            "title": "Lift 2"
+          },
+          "membership": {
+            "subsystem": "vt"
+          }
         }
       ]
     },
     {
-      "name": "van/uk/brum/ugs/eg-bc-01/driver/external", "type": "mock", "devices": [
-      {
-        "name": "van/uk/brum/ugs/devices/EVD-EXT-01",
-        "traits": [
-          {"name": "smartcore.traits.EnergyStorage", "more": {"type": "ev"}}, {"name": "smartcore.bos.Status"}
-        ],
-        "appearance": {"title": "EV Delivery Car", "description": "Delivers AV equipment to sites"},
-        "membership": {"subsystem": "fleet"}
-      }
-    ]
+      "name": "van/uk/brum/ugs/eg-bc-01/driver/external",
+      "type": "mock",
+      "devices": [
+        {
+          "name": "van/uk/brum/ugs/devices/EVD-EXT-01",
+          "traits": [
+            {
+              "name": "smartcore.traits.EnergyStorage",
+              "more": {
+                "type": "ev"
+              }
+            },
+            {
+              "name": "smartcore.bos.Status"
+            }
+          ],
+          "appearance": {
+            "title": "EV Delivery Car",
+            "description": "Delivers AV equipment to sites"
+          },
+          "membership": {
+            "subsystem": "fleet"
+          }
+        }
+      ]
     }
   ],
   "zones": [
@@ -990,9 +2787,17 @@
       "name": "van/uk/brum/ugs/zones/building",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Vanti HQ"},
-        "location": {"more": {"address": "44 Upper Gough Street, Birmingham, B1 1JL"}},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Vanti HQ"
+        },
+        "location": {
+          "more": {
+            "address": "44 Upper Gough Street, Birmingham, B1 1JL"
+          }
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
       "lights": [
         "van/uk/brum/ugs/zones/floors/basement",
@@ -1009,7 +2814,9 @@
         "van/uk/brum/ugs/zones/floors/ground"
       ],
       "meterGroups": {
-        "generated": ["van/uk/brum/ugs/devices/PV-L02-01"],
+        "generated": [
+          "van/uk/brum/ugs/devices/PV-L02-01"
+        ],
         "water": [
           "van/uk/brum/ugs/devices/WMT-L00-01",
           "van/uk/brum/ugs/devices/WMT-L00-02"
@@ -1020,7 +2827,9 @@
         "van/uk/brum/ugs/zones/floors/ground"
       ],
       "electricGroups": {
-        "generated": ["van/uk/brum/ugs/devices/PV-L02-01"]
+        "generated": [
+          "van/uk/brum/ugs/devices/PV-L02-01"
+        ]
       },
       "occupancySensors": [
         "van/uk/brum/ugs/zones/floors/basement",
@@ -1050,9 +2859,15 @@
       "name": "van/uk/brum/ugs/zones/floors/basement",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Basement"},
-        "location": {"floor": "Basement"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Basement"
+        },
+        "location": {
+          "floor": "Basement"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
       "lights": [
         "van/uk/brum/ugs/devices/LTF-LN1-01",
@@ -1068,8 +2883,12 @@
         "van/uk/brum/ugs/zones/rooms/cotswold",
         "van/uk/brum/ugs/zones/rooms/kaolin"
       ],
-      "meters": ["van/uk/brum/ugs/devices/EMT-LN1-01"],
-      "electrics": ["van/uk/brum/ugs/devices/EMT-LN1-01"],
+      "meters": [
+        "van/uk/brum/ugs/devices/EMT-LN1-01"
+      ],
+      "electrics": [
+        "van/uk/brum/ugs/devices/EMT-LN1-01"
+      ],
       "occupancySensors": [
         "van/uk/brum/ugs/devices/PIR-LN1-01",
         "van/uk/brum/ugs/zones/rooms/copper",
@@ -1098,9 +2917,15 @@
       "name": "van/uk/brum/ugs/zones/floors/ground",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Ground Floor"},
-        "location": {"floor": "Ground Floor"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Ground Floor"
+        },
+        "location": {
+          "floor": "Ground Floor"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
       "lights": [
         "van/uk/brum/ugs/zones/areas/reception",
@@ -1169,9 +2994,15 @@
       "name": "van/uk/brum/ugs/zones/floors/first",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "First Floor"},
-        "location": {"floor": "First Floor"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "First Floor"
+        },
+        "location": {
+          "floor": "First Floor"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
       "lights": [
         "van/uk/brum/ugs/zones/rooms/bank",
@@ -1209,138 +3040,289 @@
       "name": "van/uk/brum/ugs/zones/rooms/copper",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Copper Room"},
-        "location": {"floor": "Basement", "zone": "Copper Room", "description": "Near the bar"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Copper Room"
+        },
+        "location": {
+          "floor": "Basement",
+          "zone": "Copper Room",
+          "description": "Near the bar"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-LN1-04", "van/uk/brum/ugs/devices/LTF-LN1-05"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-LN1-04",
+        "van/uk/brum/ugs/devices/LTF-LN1-05"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-LN1-01"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-LN1-02"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-LN1-01"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-LN1-02"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-LN1-02"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-LN1-02"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-LN1-01"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L00-01"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-LN1-02"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-LN1-02"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-LN1-01"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L00-01"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/cotswold",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Cotswold Room"},
-        "location": {"floor": "Basement", "zone": "Cotswold Room", "description": "Far corner"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Cotswold Room"
+        },
+        "location": {
+          "floor": "Basement",
+          "zone": "Cotswold Room",
+          "description": "Far corner"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-LN1-06", "van/uk/brum/ugs/devices/LTF-LN1-07"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-LN1-06",
+        "van/uk/brum/ugs/devices/LTF-LN1-07"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-LN1-03"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-LN1-04"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-LN1-03"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-LN1-04"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-LN1-03"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-LN1-03"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-LN1-02"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L00-02"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-LN1-03"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-LN1-03"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-LN1-02"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L00-02"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/kaolin",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Kaolin Room"},
-        "location": {"floor": "Basement", "zone": "Kaolin Room", "description": "Near the pool table"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Kaolin Room"
+        },
+        "location": {
+          "floor": "Basement",
+          "zone": "Kaolin Room",
+          "description": "Near the pool table"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-LN1-08", "van/uk/brum/ugs/devices/LTF-LN1-09"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-LN1-08",
+        "van/uk/brum/ugs/devices/LTF-LN1-09"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-LN1-05"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-LN1-06"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-LN1-05"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-LN1-06"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-LN1-04"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-LN1-04"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-LN1-03"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L00-03"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-LN1-04"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-LN1-04"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-LN1-03"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L00-03"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/teal",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Teal Room"},
-        "location": {"floor": "Ground Floor", "zone": "Teal Room"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Teal Room"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Teal Room"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-05"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-05"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-L00-02"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-L00-03"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-L00-02"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-L00-03"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L00-02"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L00-02"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L00-01"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L01-02"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L00-02"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L00-02"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L00-01"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L01-02"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/green",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Green Room"},
-        "location": {"floor": "Ground Floor", "zone": "Green Room"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Green Room"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Green Room"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-06"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-06"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-L00-04"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-L00-05"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-L00-04"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-L00-05"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L00-03"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L00-03"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L00-02"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L01-03"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L00-03"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L00-03"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L00-02"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L01-03"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/yellow",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Yellow Room"},
-        "location": {"floor": "Ground Floor", "zone": "Yellow Room"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Yellow Room"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Yellow Room"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-07"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-07"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-L00-06"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-L00-07"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-L00-06"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-L00-07"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L00-04"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L00-04"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L00-03"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L01-04"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L00-04"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L00-04"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L00-03"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L01-04"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/project",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Project Room"},
-        "location": {"floor": "Ground Floor", "zone": "Project Room"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Project Room"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Project Room"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-08"],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-08"
+      ],
       "openCloseGroups": {
-        "privacy": ["van/uk/brum/ugs/devices/SHD-L00-08"],
-        "blackout": ["van/uk/brum/ugs/devices/SHD-L00-09"]
+        "privacy": [
+          "van/uk/brum/ugs/devices/SHD-L00-08"
+        ],
+        "blackout": [
+          "van/uk/brum/ugs/devices/SHD-L00-09"
+        ]
       },
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L00-05"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L00-05"],
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L00-05"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L00-05"
+      ],
       "drivers": [
         {
-          "type": "mock", "name": "van/uk/brum/ugs/zones/areas/project/driver-mock",
+          "type": "mock",
+          "name": "van/uk/brum/ugs/zones/areas/project/driver-mock",
           "devices": [
             {
-              "name": "van/uk/brum/ugs/zones/areas/project", "traits": [
-              {
-                "name": "smartcore.traits.Mode",
-                "more": {
-                  "modes": "{\"modes\": [{\"name\":\"lighting.mode\",\"values\":[{\"name\":\"auto\"},{\"name\":\"manual\"}]},{\"name\":\"hvac.mode\",\"values\":[{\"name\":\"auto\"},{\"name\":\"manual\"}]}]}"
+              "name": "van/uk/brum/ugs/zones/areas/project",
+              "traits": [
+                {
+                  "name": "smartcore.traits.Mode",
+                  "more": {
+                    "modes": "{\"modes\": [{\"name\":\"lighting.mode\",\"values\":[{\"name\":\"auto\"},{\"name\":\"manual\"}]},{\"name\":\"hvac.mode\",\"values\":[{\"name\":\"auto\"},{\"name\":\"manual\"}]}]}"
+                  }
                 }
-              }
-            ]
+              ]
             }
           ]
         }
@@ -1350,151 +3332,304 @@
       "name": "van/uk/brum/ugs/zones/areas/lab",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Lab"},
-        "location": {"floor": "Ground Floor", "zone": "Lab"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Lab"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Lab"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-09", "van/uk/brum/ugs/devices/LTF-L00-10"],
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L00-06"],
-      "meters": ["van/uk/brum/ugs/devices/EMT-L00-03"],
-      "electrics": ["van/uk/brum/ugs/devices/EMT-L00-03"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L00-06", "van/uk/brum/ugs/devices/PIR-L00-07"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L00-05"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-09",
+        "van/uk/brum/ugs/devices/LTF-L00-10"
+      ],
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L00-06"
+      ],
+      "meters": [
+        "van/uk/brum/ugs/devices/EMT-L00-03"
+      ],
+      "electrics": [
+        "van/uk/brum/ugs/devices/EMT-L00-03"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L00-06",
+        "van/uk/brum/ugs/devices/PIR-L00-07"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L00-05"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/warehouse",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Warehouse"},
-        "location": {"floor": "Ground Floor", "zone": "Warehouse"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Warehouse"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Warehouse"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-11"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-11"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/workshop",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Workshop"},
-        "location": {"floor": "Ground Floor", "zone": "Workshop"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Workshop"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Workshop"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-12", "van/uk/brum/ugs/devices/LTF-L00-13"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L00-04"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-12",
+        "van/uk/brum/ugs/devices/LTF-L00-13"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L00-04"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/kitchen",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Kitchen"},
-        "location": {"floor": "Ground Floor", "zone": "Kitchen"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Kitchen"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Kitchen"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-04"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-04"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/goods-in",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Goods In"},
-        "location": {"floor": "Ground Floor", "zone": "Goods In"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Goods In"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Goods In"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-15"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-15"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/secure-store",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Secure Store"},
-        "location": {"floor": "Ground Floor", "zone": "Secure Store"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Secure Store"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Secure Store"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-14"],
-      "enterLeaveSensors": ["van/uk/brum/ugs/devices/ACR-L00-02"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-14"
+      ],
+      "enterLeaveSensors": [
+        "van/uk/brum/ugs/devices/ACR-L00-02"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/comms-room",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Comms Room"},
-        "location": {"floor": "Ground Floor", "zone": "Comms Room"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Comms Room"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Comms Room"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-16"],
-      "meters": ["van/uk/brum/ugs/devices/EMT-L00-02"],
-      "electrics": ["van/uk/brum/ugs/devices/EMT-L00-02"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-16"
+      ],
+      "meters": [
+        "van/uk/brum/ugs/devices/EMT-L00-02"
+      ],
+      "electrics": [
+        "van/uk/brum/ugs/devices/EMT-L00-02"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/reception",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Reception"},
-        "location": {"floor": "Ground Floor", "zone": "Reception"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Reception"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Reception"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "enterLeaveSensors": ["van/uk/brum/ugs/devices/ACR-L00-01"],
+      "enterLeaveSensors": [
+        "van/uk/brum/ugs/devices/ACR-L00-01"
+      ],
       "lights": [
         "van/uk/brum/ugs/devices/LTF-L00-01",
         "van/uk/brum/ugs/devices/LTF-L00-02",
         "van/uk/brum/ugs/devices/LTF-L00-03"
       ],
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L00-01"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L00-01"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L01-01"],
-      "openClose": ["van/uk/brum/ugs/devices/ACR-L00-01"]
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L00-01"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L00-01"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L01-01"
+      ],
+      "openClose": [
+        "van/uk/brum/ugs/devices/ACR-L00-01"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/l00-wc",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "WC"},
-        "location": {"floor": "Ground Floor", "zone": "WC"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "WC"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "WC"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       }
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/loading-bay",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Loading Bay"},
-        "location": {"floor": "Ground Floor", "zone": "Loading Bay"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Loading Bay"
+        },
+        "location": {
+          "floor": "Ground Floor",
+          "zone": "Loading Bay"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "enterLeaveSensors": ["van/uk/brum/ugs/devices/DOR-L00-01"],
-      "lights": ["van/uk/brum/ugs/devices/LTF-L00-17"],
-      "openClose": ["van/uk/brum/ugs/devices/DOR-L00-01"]
+      "enterLeaveSensors": [
+        "van/uk/brum/ugs/devices/DOR-L00-01"
+      ],
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L00-17"
+      ],
+      "openClose": [
+        "van/uk/brum/ugs/devices/DOR-L00-01"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/bank",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "The Bank"},
-        "location": {"floor": "First Floor", "zone": "The Bank"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "The Bank"
+        },
+        "location": {
+          "floor": "First Floor",
+          "zone": "The Bank"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L01-01"],
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L01-01"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L01-01"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L01-01"],
-      "soundSensors": ["van/uk/brum/ugs/devices/SND-L02-01"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L01-01"
+      ],
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L01-01"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L01-01"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L01-01"
+      ],
+      "soundSensors": [
+        "van/uk/brum/ugs/devices/SND-L02-01"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/open-plan",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Open Plan"},
-        "location": {"floor": "First Floor", "zone": "Open Plan"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Open Plan"
+        },
+        "location": {
+          "floor": "First Floor",
+          "zone": "Open Plan"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
       "lights": [
         "van/uk/brum/ugs/devices/LTF-L01-03"
       ],
       "openCloseGroups": {
-        "window1": ["van/uk/brum/ugs/devices/SHD-L01-01"],
-        "window2": ["van/uk/brum/ugs/devices/SHD-L01-02"],
-        "window3": ["van/uk/brum/ugs/devices/SHD-L01-03"],
-        "window4": ["van/uk/brum/ugs/devices/SHD-L01-04"]
+        "window1": [
+          "van/uk/brum/ugs/devices/SHD-L01-01"
+        ],
+        "window2": [
+          "van/uk/brum/ugs/devices/SHD-L01-02"
+        ],
+        "window3": [
+          "van/uk/brum/ugs/devices/SHD-L01-03"
+        ],
+        "window4": [
+          "van/uk/brum/ugs/devices/SHD-L01-04"
+        ]
       },
       "thermostats": [
         "van/uk/brum/ugs/devices/FCU-L01-02",
@@ -1504,39 +3639,74 @@
         "van/uk/brum/ugs/devices/PIR-L01-03",
         "van/uk/brum/ugs/devices/PIR-L01-04"
       ],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L01-03"]
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L01-03"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/rooms/printer-room",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Printer Room"},
-        "location": {"floor": "First Floor", "zone": "Printer Room"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Printer Room"
+        },
+        "location": {
+          "floor": "First Floor",
+          "zone": "Printer Room"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L01-04"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L01-02"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L01-04"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L01-02"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/service",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "Service"},
-        "location": {"floor": "First Floor", "zone": "Service"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "Service"
+        },
+        "location": {
+          "floor": "First Floor",
+          "zone": "Service"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       },
-      "lights": ["van/uk/brum/ugs/devices/LTF-L01-02"],
-      "thermostats": ["van/uk/brum/ugs/devices/FCU-L01-04"],
-      "occupancySensors": ["van/uk/brum/ugs/devices/PIR-L01-02"],
-      "airQualitySensors": ["van/uk/brum/ugs/devices/IAQ-L01-04"]
+      "lights": [
+        "van/uk/brum/ugs/devices/LTF-L01-02"
+      ],
+      "thermostats": [
+        "van/uk/brum/ugs/devices/FCU-L01-04"
+      ],
+      "occupancySensors": [
+        "van/uk/brum/ugs/devices/PIR-L01-02"
+      ],
+      "airQualitySensors": [
+        "van/uk/brum/ugs/devices/IAQ-L01-04"
+      ]
     },
     {
       "name": "van/uk/brum/ugs/zones/areas/l01-wc",
       "type": "area",
       "metadata": {
-        "appearance": {"title": "WC"},
-        "location": {"floor": "First Floor", "zone": "WC"},
-        "membership": {"subsystem": "zones"}
+        "appearance": {
+          "title": "WC"
+        },
+        "location": {
+          "floor": "First Floor",
+          "zone": "WC"
+        },
+        "membership": {
+          "subsystem": "zones"
+        }
       }
     }
   ],
@@ -1544,611 +3714,1121 @@
     {
       "name": "van/uk/brum/ugs/automation/electric-history/EMT-LN1-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-LN1-01", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-LN1-01",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/EMT-L00-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-L00-01", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-L00-01",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/EMT-L00-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-L00-02", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-L00-02",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/EMT-L00-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-L00-03", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-L00-03",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/allocation-history/LOK-L00-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/LOK-L00-01", "trait": "smartcore.bos.Allocation"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/LOK-L00-01",
+        "trait": "smartcore.bos.Allocation"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/building",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/building/generated",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building/generated", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building/generated",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/basement",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/basement", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/basement",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/ground",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/ground", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/ground",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/electric-history/lab",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/lab", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/lab",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
-
     {
       "name": "van/uk/brum/ugs/automation/electric-history/comms-room",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/comms-room", "trait": "smartcore.traits.Electric"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/comms-room",
+        "trait": "smartcore.traits.Electric"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/EMT-LN1-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-LN1-01", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-LN1-01",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/EMT-L00-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-L00-01", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-L00-01",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/EMT-L00-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-L00-02", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-L00-02",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/EMT-L00-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/EMT-L00-03", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/EMT-L00-03",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/WMT-L00-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/WMT-L00-01", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/WMT-L00-01",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/WMT-L00-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/WMT-L00-02", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/WMT-L00-02",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/building",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/building/generated",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building/generated", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building/generated",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/building/water",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building/water", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building/water",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/basement",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/basement", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/basement",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/ground",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/ground", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/ground",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/lab",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/lab", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/lab",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/meter-history/comms-room",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/comms-room", "trait": "smartcore.bos.Meter"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/comms-room",
+        "trait": "smartcore.bos.Meter"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/lab",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/lab", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/lab",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/open-plan",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/open-plan", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/open-plan",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/service",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/service", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/service",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/floors/basement",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/basement", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/basement",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/floors/first",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/first", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/first",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/floors/ground",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/ground", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/ground",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/rooms/bank",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/bank", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/bank",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/rooms/printer-room",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/printer-room", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/printer-room",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/rooms/bank",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/bank", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/bank",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/building",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/copper",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/copper", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/copper",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/cotswold",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/cotswold", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/cotswold",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/kaolin",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/kaolin", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/kaolin",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/teal",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/teal", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/teal",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/green",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/green", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/green",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/yellow",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/yellow", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/yellow",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/project",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/project", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/project",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/occupancy-history/lab",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/lab", "trait": "smartcore.traits.OccupancySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/lab",
+        "trait": "smartcore.traits.OccupancySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/building",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/copper",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/copper", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/copper",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/cotswold",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/cotswold", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/cotswold",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/kaolin",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/kaolin", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/kaolin",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/teal",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/teal", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/teal",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/green",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/green", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/green",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/yellow",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/yellow", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/yellow",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/workshop",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/workshop", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/workshop",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-LN1-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-LN1-01", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-LN1-01",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-LN1-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-LN1-02", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-LN1-02",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-LN1-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-LN1-03", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-LN1-03",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-LN1-04",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-LN1-04", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-LN1-04",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L00-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L00-01", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L00-01",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L00-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L00-02", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L00-02",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L00-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L00-03", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L00-03",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L00-04",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L00-04", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L00-04",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L00-05",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L00-05", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L00-05",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L01-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L01-01", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L01-01",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L01-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L01-02", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L01-02",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L01-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L01-03", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L01-03",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-quality-history/IAQ-L01-04",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/IAQ-L01-04", "trait": "smartcore.traits.AirQualitySensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/IAQ-L01-04",
+        "trait": "smartcore.traits.AirQualitySensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/lift-history/lift-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/lift-01", "trait": "smartcore.bos.Transport"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/lift-01",
+        "trait": "smartcore.bos.Transport"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/lift-history/lift-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/lift-02", "trait": "smartcore.bos.Transport"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/lift-02",
+        "trait": "smartcore.bos.Transport"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L00-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L00-01", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L00-01",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L00-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L00-02", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L00-02",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L00-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L00-03", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L00-03",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L01-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L01-01", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L01-01",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L01-02",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L01-02", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L01-02",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L01-03",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L01-03", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L01-03",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L01-04",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L01-04", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L01-04",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/sound-history/SND-L02-01",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/devices/SND-L02-01", "trait": "smartcore.bos.SoundSensor"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/devices/SND-L02-01",
+        "trait": "smartcore.bos.SoundSensor"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/building",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/building", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/building",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/floors/basement",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/basement", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/basement",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/floors/ground",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/ground", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/ground",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/floors/first",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/floors/first", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/floors/first",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/copper",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/copper", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/copper",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/cotswold",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/cotswold", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/cotswold",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/kaolin",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/kaolin", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/kaolin",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/teal",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/teal", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/teal",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/green",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/green", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/green",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/yellow",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/yellow", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/yellow",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/areas/reception",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/reception", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/reception",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/areas/project",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/project", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/project",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/areas/lab",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/lab", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/lab",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/rooms/bank",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/rooms/bank", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/rooms/bank",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/areas/open-plan",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/open-plan", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/open-plan",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/air-temperature-history/areas/service",
       "type": "history",
-      "source": {"name": "van/uk/brum/ugs/zones/areas/service", "trait": "smartcore.traits.AirTemperature"},
-      "storage": {"type": "postgres"}
+      "source": {
+        "name": "van/uk/brum/ugs/zones/areas/service",
+        "trait": "smartcore.traits.AirTemperature"
+      },
+      "storage": {
+        "type": "postgres"
+      }
     },
     {
       "name": "van/uk/brum/ugs/automation/health/air-temperature-range",
       "type": "healthbounds",
-      "devices": [{"field": "metadata.traits.name", "stringEqual": "smartcore.traits.AirTemperature"}],
-      "source": {"trait": "smartcore.traits.AirTemperature", "value": "ambientTemperature.valueCelsius"},
+      "devices": [
+        {
+          "field": "metadata.traits.name",
+          "stringEqual": "smartcore.traits.AirTemperature"
+        }
+      ],
+      "source": {
+        "trait": "smartcore.traits.AirTemperature",
+        "value": "ambientTemperature.valueCelsius"
+      },
       "check": {
         "displayName": "Comfortable Air Temperature",
         "description": "Checks that the air temperature is within a comfortable range",
         "occupantImpact": "COMFORT",
         "bounds": {
           "normalRange": {
-            "low": {"floatValue": 18},
-            "high": {"floatValue": 24},
-            "deadband": {"floatValue": 1}
+            "low": {
+              "floatValue": 18
+            },
+            "high": {
+              "floatValue": 24
+            },
+            "deadband": {
+              "floatValue": 1
+            }
           },
-          "displayUnit": "°C"
+          "displayUnit": "\u00b0C"
         }
       }
     },
     {
       "name": "van/uk/brum/ugs/automation/health/air-temperature-manufacturer-range",
       "type": "healthbounds",
-      "devices": [{"field": "metadata.traits.name", "stringEqual": "smartcore.traits.AirTemperature"}],
-      "source": {"trait": "smartcore.traits.AirTemperature", "value": "ambientTemperature.valueCelsius"},
+      "devices": [
+        {
+          "field": "metadata.traits.name",
+          "stringEqual": "smartcore.traits.AirTemperature"
+        }
+      ],
+      "source": {
+        "trait": "smartcore.traits.AirTemperature",
+        "value": "ambientTemperature.valueCelsius"
+      },
       "check": {
         "displayName": "Manufacturer Air Temperature Range",
         "description": "Checks that the air temperature is within the manufacturer's recommended range",
         "equipmentImpact": "LIFESPAN",
         "bounds": {
           "normalRange": {
-            "low": {"floatValue": 10},
-            "high": {"floatValue": 35},
-            "deadband": {"floatValue": 2}
+            "low": {
+              "floatValue": 10
+            },
+            "high": {
+              "floatValue": 35
+            },
+            "deadband": {
+              "floatValue": 2
+            }
           },
-          "displayUnit": "°C"
+          "displayUnit": "\u00b0C"
         }
       }
     },
     {
       "name": "van/uk/brum/ugs/automation/health/emergency-light-function-test",
       "type": "healthbounds",
-      "devices": [{"field": "metadata.traits.name", "stringEqual": "smartcore.bos.EmergencyLight"}],
-      "source": {"trait": "smartcore.bos.EmergencyLight", "value": "functionTest.result"},
+      "devices": [
+        {
+          "field": "metadata.traits.name",
+          "stringEqual": "smartcore.bos.EmergencyLight"
+        }
+      ],
+      "source": {
+        "trait": "smartcore.bos.EmergencyLight",
+        "value": "functionTest.result"
+      },
       "check": {
         "displayName": "Emergency Light Function Test",
         "description": "Checks that an emergency lights function test is passing without error",
         "complianceImpacts": [
           {
-            "standard": {"displayName": "BS 5266"},
+            "standard": {
+              "displayName": "BS 5266"
+            },
             "contribution": "FAIL"
           }
         ],
         "bounds": {
-          "normalValues": {"values": [{"stringValue": "TEST_RESULT_PENDING"}, {"stringValue": "TEST_PASSED"}]}
+          "normalValues": {
+            "values": [
+              {
+                "stringValue": "TEST_RESULT_PENDING"
+              },
+              {
+                "stringValue": "TEST_PASSED"
+              }
+            ]
+          }
         }
       }
     },
     {
       "name": "van/uk/brum/ugs/automation/health/emergency-light-duration-test",
       "type": "healthbounds",
-      "devices": [{"field": "metadata.traits.name", "stringEqual": "smartcore.bos.EmergencyLight"}],
-      "source": {"trait": "smartcore.bos.EmergencyLight", "value": "durationTest.result"},
+      "devices": [
+        {
+          "field": "metadata.traits.name",
+          "stringEqual": "smartcore.bos.EmergencyLight"
+        }
+      ],
+      "source": {
+        "trait": "smartcore.bos.EmergencyLight",
+        "value": "durationTest.result"
+      },
       "check": {
         "displayName": "Emergency Light Duration Test",
         "description": "Checks that an emergency lights duration test is passing without error",
         "complianceImpacts": [
           {
-            "standard": {"displayName": "BS 5266"},
+            "standard": {
+              "displayName": "BS 5266"
+            },
             "contribution": "FAIL"
           }
         ],
         "bounds": {
-          "normalValues": {"values": [{"stringValue": "TEST_RESULT_PENDING"}, {"stringValue": "TEST_PASSED"}]}
+          "normalValues": {
+            "values": [
+              {
+                "stringValue": "TEST_RESULT_PENDING"
+              },
+              {
+                "stringValue": "TEST_PASSED"
+              }
+            ]
+          }
         }
       }
     }

--- a/example/config/vanti-ugs/ui-config.json
+++ b/example/config/vanti-ugs/ui-config.json
@@ -1279,6 +1279,69 @@
           }
         }
       }
+    },
+    "system": {
+      "subsystemHealth": {
+        "subsystems": [
+          {
+            "title": "Lighting",
+            "icon": "mdi-lightbulb-group-outline",
+            "description": "Lighting control",
+            "checks": [
+              {
+                "displayName": "Basement",
+                "checks": [
+                  {"name": "van/uk/brum/ugs/floor-b1/driver/lighting-ctrl-a", "displayName": "Panel A – Bar & Common"},
+                  {"name": "van/uk/brum/ugs/floor-b1/driver/lighting-ctrl-b", "displayName": "Panel B – Meeting Rooms"}
+                ]
+              },
+              {
+                "displayName": "Ground Floor",
+                "checks": [
+                  {"name": "van/uk/brum/ugs/floor-gf/driver/lighting-ctrl-a", "displayName": "Panel A – Office"},
+                  {"name": "van/uk/brum/ugs/floor-gf/driver/lighting-ctrl-b", "displayName": "Panel B – Industrial"}
+                ]
+              },
+              {
+                "displayName": "First Floor",
+                "checks": [
+                  {"name": "van/uk/brum/ugs/floor-01/driver/lighting-ctrl-a", "displayName": "Panel A – Open Plan"},
+                  {"name": "van/uk/brum/ugs/floor-01/driver/lighting-ctrl-b", "displayName": "Panel B – Service"}
+                ]
+              }
+            ]
+          },
+          {
+            "title": "HVAC",
+            "icon": "mdi-hvac",
+            "description": "Heating, ventilation and air conditioning",
+            "checks": [
+              {"name": "van/uk/brum/ugs/floor-b1/driver/hvac", "displayName": "Basement"},
+              {"name": "van/uk/brum/ugs/floor-gf/driver/hvac", "displayName": "Ground Floor"},
+              {"name": "van/uk/brum/ugs/floor-01/driver/hvac", "displayName": "First Floor"},
+              {"name": "van/uk/brum/ugs/floor-rf/driver/hvac", "displayName": "Roof"}
+            ]
+          },
+          {
+            "title": "Access Control",
+            "icon": "mdi-shield-key-outline",
+            "description": "Door access readers",
+            "checks": [
+              {"name": "van/uk/brum/ugs/floor-gf/driver/acs", "displayName": "Ground Floor"}
+            ]
+          },
+          {
+            "title": "Sensors",
+            "icon": "mdi-leak",
+            "description": "Environmental and occupancy sensors",
+            "checks": [
+              {"name": "van/uk/brum/ugs/floor-b1/driver/sensors", "displayName": "Basement"},
+              {"name": "van/uk/brum/ugs/floor-gf/driver/sensors", "displayName": "Ground Floor"},
+              {"name": "van/uk/brum/ugs/floor-01/driver/sensors", "displayName": "First Floor"}
+            ]
+          }
+        ]
+      }
     }
   },
   "experiments": {

--- a/pkg/app/services.go
+++ b/pkg/app/services.go
@@ -39,6 +39,7 @@ func (c *Controller) startDrivers(configs []driver.RawConfig) (*service.Map, err
 		driverServices.Config = &serviceConfigStore{store: c.ControllerConfig.Drivers(), id: id}
 		driverServices.Logger = loggerWithServiceInfo(driverServices.Logger, id, kind)
 		driverServices.Health = healthChecksForService(c.CheckRegistry, id, kind)
+		driverServices.SystemCheck = newDriverSystemCheck(driverServices.Health, id, kind, driverServices.Logger)
 
 		f, ok := c.SystemConfig.DriverFactories[kind]
 		if !ok {
@@ -226,6 +227,22 @@ func loggerWithServiceInfo(logger *zap.Logger, id, kind string) *zap.Logger {
 func healthChecksForService(r *healthpb.Registry, id, kind string) *healthpb.Checks {
 	owner := fmt.Sprintf("%s:%s", kind, id)
 	return r.ForOwner(owner)
+}
+
+// newDriverSystemCheck creates a driver-level system check registered under the driver's own name.
+// Drivers should call MarkFailed/MarkRunning to reflect connectivity state, and must call
+// Dispose in their stop handler. Returns nil if the check cannot be created.
+func newDriverSystemCheck(health *healthpb.Checks, id, kind string, logger *zap.Logger) service.SystemCheck {
+	check, err := health.NewFaultCheck(id, &healthpb.HealthCheck{
+		Id:          "systemStatusCheck",
+		DisplayName: "System Status Check",
+		Description: fmt.Sprintf("Checks the %s driver is connected and operating correctly", kind),
+	})
+	if err != nil {
+		logger.Warn("failed to create driver system check", zap.Error(err))
+		return nil
+	}
+	return check
 }
 
 func devicesToHealthCheckCollection(d *devicespb.Collection) system.HealthCheckCollection {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -20,6 +20,11 @@ type Services struct {
 	Config          service.ConfigUpdater
 	Database        *bolthold.Store
 	Health          *healthpb.Checks
+	// SystemCheck is a driver-level health check for top-level connectivity state
+	// (server reachable, licence valid, etc.). Call MarkFailed when connectivity is lost and
+	// MarkRunning when it is restored. Call Dispose in the driver's stop handler.
+	// May be nil if the check could not be registered; always nil-check before use.
+	SystemCheck service.SystemCheck
 }
 
 type Factory interface {

--- a/pkg/driver/mock/config/root.go
+++ b/pkg/driver/mock/config/root.go
@@ -9,7 +9,15 @@ import (
 
 type Root struct {
 	driver.BaseConfig
-	Devices []Device `json:"devices,omitempty"`
+	HealthCheck *HealthCheck `json:"healthCheck,omitempty"`
+	Devices     []Device     `json:"devices,omitempty"`
+}
+
+// HealthCheck configures a simulated driver-level connectivity health check for UI testing.
+type HealthCheck struct {
+	// FaultProbability is the probability (0.0–1.0) that each tick results in a fault state.
+	// The remaining probability results in a healthy state. Defaults to 0.15.
+	FaultProbability float64 `json:"faultProbability,omitempty"`
 }
 
 type Device struct {

--- a/pkg/driver/mock/driver.go
+++ b/pkg/driver/mock/driver.go
@@ -2,7 +2,10 @@ package mock
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"strconv"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -74,10 +77,20 @@ func (factory) ConfigBlocks() []block.Block {
 
 func NewDriver(services driver.Services) *Driver {
 	d := &Driver{
-		announcer: services.Node,
-		known:     make(map[deviceTrait]node.Undo),
+		announcer:   services.Node,
+		systemCheck: services.SystemCheck,
+		known:       make(map[deviceTrait]node.Undo),
 	}
-	d.Service = service.New(d.applyConfig, service.WithOnStop[config.Root](d.Clean))
+	d.Service = service.New(d.applyConfig, service.WithOnStop[config.Root](func() {
+		if d.simCancel != nil {
+			d.simCancel()
+			d.simCancel = nil
+		}
+		d.Clean()
+		if d.systemCheck != nil {
+			d.systemCheck.Dispose()
+		}
+	}))
 	d.logger = services.Logger.Named(DriverName)
 	return d
 }
@@ -85,9 +98,11 @@ func NewDriver(services driver.Services) *Driver {
 type Driver struct {
 	*service.Service[config.Root]
 
-	logger    *zap.Logger
-	announcer node.Announcer
-	known     map[deviceTrait]node.Undo
+	logger      *zap.Logger
+	announcer   node.Announcer
+	systemCheck service.SystemCheck
+	simCancel   context.CancelFunc
+	known       map[deviceTrait]node.Undo
 }
 
 type deviceTrait struct {
@@ -102,7 +117,13 @@ func (d *Driver) Clean() {
 	d.known = make(map[deviceTrait]node.Undo)
 }
 
-func (d *Driver) applyConfig(_ context.Context, cfg config.Root) error {
+func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
+	// Cancel any running health simulation before (re)configuring.
+	if d.simCancel != nil {
+		d.simCancel()
+		d.simCancel = nil
+	}
+
 	toUndo := maps.Clone(d.known)
 	for _, device := range cfg.Devices {
 		var undos []node.Undo
@@ -161,6 +182,21 @@ func (d *Driver) applyConfig(_ context.Context, cfg config.Root) error {
 	for k, undo := range toUndo {
 		undo()
 		delete(d.known, k)
+	}
+
+	// Start driver-level health simulation if configured.
+	if cfg.HealthCheck != nil && d.systemCheck != nil {
+		p := cfg.HealthCheck.FaultProbability
+		if p <= 0 {
+			p = 0.15
+		}
+		if p > 1 {
+			return fmt.Errorf("healthCheck.faultProbability must be between 0 and 1, got %g", p)
+		}
+		simCtx, cancel := context.WithCancel(ctx)
+		d.simCancel = cancel
+		d.systemCheck.MarkRunning()
+		go runDriverHealthSimulation(simCtx, d.systemCheck, p)
 	}
 
 	return nil
@@ -351,4 +387,28 @@ func newMockClient(traitMd *metadatapb.TraitMetadata, deviceName string, logger 
 	}
 
 	return nil, nil
+}
+
+// runDriverHealthSimulation periodically randomises the driver's system-level health check state.
+// With probability p it transitions to a fault state; otherwise healthy.
+func runDriverHealthSimulation(ctx context.Context, check service.SystemCheck, p float64) {
+	timer := time.NewTimer(randDuration(30*time.Second, 90*time.Second))
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		timer.Reset(randDuration(30*time.Second, 90*time.Second))
+		if rand.Float64() < p {
+			check.MarkFailed(fmt.Errorf("simulated connectivity failure"))
+		} else {
+			check.MarkRunning()
+		}
+	}
+}
+
+func randDuration(min, max time.Duration) time.Duration {
+	return time.Duration(rand.Intn(int(max-min))) + min
 }

--- a/pkg/proto/healthpb/faults.go
+++ b/pkg/proto/healthpb/faults.go
@@ -124,6 +124,18 @@ func findFault(n *HealthCheck_Error, faults []*HealthCheck_Error) (int, bool) {
 	})
 }
 
+// MarkRunning marks the check as healthy. Equivalent to ClearFaults.
+func (c *FaultCheck) MarkRunning() {
+	c.ClearFaults()
+}
+
+// MarkFailed marks the check as unhealthy with the given error.
+func (c *FaultCheck) MarkFailed(err error) {
+	c.SetFault(&HealthCheck_Error{
+		SummaryText: err.Error(),
+	})
+}
+
 func (c *FaultCheck) writeFaults(f func(old []*HealthCheck_Error) []*HealthCheck_Error) {
 	c.write(func(dst *HealthCheck) {
 		out := dst.GetFaults()

--- a/pkg/proto/healthpb/faults_test.go
+++ b/pkg/proto/healthpb/faults_test.go
@@ -1,6 +1,7 @@
 package healthpb
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -371,6 +372,91 @@ func TestFaultCheck_RemoveFault(t *testing.T) {
 				if got := fc.check.GetReliability().GetState(); got != HealthCheck_Reliability_RELIABLE {
 					t.Errorf("RemoveFault() reliability = %v, want %v", got, HealthCheck_Reliability_RELIABLE)
 				}
+			}
+		})
+	}
+}
+
+func TestFaultCheck_MarkFailed(t *testing.T) {
+	tests := map[string]struct {
+		err         error
+		wantSummary string
+	}{
+		"uses error message as summary": {
+			err:         errors.New("connection timeout"),
+			wantSummary: "connection timeout",
+		},
+		"replaces existing fault": {
+			err:         errors.New("new error"),
+			wantSummary: "new error",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &HealthCheck{
+				Check: &HealthCheck_Faults_{Faults: &HealthCheck_Faults{
+					CurrentFaults: []*HealthCheck_Error{newFault("", "", "old error", "")},
+				}},
+				Normality: HealthCheck_ABNORMAL,
+			}
+			fc, err := newFaultCheck(c)
+			if err != nil {
+				t.Fatalf("newFaultCheck() error = %v", err)
+			}
+			fc.MarkFailed(tt.err)
+			faults := fc.check.GetFaults().GetCurrentFaults()
+			if len(faults) != 1 {
+				t.Fatalf("MarkFailed() fault count = %d, want 1", len(faults))
+			}
+			if got := faults[0].GetSummaryText(); got != tt.wantSummary {
+				t.Errorf("MarkFailed() summary = %q, want %q", got, tt.wantSummary)
+			}
+			if got := fc.check.GetNormality(); got != HealthCheck_ABNORMAL {
+				t.Errorf("MarkFailed() normality = %v, want %v", got, HealthCheck_ABNORMAL)
+			}
+			if got := fc.check.GetReliability().GetState(); got != HealthCheck_Reliability_RELIABLE {
+				t.Errorf("MarkFailed() reliability = %v, want %v", got, HealthCheck_Reliability_RELIABLE)
+			}
+		})
+	}
+}
+
+func TestFaultCheck_MarkRunning(t *testing.T) {
+	tests := map[string]struct {
+		initial []*HealthCheck_Error
+	}{
+		"clears faults when unhealthy": {
+			initial: []*HealthCheck_Error{newFault("", "", "some error", "")},
+		},
+		"no-op when already healthy": {
+			initial: nil,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			normality := HealthCheck_NORMAL
+			if len(tt.initial) > 0 {
+				normality = HealthCheck_ABNORMAL
+			}
+			c := &HealthCheck{
+				Check: &HealthCheck_Faults_{Faults: &HealthCheck_Faults{
+					CurrentFaults: tt.initial,
+				}},
+				Normality: normality,
+			}
+			fc, err := newFaultCheck(c)
+			if err != nil {
+				t.Fatalf("newFaultCheck() error = %v", err)
+			}
+			fc.MarkRunning()
+			if faults := fc.check.GetFaults().GetCurrentFaults(); len(faults) != 0 {
+				t.Errorf("MarkRunning() faults = %v, want none", faults)
+			}
+			if got := fc.check.GetNormality(); got != HealthCheck_NORMAL {
+				t.Errorf("MarkRunning() normality = %v, want %v", got, HealthCheck_NORMAL)
+			}
+			if got := fc.check.GetReliability().GetState(); got != HealthCheck_Reliability_RELIABLE {
+				t.Errorf("MarkRunning() reliability = %v, want %v", got, HealthCheck_Reliability_RELIABLE)
 			}
 		})
 	}

--- a/pkg/task/service/check.go
+++ b/pkg/task/service/check.go
@@ -1,0 +1,11 @@
+package service
+
+// SystemCheck is the driver's persistent top-level health indicator, created by the framework
+// and passed via driver.Services.SystemCheck. Drivers call MarkFailed when connectivity is
+// lost and MarkRunning when it is restored. Drivers must call Dispose in their stop handler.
+// May be nil if the check could not be registered; always nil-check before use.
+type SystemCheck interface {
+	Dispose()
+	MarkRunning()
+	MarkFailed(err error)
+}

--- a/ui/ops/src/routes/system/SystemNav.vue
+++ b/ui/ops/src/routes/system/SystemNav.vue
@@ -41,6 +41,11 @@ const menuItems = [
     link: {path: '/system/components'}
   },
   {
+    title: 'Subsystems',
+    icon: 'mdi-check-network',
+    link: {path: '/system/subsystems'}
+  },
+  {
     title: 'Logs',
     icon: 'mdi-text-box-outline',
     link: {path: '/system/logs'}

--- a/ui/ops/src/routes/system/components/SubsystemHealthCard.vue
+++ b/ui/ops/src/routes/system/components/SubsystemHealthCard.vue
@@ -1,0 +1,394 @@
+<template>
+  <v-card width="300px" class="subsystem-health-card">
+    <div class="subsystem-health-card__accent" :style="{ background: accentColor }"/>
+    <v-card-text class="pa-3" style="position: relative; overflow: hidden;">
+      <!-- Watermark icon -->
+      <v-icon class="subsystem-health-card__watermark">{{ icon }}</v-icon>
+
+      <!-- Header -->
+      <div class="d-flex align-start mb-1" style="position: relative;">
+        <v-icon size="20" class="mr-2 mt-1" :color="statusColor">{{ icon }}</v-icon>
+        <div class="flex-grow-1 min-width-0">
+          <div class="text-subtitle-2 font-weight-bold text-truncate" :title="title">{{ title }}</div>
+          <div v-if="description" class="text-caption text-medium-emphasis text-truncate">{{ description }}</div>
+        </div>
+      </div>
+
+      <v-divider class="my-2"/>
+
+      <!-- Aggregate status row -->
+      <div class="d-flex align-center mb-2" style="position: relative;">
+        <v-icon size="16" :color="statusColor" class="mr-1">{{ statusIcon }}</v-icon>
+        <span class="text-caption font-weight-medium" :class="`text-${statusColor}`">{{ statusLabel }}</span>
+      </div>
+
+      <!-- Stream error explanation -->
+      <div v-if="streamErrorMessage" class="detail-line text-caption text-error mb-2" style="position: relative;">
+        <v-icon size="12" class="mr-1" color="error">mdi-alert-circle-outline</v-icon>
+        Could not load checks: {{ streamErrorMessage }}
+      </div>
+
+      <!-- Check rows (grouped or flat) -->
+      <template v-if="displayGroups.length > 0">
+        <template v-for="group in displayGroups" :key="group.key">
+          <!-- Group header row (only when the config entry is a named group) -->
+          <div v-if="group.label" class="group-header d-flex align-center py-1 mt-1">
+            <normality-icon :model-value="{ normality: worstNormality(group.allItems) }" size="12" class="mr-1"/>
+            <reliability-icon :model-value="{ reliability: { state: worstReliabilityState(group.allItems) } }" size="12" class="mr-2"/>
+            <span class="text-caption font-weight-medium text-medium-emphasis flex-grow-1 text-truncate" :title="group.label">
+              {{ group.label }}
+            </span>
+            <span class="text-caption text-medium-emphasis flex-shrink-0 ml-1">
+              {{ checkCountLabel(group.allItems) }}
+            </span>
+          </div>
+
+          <!-- Check entries; indented when inside a named group -->
+          <div :class="group.label ? 'pl-3' : ''">
+            <div v-for="entry in group.entries" :key="entry.check.name" style="position: relative;">
+              <!-- Clickable summary row -->
+              <div
+                  class="d-flex align-center check-row py-1"
+                  :class="{ 'check-row--expandable': hasDetail(entry) }"
+                  @click="hasDetail(entry) && toggleExpand(entry.check.name)">
+                <normality-icon :model-value="{ normality: worstNormality(entry.items) }" size="14" class="mr-1"/>
+                <reliability-icon :model-value="{ reliability: { state: worstReliabilityState(entry.items) } }" size="14" class="mr-2"/>
+                <span class="text-caption text-truncate flex-grow-1" :title="entry.check.displayName ?? entry.check.name">
+                  {{ entry.check.displayName ?? entry.check.name }}
+                </span>
+                <span class="text-caption text-medium-emphasis flex-shrink-0 ml-1">
+                  {{ checkCountLabel(entry.items) }}
+                </span>
+                <v-icon
+                    v-if="hasDetail(entry)"
+                    size="14"
+                    class="ml-1 flex-shrink-0 expand-chevron"
+                    :class="{ 'expand-chevron--open': expandedChecks.has(entry.check.name) }">
+                  mdi-chevron-down
+                </v-icon>
+              </div>
+
+              <!-- Expandable detail -->
+              <v-expand-transition>
+                <div v-if="expandedChecks.has(entry.check.name)" class="check-detail pb-1">
+                  <template v-for="item in entry.items" :key="item.id">
+                    <!-- Item header when multiple checks exist under this entry -->
+                    <div v-if="entry.items.length > 1" class="text-caption font-weight-medium text-medium-emphasis mt-1 mb-0-5">
+                      {{ item.displayName || item.id }}
+                    </div>
+                    <!-- Description -->
+                    <div v-if="item.description" class="detail-line text-caption text-medium-emphasis">
+                      <v-icon size="12" class="mr-1">mdi-information-outline</v-icon>
+                      {{ item.description }}
+                    </div>
+                    <!-- Reliability state + offline-since timestamp -->
+                    <template v-if="item.reliability && item.reliability.state > reliableState">
+                      <div class="detail-line text-caption text-error">
+                        <v-icon size="12" class="mr-1" color="error">mdi-lan-disconnect</v-icon>
+                        {{ reliabilityStateToString(item.reliability.state) }}
+                        <span v-if="item.reliability.unreliableTime" class="text-medium-emphasis ml-1">
+                          since {{ formatTimestamp(item.reliability.unreliableTime) }}
+                        </span>
+                      </div>
+                      <!-- Last error message -->
+                      <div v-if="item.reliability.lastError" class="detail-line text-caption text-error">
+                        <v-icon size="12" class="mr-1" color="error">mdi-alert-circle-outline</v-icon>
+                        {{ item.reliability.lastError.summaryText }}
+                        <span v-if="item.reliability.lastError.detailsText" class="text-medium-emphasis d-block ml-4">
+                          {{ item.reliability.lastError.detailsText }}
+                        </span>
+                      </div>
+                      <!-- Root cause -->
+                      <div v-if="item.reliability.cause" class="detail-line text-caption text-medium-emphasis">
+                        <v-icon size="12" class="mr-1">mdi-transit-connection-variant</v-icon>
+                        Caused by: {{ item.reliability.cause.displayName || item.reliability.cause.name }}
+                        <span v-if="item.reliability.cause.error && item.reliability.cause.error.summaryText" class="d-block ml-4">
+                          {{ item.reliability.cause.error.summaryText }}
+                        </span>
+                      </div>
+                    </template>
+                    <!-- Abnormal-since timestamp (for normality issues unrelated to reliability) -->
+                    <div
+                        v-else-if="item.normality > normalNormality && item.abnormalTime"
+                        class="detail-line text-caption text-warning">
+                      <v-icon size="12" class="mr-1" color="warning">mdi-clock-alert-outline</v-icon>
+                      Abnormal since {{ formatTimestamp(item.abnormalTime) }}
+                    </div>
+                    <!-- Faults -->
+                    <div
+                        v-for="(fault, fi) in item.faults?.currentFaultsList"
+                        :key="fi"
+                        class="detail-line text-caption text-warning">
+                      <v-icon size="12" class="mr-1" color="warning">mdi-alert-outline</v-icon>
+                      {{ fault.summaryText }}
+                      <span v-if="fault.detailsText" class="text-medium-emphasis d-block ml-4">
+                        {{ fault.detailsText }}
+                      </span>
+                    </div>
+                  </template>
+                </div>
+              </v-expand-transition>
+            </div>
+          </div>
+        </template>
+      </template>
+      <div v-else class="text-caption text-medium-emphasis" style="position: relative;">
+        No checks configured
+      </div>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup>
+import {timestampToDate} from '@/api/convpb.js';
+import {reliabilityStateToString} from '@/api/sc/traits/health.js';
+import {usePullHealthChecks} from '@/traits/health/health.js';
+import NormalityIcon from '@/traits/health/NormalityIcon.vue';
+import ReliabilityIcon from '@/traits/health/ReliabilityIcon.vue';
+import {HealthCheck} from '@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/health/v1/health_pb';
+import {computed, ref} from 'vue';
+
+const props = defineProps({
+  title: {type: String, required: true},
+  icon: {type: String, default: 'mdi-cube-outline'},
+  description: {type: String, default: ''},
+  checks: {
+    /**
+     * Each entry is either a leaf check or a named group of leaf checks:
+     *   {name: string, displayName?: string}
+     *   {displayName: string, checks: Array<{name: string, displayName?: string}>}
+     *
+     * @type {import('vue').PropType<Array<
+     *   {name: string, displayName?: string} |
+     *   {displayName: string, checks: Array<{name: string, displayName?: string}>}
+     * >>}
+     */
+    type: Array,
+    default: () => []
+  }
+});
+
+const reliableState = HealthCheck.Reliability.State.RELIABLE;
+const normalNormality = HealthCheck.Normality.NORMAL;
+
+/**
+ * @param {{seconds: number, nanos: number}|undefined} ts
+ * @return {string}
+ */
+function formatTimestamp(ts) {
+  if (!ts) return '';
+  return timestampToDate(ts).toLocaleString();
+}
+
+// Flatten all leaf checks so we can set up composable streams at component setup time.
+// Composables cannot be called conditionally or in dynamically-sized loops after setup.
+const allLeaves = props.checks.flatMap(c => c.checks ?? [c]);
+
+const checkResources = allLeaves.map(check => {
+  const {value: checksRef, streamError} = usePullHealthChecks(() => check.name);
+  return {check, checksRef, streamError};
+});
+
+const resourceByName = new Map(checkResources.map(r => [r.check.name, r]));
+
+// Build display groups reactively. Each group has a label (null for ungrouped leaves),
+// its check entries, and a flat allItems list for group-level aggregation.
+const displayGroups = computed(() => {
+  return props.checks.map((c, i) => {
+    if (c.checks) {
+      const entries = c.checks.map(leaf => {
+        const r = resourceByName.get(leaf.name);
+        return {check: leaf, items: Object.values(r?.checksRef.value ?? {})};
+      });
+      return {
+        key: c.displayName ?? `group-${i}`,
+        label: c.displayName ?? null,
+        entries,
+        allItems: entries.flatMap(e => e.items)
+      };
+    }
+    const r = resourceByName.get(c.name);
+    const items = Object.values(r?.checksRef.value ?? {});
+    return {
+      key: c.name,
+      label: null,
+      entries: [{check: c, items}],
+      allItems: items
+    };
+  });
+});
+
+/**
+ * @param {object[]} items
+ * @return {number}
+ */
+function worstNormality(items) {
+  if (!items.length) return 0;
+  return Math.max(...items.map(c => c.normality ?? 0));
+}
+
+/**
+ * @param {object[]} items
+ * @return {number}
+ */
+function worstReliabilityState(items) {
+  if (!items.length) return 0;
+  return Math.max(...items.map(c => c.reliability?.state ?? 0));
+}
+
+/**
+ * @param {object[]} items
+ * @return {string}
+ */
+function checkCountLabel(items) {
+  if (!items.length) return '';
+  const normal = items.filter(c => (c.normality ?? 0) === HealthCheck.Normality.NORMAL).length;
+  return `${normal}/${items.length}`;
+}
+
+/**
+ * @param {{items: object[]}} entry
+ * @return {boolean}
+ */
+function hasDetail(entry) {
+  return entry.items.some(item =>
+      item.description ||
+      (item.reliability?.state > reliableState) ||
+      item.faults?.currentFaultsList?.length > 0 ||
+      (item.normality > normalNormality && item.abnormalTime)
+  );
+}
+
+const expandedChecks = ref(new Set());
+
+/** @param {string} name */
+function toggleExpand(name) {
+  const next = new Set(expandedChecks.value);
+  if (next.has(name)) {
+    next.delete(name);
+  } else {
+    next.add(name);
+  }
+  expandedChecks.value = next;
+}
+
+const streamErrorMessage = computed(() => {
+  const errored = checkResources.find(r => r.streamError.value !== null);
+  return errored?.streamError.value.error?.message ?? null;
+});
+
+const aggregateStatus = computed(() => {
+  const allItems = displayGroups.value.flatMap(g => g.allItems);
+  const hasStreamError = checkResources.some(r => r.streamError.value !== null);
+  if (allItems.length === 0) return hasStreamError ? 'error' : 'unknown';
+  const anyUnreliable = allItems.some(c => (c.reliability?.state ?? 0) > HealthCheck.Reliability.State.RELIABLE);
+  if (anyUnreliable) return 'error';
+  const anyAbnormal = allItems.some(c => (c.normality ?? 0) > HealthCheck.Normality.NORMAL);
+  if (anyAbnormal) return 'warning';
+  return 'ok';
+});
+
+const statusColor = computed(() => {
+  switch (aggregateStatus.value) {
+    case 'ok': return 'success';
+    case 'warning': return 'warning';
+    case 'error': return 'error';
+    default: return 'medium-emphasis';
+  }
+});
+
+const statusIcon = computed(() => {
+  switch (aggregateStatus.value) {
+    case 'ok': return 'mdi-check-circle';
+    case 'warning': return 'mdi-alert';
+    case 'error': return 'mdi-alert-circle';
+    default: return 'mdi-help-circle';
+  }
+});
+
+const statusLabel = computed(() => {
+  switch (aggregateStatus.value) {
+    case 'ok': return 'Healthy';
+    case 'warning': return 'Degraded';
+    case 'error': return 'Fault';
+    default: return 'Unknown';
+  }
+});
+
+const accentColor = computed(() => {
+  switch (aggregateStatus.value) {
+    case 'ok': return 'rgb(var(--v-theme-success))';
+    case 'warning': return 'rgb(var(--v-theme-warning))';
+    case 'error': return 'rgb(var(--v-theme-error))';
+    default: return 'rgba(var(--v-theme-on-surface), 0.12)';
+  }
+});
+</script>
+
+<style scoped>
+.subsystem-health-card__accent {
+  height: 3px;
+  width: 100%;
+  transition: background 0.3s ease;
+}
+
+.subsystem-health-card__watermark {
+  position: absolute;
+  bottom: -12px;
+  right: -8px;
+  font-size: 96px !important;
+  opacity: 0.04;
+  pointer-events: none;
+  user-select: none;
+}
+
+.min-width-0 {
+  min-width: 0;
+}
+
+.group-header {
+  border-bottom: 1px solid rgba(var(--v-theme-on-surface), 0.08);
+}
+
+.group-header:not(:first-child) {
+  margin-top: 6px !important;
+}
+
+.check-row:not(:last-child) {
+  border-bottom: 1px solid rgba(var(--v-theme-on-surface), 0.04);
+}
+
+.check-row--expandable {
+  cursor: pointer;
+}
+
+.check-row--expandable:hover {
+  background: rgba(var(--v-theme-on-surface), 0.04);
+  border-radius: 4px;
+}
+
+.expand-chevron {
+  transition: transform 0.2s ease;
+  opacity: 0.6;
+}
+
+.expand-chevron--open {
+  transform: rotate(180deg);
+}
+
+.check-detail {
+  padding-left: 30px;
+  border-left: 2px solid rgba(var(--v-theme-on-surface), 0.08);
+  margin-left: 4px;
+  margin-bottom: 4px;
+}
+
+.detail-line {
+  line-height: 1.4;
+  padding: 1px 0;
+}
+
+.mb-0-5 {
+  margin-bottom: 2px;
+}
+</style>

--- a/ui/ops/src/routes/system/components/SubsystemHealthCard.vue
+++ b/ui/ops/src/routes/system/components/SubsystemHealthCard.vue
@@ -93,7 +93,7 @@
                       <!-- Last error message -->
                       <div v-if="item.reliability.lastError" class="detail-line text-caption text-error">
                         <v-icon size="12" class="mr-1" color="error">mdi-alert-circle-outline</v-icon>
-                        {{ item.reliability.lastError.summaryText }}
+                        {{ toSentenceCase(item.reliability.lastError.summaryText) }}
                         <span v-if="item.reliability.lastError.detailsText" class="text-medium-emphasis d-block ml-4">
                           {{ item.reliability.lastError.detailsText }}
                         </span>
@@ -103,7 +103,7 @@
                         <v-icon size="12" class="mr-1">mdi-transit-connection-variant</v-icon>
                         Caused by: {{ item.reliability.cause.displayName || item.reliability.cause.name }}
                         <span v-if="item.reliability.cause.error && item.reliability.cause.error.summaryText" class="d-block ml-4">
-                          {{ item.reliability.cause.error.summaryText }}
+                          {{ toSentenceCase(item.reliability.cause.error.summaryText) }}
                         </span>
                       </div>
                     </template>
@@ -120,7 +120,7 @@
                         :key="fi"
                         class="detail-line text-caption text-warning">
                       <v-icon size="12" class="mr-1" color="warning">mdi-alert-outline</v-icon>
-                      {{ fault.summaryText }}
+                      {{ toSentenceCase(fault.summaryText) }}
                       <span v-if="fault.detailsText" class="text-medium-emphasis d-block ml-4">
                         {{ fault.detailsText }}
                       </span>
@@ -178,6 +178,12 @@ const normalNormality = HealthCheck.Normality.NORMAL;
 function formatTimestamp(ts) {
   if (!ts) return '';
   return timestampToDate(ts).toLocaleString();
+}
+
+/** @param {string|undefined} str */
+function toSentenceCase(str) {
+  if (!str) return '';
+  return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 // Flatten all leaf checks so we can set up composable streams at component setup time.

--- a/ui/ops/src/routes/system/components/SubsystemHealthCard.vue
+++ b/ui/ops/src/routes/system/components/SubsystemHealthCard.vue
@@ -145,6 +145,7 @@ import {reliabilityStateToString} from '@/api/sc/traits/health.js';
 import {usePullHealthChecks} from '@/traits/health/health.js';
 import NormalityIcon from '@/traits/health/NormalityIcon.vue';
 import ReliabilityIcon from '@/traits/health/ReliabilityIcon.vue';
+import {toSentenceCase} from '@/util/string.js';
 import {HealthCheck} from '@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/health/v1/health_pb';
 import {computed, ref} from 'vue';
 
@@ -180,11 +181,6 @@ function formatTimestamp(ts) {
   return timestampToDate(ts).toLocaleString();
 }
 
-/** @param {string|undefined} str */
-function toSentenceCase(str) {
-  if (!str) return '';
-  return str.charAt(0).toUpperCase() + str.slice(1);
-}
 
 // Flatten all leaf checks so we can set up composable streams at component setup time.
 // Composables cannot be called conditionally or in dynamically-sized loops after setup.

--- a/ui/ops/src/routes/system/components/pages/SubsystemHealthList.vue
+++ b/ui/ops/src/routes/system/components/pages/SubsystemHealthList.vue
@@ -1,0 +1,29 @@
+<template>
+  <div>
+    <h3 class="text-h3 pt-2 pb-6">Subsystems</h3>
+
+    <div v-if="subsystems.length > 0" class="d-flex flex-wrap ml-n2">
+      <subsystem-health-card
+          v-for="subsystem in subsystems"
+          :key="subsystem.title"
+          :title="subsystem.title"
+          :icon="subsystem.icon"
+          :description="subsystem.description"
+          :checks="subsystem.checks"
+          class="ma-2"/>
+    </div>
+    <div v-else class="text-body-2 text-medium-emphasis">
+      No subsystems configured. Add entries to
+      <code>config.system.subsystemHealth.subsystems</code> in your UI configuration.
+    </div>
+  </div>
+</template>
+
+<script setup>
+import SubsystemHealthCard from '@/routes/system/components/SubsystemHealthCard.vue';
+import {useUiConfigStore} from '@/stores/uiConfig.js';
+import {computed} from 'vue';
+
+const uiConfig = useUiConfigStore();
+const subsystems = computed(() => uiConfig.getOrDefault('system.subsystemHealth.subsystems', []));
+</script>

--- a/ui/ops/src/routes/system/route.js
+++ b/ui/ops/src/routes/system/route.js
@@ -62,6 +62,17 @@ export default [
         }
       },
       {
+        path: 'subsystems',
+        components: {
+          default: () => import('./components/pages/SubsystemHealthList.vue')
+        },
+        meta: {
+          authentication: {
+            rolesRequired: ['superAdmin', 'admin', 'commissioner', 'operator', 'viewer']
+          }
+        }
+      },
+      {
         path: 'logs',
         components: {
           default: () => import('./components/pages/LogsPage.vue')

--- a/ui/ops/src/util/string.js
+++ b/ui/ops/src/util/string.js
@@ -7,3 +7,14 @@
 export function camelToSentence(key) {
   return key.replace(/([A-Z])/g, ' $1');
 }
+
+/**
+ * Capitalizes the first letter of a string
+ *
+ * @param {string|undefined} str
+ * @return {string}
+ */
+export function toSentenceCase(str) {
+  if (!str) return '';
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}


### PR DESCRIPTION
- Adds a 'system' health check as a first class concept to the driver services framework. This gives drivers a common pattern to use  to say whether they are functioning on a 'system' level. It is still up the the implementation of the driver to determine if they use this or define their own health checks for a 'system level' check.
- Adds a page to the ops UI to surface these checks (or any named checks) in a flexible way, which can show the health of each subsystem from a high level. The idea is that this page is flexible enough to group related checks and desribe any health checks so the health data is more accessible to operators

Also add health info to mock drivers and restructure the vanti ugs config so the mock drivers are named per floor (`floor/02/drivers`) rather than all on a controller level, which reflects reality better and make the health UI cleaner

For drivers which talk to one or just a few servers, this change makes it easy to just implement the check and add the driver's name to the UI config, as the system health check uses the driver's name. But as we have a diverse range of drivers which all work differently, a single health check might not always work. 
I.e. the BACnet driver can talk to multiple controllers from a single driver instance. 

Some ramblings: we could still add this 'system check' pattern to things like the BACnet driver, and then just structure the project config in a way that a single bacnet driver instance talks to a single bacnet controller. That would make detecting and surfacing issues a bit easier without adding more complexity to the driver itself.


<img width="2189" height="980" alt="image" src="https://github.com/user-attachments/assets/828758fc-d5de-4e45-8692-d849298a708d" />
