### PR TITLE
Feat/UI enhancements oc lint

### DIFF
--- a/example/config/vanti-ugs-cohort/ac-01/app.conf.json
+++ b/example/config/vanti-ugs-cohort/ac-01/app.conf.json
@@ -707,7 +707,11 @@
           "name": "van/uk/brum/ugs/devices/SHD-LN1-01",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]",
+                "openPercentAttributes": "{\"bounds\":{\"min\":0,\"max\":100},\"step\":25}"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -728,7 +732,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-LN1-02",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -749,7 +756,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-LN1-03",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -770,7 +780,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-LN1-04",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -791,7 +804,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-LN1-05",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -812,7 +828,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-LN1-06",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1800,7 +1819,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-01",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1821,7 +1843,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-02",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1842,7 +1867,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-03",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1863,7 +1891,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-04",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1884,7 +1915,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-05",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1905,7 +1939,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-06",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1926,7 +1963,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-07",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1947,7 +1987,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-08",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1968,7 +2011,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-09",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2004,7 +2050,10 @@
               "name": "smartcore.traits.EnterLeaveSensor"
             },
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2046,7 +2095,10 @@
           "name": "van/uk/brum/ugs/devices/DOR-L00-01",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2067,7 +2119,10 @@
           "name": "van/uk/brum/ugs/devices/DOR-L00-02",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2530,7 +2585,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L01-01",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2552,7 +2610,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L01-02",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2574,7 +2635,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L01-03",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2596,7 +2660,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L01-04",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"

--- a/example/config/vanti-ugs/app.conf.json
+++ b/example/config/vanti-ugs/app.conf.json
@@ -707,7 +707,11 @@
           "name": "van/uk/brum/ugs/devices/SHD-LN1-01",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]",
+                "openPercentAttributes": "{\"bounds\":{\"min\":0,\"max\":100},\"step\":25}"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -728,7 +732,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-LN1-02",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -749,7 +756,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-LN1-03",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -770,7 +780,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-LN1-04",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -791,7 +804,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-LN1-05",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -812,7 +828,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-LN1-06",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1800,7 +1819,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-01",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1821,7 +1843,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-02",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1842,7 +1867,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-03",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1863,7 +1891,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-04",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1884,7 +1915,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-05",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1905,7 +1939,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-06",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1926,7 +1963,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-07",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1947,7 +1987,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-08",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -1968,7 +2011,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L00-09",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2004,7 +2050,10 @@
               "name": "smartcore.traits.EnterLeaveSensor"
             },
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2046,7 +2095,10 @@
           "name": "van/uk/brum/ugs/devices/DOR-L00-01",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2067,7 +2119,10 @@
           "name": "van/uk/brum/ugs/devices/DOR-L00-02",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2530,7 +2585,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L01-01",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2552,7 +2610,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L01-02",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2574,7 +2635,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L01-03",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"
@@ -2596,7 +2660,10 @@
           "name": "van/uk/brum/ugs/devices/SHD-L01-04",
           "traits": [
             {
-              "name": "smartcore.traits.OpenClose"
+              "name": "smartcore.traits.OpenClose",
+              "more": {
+                "presets": "[{\"name\":\"closed\",\"title\":\"Closed\",\"positions\":{\"openPercent\":0}},{\"name\":\"ajar\",\"title\":\"Ajar\",\"positions\":{\"openPercent\":50}},{\"name\":\"opened\",\"title\":\"Opened\",\"positions\":{\"openPercent\":100}}]"
+              }
             },
             {
               "name": "smartcore.bos.Status"

--- a/pkg/driver/gallagher/occupancy.go
+++ b/pkg/driver/gallagher/occupancy.go
@@ -64,7 +64,11 @@ func (o *OccupancyEventController) run(ctx context.Context) error {
 
 func (o *OccupancyEventController) refresh() error {
 
-	reqUrl := fmt.Sprintf("%s?after=%s&fields=source&top=1000", o.client.getUrl("events"), o.lastRefreshCycle.Format(time.RFC3339))
+	if o.lastRefreshCycle.IsZero() {
+		o.lastRefreshCycle = o.bootupTime
+	}
+
+	reqUrl := fmt.Sprintf("%s?after=%s&fields=source&top=1000", o.client.getUrl("events"), o.lastRefreshCycle.UTC().Format(time.RFC3339))
 
 	bytes, err := o.client.doRequest(reqUrl)
 

--- a/pkg/driver/mock/openclose.go
+++ b/pkg/driver/mock/openclose.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/node"
 	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/openclosepb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/typespb"
 	"github.com/smart-core-os/sc-bos/pkg/resource"
 	"github.com/smart-core-os/sc-bos/pkg/task/service"
 )
@@ -19,10 +20,17 @@ import (
 // Configuration of the mock device is done via the trait metadata more map.
 // You can specify a "presets" key which has the JSON format of `[{name, title?, positions}, ...]`,
 // where `positions` is the protojson representation of either a single or array of traits.OpenClosePosition.
+//
+// You can also specify an "openPercentAttributes" key with the protojson representation of
+// types.FloatAttributes to advertise the bounds and step of the open percent value via DescribePositions,
+// e.g. `{"bounds":{"min":0,"max":100},"step":25}`.
 func mockOpenClose(traitMd *metadatapb.TraitMetadata, deviceName string, logger *zap.Logger) ([]node.Feature, service.Lifecycle) {
 	var opts []resource.Option
 
 	opts = append(opts, parseOpenClosePresets(traitMd, deviceName, logger)...)
+	if attrsOpt := parseOpenPercentAttributes(traitMd, deviceName, logger); attrsOpt != nil {
+		opts = append(opts, attrsOpt)
+	}
 
 	model := openclosepb.NewModel(opts...)
 	server := openclosepb.NewModelServer(model)
@@ -30,6 +38,19 @@ func mockOpenClose(traitMd *metadatapb.TraitMetadata, deviceName string, logger 
 		node.HasServer(openclosepb.RegisterOpenCloseApiServer, openclosepb.OpenCloseApiServer(server)),
 		node.HasServer(openclosepb.RegisterOpenCloseInfoServer, openclosepb.OpenCloseInfoServer(server)),
 	}, auto.OpenClose(model)
+}
+
+func parseOpenPercentAttributes(traitMd *metadatapb.TraitMetadata, deviceName string, logger *zap.Logger) resource.Option {
+	raw, ok := traitMd.GetMore()["openPercentAttributes"]
+	if !ok {
+		return nil
+	}
+	attrs := &typespb.FloatAttributes{}
+	if err := protojson.Unmarshal([]byte(raw), attrs); err != nil {
+		logger.Sugar().Warnf("Unable to unmarshal openPercentAttributes for mock device %q: %v. %v", deviceName, err, raw)
+		return nil
+	}
+	return openclosepb.WithOpenPercentAttributes(attrs)
 }
 
 func parseOpenClosePresets(traitMd *metadatapb.TraitMetadata, deviceName string, logger *zap.Logger) []resource.Option {

--- a/pkg/proto/openclosepb/model.go
+++ b/pkg/proto/openclosepb/model.go
@@ -11,14 +11,16 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/smart-core-os/sc-bos/pkg/proto/typespb"
 	"github.com/smart-core-os/sc-bos/pkg/resource"
 	"github.com/smart-core-os/sc-bos/pkg/util/cmp"
 	"github.com/smart-core-os/sc-bos/pkg/util/masks"
 )
 
 type Model struct {
-	positions *resource.Collection // of *traits.OpenClosePosition
-	presets   []preset
+	positions        *resource.Collection // of *traits.OpenClosePosition
+	presets          []preset
+	openPercentAttrs *typespb.FloatAttributes
 }
 
 // NewModel creates a new *Model with the given options.
@@ -26,8 +28,9 @@ type Model struct {
 func NewModel(opts ...resource.Option) *Model {
 	args := calcModelArgs(opts...)
 	return &Model{
-		positions: resource.NewCollection(args.positionsOpts...),
-		presets:   args.presets,
+		positions:        resource.NewCollection(args.positionsOpts...),
+		presets:          args.presets,
+		openPercentAttrs: args.openPercentAttrs,
 	}
 }
 
@@ -160,6 +163,10 @@ func (m *Model) PullPositions(ctx context.Context, ops ...resource.ReadOption) <
 type PullOpenClosePositionsChange struct {
 	Positions  *OpenClosePositions
 	ChangeTime time.Time
+}
+
+func (m *Model) OpenPercentAttributes() *typespb.FloatAttributes {
+	return m.openPercentAttrs
 }
 
 func (m *Model) ListPresets() []*OpenClosePositions_Preset {

--- a/pkg/proto/openclosepb/model_opts.go
+++ b/pkg/proto/openclosepb/model_opts.go
@@ -1,6 +1,7 @@
 package openclosepb
 
 import (
+	"github.com/smart-core-os/sc-bos/pkg/proto/typespb"
 	"github.com/smart-core-os/sc-bos/pkg/resource"
 )
 
@@ -35,6 +36,15 @@ func WithPreset(desc *OpenClosePositions_Preset, positions ...*OpenClosePosition
 	})
 }
 
+// WithOpenPercentAttributes returns an option that configures the model with the given open percent attributes.
+// These attributes are reported via OpenCloseInfo.DescribePositions and inform clients of the bounds and step
+// available for the open percent value.
+func WithOpenPercentAttributes(attrs *typespb.FloatAttributes) resource.Option {
+	return modelOptionFunc(func(args *modelArgs) {
+		args.openPercentAttrs = attrs
+	})
+}
+
 func calcModelArgs(opts ...resource.Option) modelArgs {
 	args := new(modelArgs)
 	args.apply(DefaultModelOptions...)
@@ -43,8 +53,9 @@ func calcModelArgs(opts ...resource.Option) modelArgs {
 }
 
 type modelArgs struct {
-	positionsOpts []resource.Option
-	presets       []preset
+	positionsOpts    []resource.Option
+	presets          []preset
+	openPercentAttrs *typespb.FloatAttributes
 }
 
 func (a *modelArgs) apply(opts ...resource.Option) {

--- a/pkg/proto/openclosepb/model_server.go
+++ b/pkg/proto/openclosepb/model_server.go
@@ -56,8 +56,9 @@ func (s *ModelServer) DescribePositions(_ context.Context, _ *DescribePositionsR
 			Readable: true, Writable: true, Observable: true,
 			PullSupport: typespb.PullSupport_PULL_SUPPORT_NATIVE,
 		},
-		SupportsStop: true,
-		Presets:      s.model.ListPresets(),
+		SupportsStop:          true,
+		Presets:               s.model.ListPresets(),
+		OpenPercentAttributes: s.model.OpenPercentAttributes(),
 	}
 	return support, nil
 }

--- a/pkg/util/masks/util.go
+++ b/pkg/util/masks/util.go
@@ -16,18 +16,18 @@ func RemovePrefix(prefix string, mask *fieldmaskpb.FieldMask) *fieldmaskpb.Field
 		case path == prefix:
 			continue // skip this one
 		case strings.HasPrefix(path, prefix+"."):
-			path = path[7:]
+			path = path[len(prefix)+1:]
 			switch {
 			case path == "*":
 				continue
 			case strings.HasPrefix(path, "*."):
 				path = path[2:]
 			}
-			out.Paths = append(mask.Paths, path)
+			out.Paths = append(out.Paths, path)
 		}
 	}
 
-	if len(mask.Paths) == 0 {
+	if len(out.Paths) == 0 {
 		return nil
 	}
 	return out

--- a/ui/ops/src/api/sc/traits/open-close.js
+++ b/ui/ops/src/api/sc/traits/open-close.js
@@ -1,8 +1,14 @@
 import {fieldMaskFromObject, setProperties} from '@/api/convpb';
 import {clientOptions} from '@/api/grpcweb.js';
-import {pullResource, setValue} from '@/api/resource.js';
-import {OpenCloseApiPromiseClient} from '@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/openclose/v1/open_close_grpc_web_pb';
-import {PullOpenClosePositionsRequest} from '@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/openclose/v1/open_close_pb';
+import {pullResource, setValue, trackAction} from '@/api/resource.js';
+import {OpenCloseApiPromiseClient, OpenCloseInfoPromiseClient} from '@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/openclose/v1/open_close_grpc_web_pb';
+import {
+  DescribePositionsRequest,
+  OpenClosePosition,
+  OpenClosePositions,
+  PullOpenClosePositionsRequest,
+  UpdateOpenClosePositionsRequest
+} from '@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/openclose/v1/open_close_pb';
 
 /**
  * @param {Partial<PullOpenClosePositionsRequest.AsObject>} request
@@ -23,11 +29,43 @@ export function pullOpenClosePositions(request, resource) {
 }
 
 /**
+ * @param {Partial<UpdateOpenClosePositionsRequest.AsObject>} request
+ * @param {ActionTracker<OpenClosePositions.AsObject>} [tracker]
+ * @return {Promise<OpenClosePositions.AsObject>}
+ */
+export function updateOpenClosePositions(request, tracker) {
+  return trackAction('OpenClose.updatePositions', tracker ?? {}, endpoint => {
+    const api = apiClient(endpoint);
+    return api.updatePositions(updateOpenClosePositionsRequestFromObject(request));
+  });
+}
+
+/**
+ * @param {Partial<DescribePositionsRequest.AsObject>} request
+ * @param {ActionTracker<PositionsSupport.AsObject>} [tracker]
+ * @return {Promise<PositionsSupport.AsObject>}
+ */
+export function describeOpenClosePositions(request, tracker) {
+  return trackAction('OpenCloseInfo.describePositions', tracker ?? {}, endpoint => {
+    const api = infoClient(endpoint);
+    return api.describePositions(describePositionsRequestFromObject(request));
+  });
+}
+
+/**
  * @param {string} endpoint
  * @return {OpenCloseApiPromiseClient}
  */
 function apiClient(endpoint) {
   return new OpenCloseApiPromiseClient(endpoint, null, clientOptions());
+}
+
+/**
+ * @param {string} endpoint
+ * @return {OpenCloseInfoPromiseClient}
+ */
+function infoClient(endpoint) {
+  return new OpenCloseInfoPromiseClient(endpoint, null, clientOptions());
 }
 
 /**
@@ -40,5 +78,62 @@ function pullOpenClosePositionsRequestFromObject(obj) {
   const dst = new PullOpenClosePositionsRequest();
   setProperties(dst, obj, 'name', 'excludeTweening', 'updatesOnly');
   dst.setReadMask(fieldMaskFromObject(obj.readMask));
+  return dst;
+}
+
+/**
+ * @param {Partial<UpdateOpenClosePositionsRequest.AsObject>} obj
+ * @return {undefined|UpdateOpenClosePositionsRequest}
+ */
+function updateOpenClosePositionsRequestFromObject(obj) {
+  if (!obj) return undefined;
+
+  const dst = new UpdateOpenClosePositionsRequest();
+  setProperties(dst, obj, 'name', 'delta');
+  dst.setStates(openClosePositionsFromObject(obj.states));
+  dst.setUpdateMask(fieldMaskFromObject(obj.updateMask));
+  return dst;
+}
+
+/**
+ * @param {Partial<OpenClosePositions.AsObject>} obj
+ * @return {undefined|OpenClosePositions}
+ */
+function openClosePositionsFromObject(obj) {
+  if (!obj) return undefined;
+
+  const dst = new OpenClosePositions();
+  if (obj.statesList) {
+    dst.setStatesList(obj.statesList.map(openClosePositionFromObject).filter(Boolean));
+  }
+  if (obj.preset) {
+    const preset = new OpenClosePositions.Preset();
+    setProperties(preset, obj.preset, 'name', 'title');
+    dst.setPreset(preset);
+  }
+  return dst;
+}
+
+/**
+ * @param {Partial<OpenClosePosition.AsObject>} obj
+ * @return {undefined|OpenClosePosition}
+ */
+function openClosePositionFromObject(obj) {
+  if (!obj) return undefined;
+
+  const dst = new OpenClosePosition();
+  setProperties(dst, obj, 'openPercent', 'targetOpenPercent', 'direction', 'resistance');
+  return dst;
+}
+
+/**
+ * @param {Partial<DescribePositionsRequest.AsObject>} obj
+ * @return {undefined|DescribePositionsRequest}
+ */
+function describePositionsRequestFromObject(obj) {
+  if (!obj) return undefined;
+
+  const dst = new DescribePositionsRequest();
+  setProperties(dst, obj, 'name');
   return dst;
 }

--- a/ui/ops/src/dynamic/widgets/meter/MeterHistoryCard.vue
+++ b/ui/ops/src/dynamic/widgets/meter/MeterHistoryCard.vue
@@ -75,7 +75,7 @@ import PeriodChooserRows from '@/components/PeriodChooserRows.vue';
 import {useDescribeMeterReading} from '@/traits/meter/meter.js';
 import {isNullOrUndef} from '@/util/types.js';
 import {useLocalProp} from '@/util/vue.js';
-import {BarElement, Chart as ChartJS, Legend, LinearScale, TimeScale, Title, Tooltip} from 'chart.js'
+import {BarElement, Chart as ChartJS, Filler, Legend, LinearScale, TimeScale, Title, Tooltip} from 'chart.js'
 import {startOfDay, startOfYear} from 'date-fns';
 import {computed, nextTick, ref, toRef, watch} from 'vue';
 import {Bar} from 'vue-chartjs';
@@ -83,7 +83,7 @@ import 'chartjs-adapter-date-fns';
 import {useMeterConsumption, useMetersConsumption} from './consumption.js';
 import NoDataGraphic from '@/dynamic/widgets/general/no-data-in-date-range.svg';
 
-ChartJS.register(Title, Tooltip, BarElement, LinearScale, TimeScale, Legend);
+ChartJS.register(Title, Tooltip, BarElement, Filler, LinearScale, TimeScale, Legend);
 const chartRef = ref(null);
 
 const props = defineProps({

--- a/ui/ops/src/dynamic/widgets/transport/LiftPositionCard.vue
+++ b/ui/ops/src/dynamic/widgets/transport/LiftPositionCard.vue
@@ -132,23 +132,13 @@ onScopeDispose(() => {
 
 const anyLoading = computed(() => Object.values(liftData).some(d => d.loading));
 
-/**
- *
- * @param name
- * @param floorNum
- */
 function isAtFloor(name, floorNum) {
   const currentPos = liftData[name]?.pos;
   if (!currentPos) return false;
-  // Handle if floorNum is a string and currentPos is a string/number
-  // Trim spaces to handle mock driver formatting like " 1"
+  // Trim to handle mock driver formatting like " 1".
   return currentPos.toString().trim() === floorNum.toString().trim();
 }
 
-/**
- *
- * @param name
- */
 function directionIcon(name) {
   const data = liftData[name];
   const dir = data?.dir;
@@ -159,20 +149,12 @@ function directionIcon(name) {
   return 'mdi-elevator';
 }
 
-/**
- *
- * @param name
- */
 function isDoorOpen(name) {
   const data = liftData[name];
   if (!data || !data.doors) return false;
   return data.doors.some(d => d.value === 'Open' || d.value === 'Opening');
 }
 
-/**
- *
- * @param name
- */
 function directionClass(name) {
   const data = liftData[name];
   const dir = data?.dir;
@@ -182,19 +164,11 @@ function directionClass(name) {
   return '';
 }
 
-/**
- *
- * @param h
- */
 function formatHeight(h) {
   if (typeof h === 'number') return `${h}px`;
   return h;
 }
 
-/**
- *
- * @param name
- */
 function shortName(name) {
   return name.split('/').pop();
 }

--- a/ui/ops/src/dynamic/widgets/transport/LiftPositionCard.vue
+++ b/ui/ops/src/dynamic/widgets/transport/LiftPositionCard.vue
@@ -132,6 +132,11 @@ onScopeDispose(() => {
 
 const anyLoading = computed(() => Object.values(liftData).some(d => d.loading));
 
+/**
+ *
+ * @param name
+ * @param floorNum
+ */
 function isAtFloor(name, floorNum) {
   const currentPos = liftData[name]?.pos;
   if (!currentPos) return false;
@@ -140,6 +145,10 @@ function isAtFloor(name, floorNum) {
   return currentPos.toString().trim() === floorNum.toString().trim();
 }
 
+/**
+ *
+ * @param name
+ */
 function directionIcon(name) {
   const data = liftData[name];
   const dir = data?.dir;
@@ -150,12 +159,20 @@ function directionIcon(name) {
   return 'mdi-elevator';
 }
 
+/**
+ *
+ * @param name
+ */
 function isDoorOpen(name) {
   const data = liftData[name];
   if (!data || !data.doors) return false;
   return data.doors.some(d => d.value === 'Open' || d.value === 'Opening');
 }
 
+/**
+ *
+ * @param name
+ */
 function directionClass(name) {
   const data = liftData[name];
   const dir = data?.dir;
@@ -165,11 +182,19 @@ function directionClass(name) {
   return '';
 }
 
+/**
+ *
+ * @param h
+ */
 function formatHeight(h) {
   if (typeof h === 'number') return `${h}px`;
   return h;
 }
 
+/**
+ *
+ * @param name
+ */
 function shortName(name) {
   return name.split('/').pop();
 }

--- a/ui/ops/src/routes/devices/components/DeviceSideBarContent.vue
+++ b/ui/ops/src/routes/devices/components/DeviceSideBarContent.vue
@@ -16,6 +16,18 @@
     <with-on-off v-if="traits['smartcore.traits.OnOff']" :name="deviceId" v-slot="{resource, update}">
       <on-off-card v-bind="resource" @update-on-off="update" :name="deviceId"/>
     </with-on-off>
+    <with-open-close
+        v-if="traits['smartcore.traits.OpenClose']"
+        :name="deviceId"
+        v-slot="{resource, info, update, updateTracker}">
+      <v-divider class="mt-4 mb-1"/>
+      <open-close-card
+          v-bind="resource"
+          :info="info"
+          :update-tracker="updateTracker"
+          :name="deviceId"
+          @update-positions="update"/>
+    </with-open-close>
     <with-air-quality v-if="traits['smartcore.traits.AirQualitySensor']" :name="deviceId" v-slot="{resource}">
       <v-divider class="mt-4 mb-1"/>
       <air-quality-card v-bind="resource" :name="deviceId"/>
@@ -88,6 +100,8 @@ import OccupancyCard from '@/traits/occupancy/OccupancyCard.vue';
 import WithOccupancy from '@/traits/occupancy/WithOccupancy.vue';
 import OnOffCard from '@/traits/onOff/OnOffCard.vue';
 import WithOnOff from '@/traits/onOff/WithOnOff.vue';
+import OpenCloseCard from '@/traits/openClose/OpenCloseCard.vue';
+import WithOpenClose from '@/traits/openClose/WithOpenClose.vue';
 import StatusLogCard from '@/traits/status/StatusLogCard.vue';
 import WithStatus from '@/traits/status/WithStatus.vue';
 import TemperatureCard from '@/traits/temperature/TemperatureCard.vue';

--- a/ui/ops/src/traits/openClose/OpenCloseCard.vue
+++ b/ui/ops/src/traits/openClose/OpenCloseCard.vue
@@ -1,29 +1,119 @@
 <template>
   <v-card elevation="0" tile>
-    <v-list tile class="ma-0 pa-0" lines="two">
-      <v-list-subheader class="text-title-caps-large text-neutral-lighten-3">Open / Closed</v-list-subheader>
+    <v-list tile class="ma-0 pa-0">
+      <v-list-subheader class="text-title-caps-large text-neutral-lighten-3">Open / Close</v-list-subheader>
 
-      <v-list-item class="mt-n4 mb-4">
-        <div class="d-flex flex-row flex-nowrap justify-space-between align-center py-0">
-          <v-list-item-title class="text-body-small text-capitalize my-auto">Open Percentage</v-list-item-title>
-          <v-list-item-subtitle class="text-subtitle-1 font-weight-medium text-wrap ml-2">
-            {{ openStr }}
-          </v-list-item-subtitle>
-        </div>
+      <v-list-item class="py-1">
+        <v-list-item-title class="text-body-small text-capitalize">Open Percentage</v-list-item-title>
+        <template #append>
+          <v-list-item-subtitle class="text-body-1">{{ openStr }}</v-list-item-subtitle>
+        </template>
       </v-list-item>
     </v-list>
+
+    <v-slider
+        class="mx-4 my-2"
+        :model-value="sliderValue"
+        @update:model-value="onSliderInput"
+        @start="onSliderStart"
+        @end="onSliderEnd"
+        :min="sliderMin"
+        :max="sliderMax"
+        :step="sliderStep"
+        thumb-label
+        hide-details
+        color="accent"
+        :disabled="blockActions || updateTracker?.loading"/>
+
+    <v-card-actions v-if="presets.length > 0" class="px-4">
+      <v-select
+          class="flex-grow-1"
+          density="compact"
+          variant="outlined"
+          hide-details
+          label="Preset"
+          :items="presetItems"
+          :model-value="currentPreset"
+          :disabled="blockActions || updateTracker?.loading"
+          @update:model-value="setPreset"/>
+    </v-card-actions>
+
+    <v-progress-linear color="primary" indeterminate :active="updateTracker?.loading"/>
   </v-card>
 </template>
 
 <script setup>
+import useAuthSetup from '@/composables/useAuthSetup';
 import {useOpenClosePositions} from '@/traits/openClose/openClose.js';
+import {computed, ref} from 'vue';
+
+const {blockActions} = useAuthSetup();
 
 const props = defineProps({
   value: {
-    type: Object,
+    type: Object, // of OpenClosePositions.AsObject
     default: () => {}
+  },
+  info: {
+    type: Object, // of PositionsSupport.AsObject
+    default: () => null
+  },
+  updateTracker: {
+    type: Object, // of ActionTracker<OpenClosePositions.AsObject>
+    default: () => null
+  },
+  name: {
+    type: String,
+    default: ''
   }
 });
+const emit = defineEmits([
+  'updatePositions' // OpenClosePositions.AsObject
+]);
 
-const {openStr} = useOpenClosePositions(() => props.value);
+const {openStr, openPercent} = useOpenClosePositions(() => props.value);
+
+const support = computed(() => props.info?.response ?? props.info ?? null);
+const presets = computed(() => support.value?.presetsList ?? []);
+const presetItems = computed(() => presets.value.map(p => ({title: p.title || p.name, value: p.name})));
+const currentPreset = computed(() => props.value?.preset?.name ?? null);
+
+const openPercentAttrs = computed(() => support.value?.openPercentAttributes ?? null);
+const sliderMin = computed(() => openPercentAttrs.value?.bounds?.min ?? 0);
+const sliderMax = computed(() => openPercentAttrs.value?.bounds?.max ?? 100);
+// proto step of 0 means "continuous"; v-slider needs a positive number so fall back to 1.
+const sliderStep = computed(() => openPercentAttrs.value?.step || 1);
+
+// While the user drags, dragValue holds the local position so the thumb tracks
+// the cursor without round-tripping through the device. When null, the slider
+// mirrors the device's reported openPercent.
+const dragValue = ref(null);
+const sliderValue = computed(() => dragValue.value ?? openPercent.value ?? 0);
+
+/**
+ * @param {number} v
+ */
+function onSliderInput(v) {
+  if (dragValue.value !== null) dragValue.value = v;
+}
+
+function onSliderStart() {
+  dragValue.value = openPercent.value ?? 0;
+}
+
+/**
+ * @param {number} v
+ */
+function onSliderEnd(v) {
+  dragValue.value = null;
+  emit('updatePositions', {statesList: [{openPercent: v}]});
+}
+
+/**
+ * @param {string} name
+ */
+function setPreset(name) {
+  if (!name) return;
+  emit('updatePositions', {preset: {name}});
+}
 </script>

--- a/ui/ops/src/traits/openClose/OpenCloseCard.vue
+++ b/ui/ops/src/traits/openClose/OpenCloseCard.vue
@@ -15,7 +15,6 @@
         class="mx-4 my-2"
         :model-value="sliderValue"
         @update:model-value="onSliderInput"
-        @start="onSliderStart"
         @end="onSliderEnd"
         :min="sliderMin"
         :max="sliderMax"
@@ -45,7 +44,7 @@
 <script setup>
 import useAuthSetup from '@/composables/useAuthSetup';
 import {useOpenClosePositions} from '@/traits/openClose/openClose.js';
-import {computed, ref} from 'vue';
+import {computed, ref, watch} from 'vue';
 
 const {blockActions} = useAuthSetup();
 
@@ -71,7 +70,7 @@ const emit = defineEmits([
   'updatePositions' // OpenClosePositions.AsObject
 ]);
 
-const {openStr, openPercent} = useOpenClosePositions(() => props.value);
+const {state, openStr, openPercent} = useOpenClosePositions(() => props.value);
 
 const support = computed(() => props.info?.response ?? props.info ?? null);
 const presets = computed(() => support.value?.presetsList ?? []);
@@ -84,29 +83,41 @@ const sliderMax = computed(() => openPercentAttrs.value?.bounds?.max ?? 100);
 // proto step of 0 means "continuous"; v-slider needs a positive number so fall back to 1.
 const sliderStep = computed(() => openPercentAttrs.value?.step || 1);
 
-// While the user drags, dragValue holds the local position so the thumb tracks
-// the cursor without round-tripping through the device. When null, the slider
-// mirrors the device's reported openPercent.
+// While the user is interacting, dragValue holds the local position so the thumb
+// tracks the cursor without round-tripping through the device. It is cleared
+// once the device echoes back a value matching the user's release, at which
+// point sliderValue falls back to mirroring openPercent.
 const dragValue = ref(null);
 const sliderValue = computed(() => dragValue.value ?? openPercent.value ?? 0);
+
+watch(openPercent, (v) => {
+  if (dragValue.value !== null && v === dragValue.value) {
+    dragValue.value = null;
+  }
+});
 
 /**
  * @param {number} v
  */
 function onSliderInput(v) {
-  if (dragValue.value !== null) dragValue.value = v;
-}
-
-function onSliderStart() {
-  dragValue.value = openPercent.value ?? 0;
+  dragValue.value = v;
 }
 
 /**
  * @param {number} v
  */
 function onSliderEnd(v) {
-  dragValue.value = null;
-  emit('updatePositions', {statesList: [{openPercent: v}]});
+  dragValue.value = v;
+  // Preserve the current state's direction so the server addresses the right
+  // element on multi-direction devices (and doesn't create a new direction-0
+  // element). The update mask scopes the write to open_percent so other
+  // fields like resistance / target_open_percent / open_percent_tween aren't
+  // reset to defaults.
+  const direction = state.value?.direction ?? 0;
+  emit('updatePositions', {
+    states: {statesList: [{openPercent: v, direction}]},
+    updateMask: {pathsList: ['states.open_percent']}
+  });
 }
 
 /**

--- a/ui/ops/src/traits/openClose/WithOpenClose.vue
+++ b/ui/ops/src/traits/openClose/WithOpenClose.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-    <slot :resource="openCloseValue"/>
+    <slot :resource="openCloseValue" :info="info" :update="doUpdatePositions" :update-tracker="updateTracker"/>
   </div>
 </template>
 
 <script setup>
-import {usePullOpenClosePositions} from '@/traits/openClose/openClose.js';
+import {useDescribePositions, usePullOpenClosePositions, useUpdateOpenClosePositions} from '@/traits/openClose/openClose.js';
 import {reactive} from 'vue';
 
 const props = defineProps({
@@ -15,7 +15,7 @@ const props = defineProps({
     default: ''
   },
   request: {
-    type: Object, // of type PullAccessAttemptsRequest.AsObject
+    type: Object, // of type PullOpenClosePositionsRequest.AsObject
     default: () => {}
   },
   paused: {
@@ -25,4 +25,7 @@ const props = defineProps({
 });
 
 const openCloseValue = reactive(usePullOpenClosePositions(() => props.request ?? props.name, () => props.paused));
+const info = reactive(useDescribePositions(() => props.name));
+const updateTracker = reactive(useUpdateOpenClosePositions(() => props.name));
+const doUpdatePositions = updateTracker.updatePositions;
 </script>

--- a/ui/ops/src/traits/openClose/openClose.js
+++ b/ui/ops/src/traits/openClose/openClose.js
@@ -1,20 +1,29 @@
-import {closeResource, newResourceValue} from '@/api/resource';
-import {pullOpenClosePositions} from '@/api/sc/traits/open-close';
-import {toQueryObject, watchResource} from '@/util/traits';
+import {closeResource, newActionTracker, newResourceValue} from '@/api/resource';
+import {describeOpenClosePositions, pullOpenClosePositions, updateOpenClosePositions} from '@/api/sc/traits/open-close';
+import {setRequestName, toQueryObject, watchResource} from '@/util/traits';
 import {computed, onScopeDispose, reactive, toRefs, toValue} from 'vue';
 
 /**
  * @typedef {import('@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/openclose/v1/open_close_pb').OpenClosePositions} OpenClosePositions
  * @typedef {import('@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/openclose/v1/open_close_pb').OpenClosePosition} OpenClosePosition
+ * @typedef {import('@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/openclose/v1/open_close_pb').PositionsSupport} PositionsSupport
  * @typedef {
  *   import('@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/openclose/v1/open_close_pb').PullOpenClosePositionsRequest
  * } PullOpenClosePositionsRequest
  * @typedef {
  *   import('@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/openclose/v1/open_close_pb').PullOpenClosePositionsResponse
  * } PullOpenClosePositionsResponse
+ * @typedef {
+ *   import('@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/openclose/v1/open_close_pb').UpdateOpenClosePositionsRequest
+ * } UpdateOpenClosePositionsRequest
+ * @typedef {
+ *   import('@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/openclose/v1/open_close_pb').DescribePositionsRequest
+ * } DescribePositionsRequest
  * @typedef {import('vue').Ref} Ref
  * @typedef {import('vue').ToRefs} ToRefs
  * @typedef {import('vue').ComputedRef} ComputedRef
+ * @typedef {import('@/api/resource').ResourceValue} ResourceValue
+ * @typedef {import('@/api/resource').ActionTracker} ActionTracker
  */
 
 /**
@@ -41,6 +50,66 @@ export function usePullOpenClosePositions(query, paused = false) {
   );
 
   return toRefs(openCloseValue);
+}
+
+/**
+ * @param {MaybeRefOrGetter<string>} name
+ * @return {{
+ *   loading: Ref<boolean>,
+ *   response: Ref<OpenClosePositions.AsObject|null>,
+ *   error: Ref<*>,
+ *   updatePositions: (req: Partial<UpdateOpenClosePositionsRequest.AsObject>|Partial<OpenClosePositions.AsObject>) => Promise<OpenClosePositions.AsObject>
+ * }}
+ */
+export function useUpdateOpenClosePositions(name) {
+  const tracker = reactive(
+      /** @type {ActionTracker<OpenClosePositions.AsObject>} */
+      newActionTracker()
+  );
+
+  /**
+   * @param {Partial<UpdateOpenClosePositionsRequest.AsObject>|Partial<OpenClosePositions.AsObject>} req
+   * @return {UpdateOpenClosePositionsRequest.AsObject}
+   */
+  const toRequestObject = (req) => {
+    req = toValue(req);
+    if (!Object.hasOwn(req, 'states')) {
+      req = {states: /** @type {OpenClosePositions.AsObject} */ req};
+    }
+    return setRequestName(req, name);
+  };
+
+  return {
+    ...toRefs(tracker),
+    updatePositions: (req) => {
+      return updateOpenClosePositions(toRequestObject(req), tracker);
+    }
+  };
+}
+
+/**
+ * @param {MaybeRefOrGetter<string|DescribePositionsRequest.AsObject>} query
+ * @return {ToRefs<ActionTracker<PositionsSupport.AsObject>>}
+ */
+export function useDescribePositions(query) {
+  const tracker = reactive(
+      /** @type {ActionTracker<PositionsSupport.AsObject>} */
+      newActionTracker()
+  );
+
+  const queryObject = computed(() => toQueryObject(query));
+
+  watchResource(
+      () => toValue(queryObject),
+      false,
+      (req) => {
+        describeOpenClosePositions(req, tracker)
+            .catch(() => {}); // errors are tracked by tracker
+        return () => closeResource(tracker);
+      }
+  );
+
+  return toRefs(tracker);
 }
 
 /**


### PR DESCRIPTION
Includes:
 - fixing lint errors in lift position card
 - fixing a warning for chart.js imports
 - improving the gallagher events retrieval to use the boot up time instead of the start of all time


The main body of this PR is to introduce controls to the Ops UI for the Open Close devices including supporting presets, step and capped bounds for open percentage inputs.