### PR TITLE
feat/driver system health

### DIFF
--- a/pkg/driver/gallagher/client.go
+++ b/pkg/driver/gallagher/client.go
@@ -1,21 +1,26 @@
 package gallagher
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+
+	"github.com/smart-core-os/sc-bos/pkg/task/service"
 )
 
 type Client struct {
-	BaseURL    string
-	HTTPClient *http.Client
-	ApiKey     string
+	BaseURL     string
+	HTTPClient  *http.Client
+	ApiKey      string
+	systemCheck service.SystemCheck
 }
 
-func newHttpClient(baseURL string, apiKey string, caPath string, certPath string, keyPath string) (*Client, error) {
+func newHttpClient(baseURL string, apiKey string, caPath string, certPath string, keyPath string, systemCheck service.SystemCheck) (*Client, error) {
 
 	caCert, err := os.ReadFile(caPath)
 	if err != nil {
@@ -36,8 +41,23 @@ func newHttpClient(baseURL string, apiKey string, caPath string, certPath string
 				},
 			},
 		},
-		ApiKey: apiKey,
+		ApiKey:      apiKey,
+		systemCheck: systemCheck,
 	}, nil
+}
+
+func (c *Client) updateSystemCheck(err error) {
+	if c.systemCheck == nil {
+		return
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+	if err != nil {
+		c.systemCheck.MarkFailed(err)
+	} else {
+		c.systemCheck.MarkRunning()
+	}
 }
 
 func (c *Client) getUrl(p string) string {
@@ -55,17 +75,22 @@ func (c *Client) doRequest(url string) ([]byte, error) {
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
+		c.updateSystemCheck(err)
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
+		c.updateSystemCheck(err)
 		return nil, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("response status: %d %s", resp.StatusCode, resp.Status)
+		err = fmt.Errorf("response status: %d %s", resp.StatusCode, resp.Status)
+		c.updateSystemCheck(err)
+		return nil, err
 	}
+	c.updateSystemCheck(nil)
 	return bytes, nil
 }

--- a/pkg/driver/gallagher/config/root.go
+++ b/pkg/driver/gallagher/config/root.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/smart-core-os/sc-bos/pkg/driver"
@@ -45,9 +48,35 @@ type HTTP struct {
 	// must include the /api suffix
 	BaseURL    string `json:"baseUrl,omitempty"`
 	ApiKeyFile string `json:"apiKeyFile,omitempty"`
+	ApiKey     string `json:"-"`
+}
+
+func ReadBytes(data []byte) (Root, error) {
+	var cfg Root
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return cfg, err
+	}
+
+	if cfg.HTTP == nil {
+		return cfg, fmt.Errorf("HTTP config is not set")
+	}
+
+	if cfg.HTTP.BaseURL == "" {
+		return cfg, fmt.Errorf("BaseURL is not set")
+	}
+
+	bytes, err := os.ReadFile(cfg.HTTP.ApiKeyFile)
+	if err != nil {
+		return cfg, fmt.Errorf("error reading api key file: %w", err)
+	}
+	cfg.HTTP.ApiKey = string(bytes)
+
+	cfg.ApplyDefaults()
+	return cfg, nil
 }
 
 func (cfg *Root) ApplyDefaults() {
+
 	if cfg.RefreshCardholders == nil {
 		cfg.RefreshCardholders = jsontypes.MustParseSchedule("* * * * *")
 	}

--- a/pkg/driver/gallagher/driver.go
+++ b/pkg/driver/gallagher/driver.go
@@ -3,7 +3,6 @@ package gallagher
 import (
 	"context"
 	"fmt"
-	"os"
 	"path"
 	"time"
 
@@ -26,9 +25,10 @@ const (
 
 type Driver struct {
 	*service.Service[config.Root]
-	announcer node.Announcer
-	logger    *zap.Logger
-	ticker    *time.Ticker
+	announcer   node.Announcer
+	logger      *zap.Logger
+	ticker      *time.Ticker
+	systemCheck service.SystemCheck
 }
 
 var Factory driver.Factory = factory{}
@@ -38,10 +38,17 @@ type factory struct{}
 func (f factory) New(services driver.Services) service.Lifecycle {
 	logger := services.Logger.Named(DriverName)
 	d := &Driver{
-		announcer: services.Node,
+		announcer:   services.Node,
+		systemCheck: services.SystemCheck,
 	}
 	d.Service = service.New(
 		service.MonoApply(d.applyConfig),
+		service.WithParser(config.ReadBytes),
+		service.WithOnStop[config.Root](func() {
+			if d.systemCheck != nil {
+				d.systemCheck.Dispose()
+			}
+		}),
 		service.WithRetry[config.Root](service.RetryWithLogger(func(logContext service.RetryContext) {
 			logContext.LogTo("applyConfig", logger)
 		})),
@@ -52,7 +59,6 @@ func (f factory) New(services driver.Services) service.Lifecycle {
 
 func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 
-	cfg.ApplyDefaults()
 	announcer, undo := node.AnnounceScope(d.announcer)
 	grp, ctx := errgroup.WithContext(ctx)
 
@@ -61,25 +67,9 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 	}
 	d.ticker = time.NewTicker(cfg.UdmiExportInterval.Duration)
 
-	if cfg.HTTP == nil {
-		d.logger.Error("http config is not set")
-		return fmt.Errorf("gallagher HTTP config is not set")
-	}
-
-	if cfg.HTTP.BaseURL == "" {
-		d.logger.Error("baseURL is not set")
-		return fmt.Errorf("gallagher BaseURL is not set")
-	}
-
-	bytes, err := os.ReadFile(cfg.HTTP.ApiKeyFile)
+	client, err := newHttpClient(cfg.HTTP.BaseURL, cfg.HTTP.ApiKey, cfg.CaPath, cfg.ClientCertPath, cfg.ClientKeyPath, d.systemCheck)
 	if err != nil {
-		return fmt.Errorf("error reading api key file: %w", err)
-	}
-	client, err := newHttpClient(cfg.HTTP.BaseURL, string(bytes), cfg.CaPath, cfg.ClientCertPath, cfg.ClientKeyPath)
-
-	if client == nil {
-		d.logger.Error("failed to create client", zap.Error(err))
-		return nil
+		return fmt.Errorf("failed to create client: %w", err)
 	}
 
 	cc := newCardholderController(client, cfg.TopicPrefix, d.logger)

--- a/pkg/driver/hikcentral/client.go
+++ b/pkg/driver/hikcentral/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/driver/hikcentral/api"
 	"github.com/smart-core-os/sc-bos/pkg/driver/hikcentral/config"
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
+	"github.com/smart-core-os/sc-bos/pkg/task/service"
 )
 
 const resourcePrefix = "/artemis/api/resource/v1"
@@ -25,14 +27,27 @@ func (e *badStatusError) Error() string {
 	return fmt.Sprintf("unexpected status code %d: %s", e.statusCode, e.status)
 }
 
-type client struct {
-	address    string
-	appKey     string
-	secret     string
-	httpClient *http.Client
+// serverError wraps errors that indicate the HikCentral server itself is unreachable or broken
+// (network failures, HTTP 5xx). Used to distinguish server-level failures from per-camera errors.
+type serverError struct{ err error }
+
+func (e *serverError) Error() string { return e.err.Error() }
+func (e *serverError) Unwrap() error { return e.err }
+
+func isServerError(err error) bool {
+	var se *serverError
+	return errors.As(err, &se)
 }
 
-func newClient(conf *config.API) *client {
+type client struct {
+	address     string
+	appKey      string
+	secret      string
+	httpClient  *http.Client
+	systemCheck service.SystemCheck
+}
+
+func newClient(conf *config.API, systemCheck service.SystemCheck) *client {
 	return &client{
 		address: conf.Address,
 		appKey:  conf.AppKey,
@@ -40,6 +55,21 @@ func newClient(conf *config.API) *client {
 		httpClient: &http.Client{
 			Timeout: conf.Timeout.Duration,
 		},
+		systemCheck: systemCheck,
+	}
+}
+
+func (c *client) updateSystemCheck(err error) {
+	if c.systemCheck == nil {
+		return
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+	if isServerError(err) {
+		c.systemCheck.MarkFailed(err)
+	} else {
+		c.systemCheck.MarkRunning()
 	}
 }
 
@@ -73,6 +103,7 @@ func (c *client) listEvents(ctx context.Context, req *api.EventsRequest, fc *hea
 func makeReqWrapper[R any, T any](ctx context.Context, client *client, path string, r *R, fc *healthpb.FaultCheck) (*T, error) {
 	t, err := makeReq[R, T](ctx, client, path, r)
 	updateReliability(ctx, err, fc)
+	client.updateSystemCheck(err)
 	return t, err
 }
 
@@ -99,12 +130,16 @@ func makeReq[R any, T any](ctx context.Context, client *client, path string, r *
 
 	resp, err := client.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("req.do: %w", err)
+		return nil, &serverError{fmt.Errorf("req.do: %w", err)}
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, &badStatusError{statusCode: resp.StatusCode, status: resp.Status}
+		badStatus := &badStatusError{statusCode: resp.StatusCode, status: resp.Status}
+		if resp.StatusCode >= 500 || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, &serverError{badStatus}
+		}
+		return nil, badStatus
 	}
 
 	respBody, err := io.ReadAll(resp.Body)

--- a/pkg/driver/hikcentral/driver.go
+++ b/pkg/driver/hikcentral/driver.go
@@ -30,14 +30,20 @@ type factory struct{}
 
 func (f factory) New(services driver.Services) service.Lifecycle {
 	d := &Driver{
-		announcer: node.NewReplaceAnnouncer(services.Node),
-		health:    services.Health,
-		logger:    services.Logger.Named(DriverName),
+		announcer:   node.NewReplaceAnnouncer(services.Node),
+		health:      services.Health,
+		logger:      services.Logger.Named(DriverName),
+		systemCheck: services.SystemCheck,
 	}
 
 	d.Service = service.New(
 		service.MonoApply(d.applyConfig),
 		service.WithParser(config.ReadBytes),
+		service.WithOnStop[config.Root](func() {
+			if d.systemCheck != nil {
+				d.systemCheck.Dispose()
+			}
+		}),
 		service.WithRetry[config.Root](service.RetryWithLogger(func(logContext service.RetryContext) {
 			logContext.LogTo("applyConfig", d.logger)
 		}), service.RetryWithMinDelay(5*time.Second), service.RetryWithInitialDelay(5*time.Second)),
@@ -49,9 +55,10 @@ func (f factory) New(services driver.Services) service.Lifecycle {
 type Driver struct {
 	*service.Service[config.Root]
 
-	announcer *node.ReplaceAnnouncer
-	health    *healthpb.Checks
-	logger    *zap.Logger
+	announcer   *node.ReplaceAnnouncer
+	health      *healthpb.Checks
+	logger      *zap.Logger
+	systemCheck service.SystemCheck
 }
 
 func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
@@ -59,7 +66,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 	rootAnnouncer := d.announcer.Replace(ctx)
 	logger := d.logger.With(zap.String("host", cfg.API.Address))
 
-	client := newClient(cfg.API)
+	client := newClient(cfg.API, d.systemCheck)
 	client.httpClient.Transport = &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,

--- a/pkg/driver/opcua/config/root.go
+++ b/pkg/driver/opcua/config/root.go
@@ -136,9 +136,6 @@ type Root struct {
 	Meta    *metadatapb.Metadata `json:"meta,omitempty"`
 	Conn    Conn                 `json:"conn"`
 	Devices []Device             `json:"devices,omitempty"`
-
-	// settings for the opc ua system health check
-	SystemHealth Health `json:"systemHealth"`
 }
 
 func ParseConfig(data []byte) (cfg Root, err error) {

--- a/pkg/driver/opcua/device.go
+++ b/pkg/driver/opcua/device.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/smart-core-os/sc-bos/pkg/driver/opcua/config"
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
+	"github.com/smart-core-os/sc-bos/pkg/task/service"
 )
 
 // device represents an OPC UA device that subscribes to variable nodes and updates trait implementations.
@@ -23,17 +24,19 @@ type device struct {
 
 	eventHandlers []EventHandler
 
-	faultCheck *healthpb.FaultCheck
+	faultCheck  *healthpb.FaultCheck
+	systemCheck service.SystemCheck
 }
 
 // newDevice creates a new device instance for the given configuration.
 // Trait implementations (Electric, Meter, Transport, udmi) must be assigned separately before calling run.
-func newDevice(conf *config.Device, logger *zap.Logger, client *Client, check *healthpb.FaultCheck) *device {
+func newDevice(conf *config.Device, logger *zap.Logger, client *Client, check *healthpb.FaultCheck, systemCheck service.SystemCheck) *device {
 	return &device{
-		client:     client,
-		conf:       conf,
-		faultCheck: check,
-		logger:     logger,
+		client:      client,
+		conf:        conf,
+		faultCheck:  check,
+		logger:      logger,
+		systemCheck: systemCheck,
 	}
 }
 
@@ -71,6 +74,14 @@ func (d *device) subscribe(ctx context.Context) error {
 // It handles both DataChangeNotification (variable value changes) and EventNotificationList (OPC UA events).
 // Values with non-OK status codes are logged as warnings and not passed to trait handlers.
 func (d *device) handleEvent(ctx context.Context, event *opcua.PublishNotificationData, node *ua.NodeID) {
+	if event.Error != nil {
+		if d.systemCheck != nil {
+			d.systemCheck.MarkFailed(event.Error)
+		}
+		d.logger.Warn("OPC UA server connection error", zap.Stringer("node", node), zap.Error(event.Error))
+		return
+	}
+
 	switch x := event.Value.(type) {
 	case *ua.DataChangeNotification:
 		for _, item := range x.MonitoredItems {
@@ -81,6 +92,9 @@ func (d *device) handleEvent(ctx context.Context, event *opcua.PublishNotificati
 
 			if errors.Is(item.Value.Status, ua.StatusOK) {
 				d.faultCheck.UpdateReliability(ctx, healthpb.ReliabilityFromErr(nil))
+				if d.systemCheck != nil {
+					d.systemCheck.MarkRunning()
+				}
 				value := item.Value.Value.Value()
 				d.handleTraitEvent(ctx, node, value)
 			} else {
@@ -95,6 +109,9 @@ func (d *device) handleEvent(ctx context.Context, event *opcua.PublishNotificati
 				if errors.Is(field.StatusCode(), ua.StatusOK) {
 					value := field.Value()
 					d.faultCheck.UpdateReliability(ctx, healthpb.ReliabilityFromErr(nil))
+					if d.systemCheck != nil {
+						d.systemCheck.MarkRunning()
+					}
 					d.handleTraitEvent(ctx, node, value)
 				} else {
 					setPointReadNotOk(ctx, node.String(), field.StatusCode(), d.faultCheck)

--- a/pkg/driver/opcua/device_test.go
+++ b/pkg/driver/opcua/device_test.go
@@ -32,7 +32,7 @@ func TestDevice_newDevice(t *testing.T) {
 		},
 	}
 
-	dev := newDevice(cfg, logger, nil, fc)
+	dev := newDevice(cfg, logger, nil, fc, nil)
 	require.NotNil(t, dev)
 	require.Equal(t, cfg, dev.conf)
 	require.NotNil(t, dev.logger)

--- a/pkg/driver/opcua/driver.go
+++ b/pkg/driver/opcua/driver.go
@@ -42,9 +42,10 @@ func (f factory) New(services driver.Services) service.Lifecycle {
 	logger := services.Logger.Named(DriverName)
 
 	d := &Driver{
-		announcer: node.NewReplaceAnnouncer(services.Node),
-		health:    services.Health,
-		logger:    logger,
+		announcer:   node.NewReplaceAnnouncer(services.Node),
+		health:      services.Health,
+		logger:      logger,
+		systemCheck: services.SystemCheck,
 	}
 	d.Service = service.New(
 		service.MonoApply(d.applyConfig),
@@ -68,7 +69,7 @@ type Driver struct {
 	health    *healthpb.Checks
 	logger    *zap.Logger
 
-	systemCheck *healthpb.FaultCheck
+	systemCheck service.SystemCheck
 	checks      []*healthpb.FaultCheck
 }
 
@@ -77,15 +78,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 
 	d.dispose()
 
-	systemCheck, err := d.health.NewFaultCheck(cfg.Name, getSystemHealthCheck(cfg.SystemHealth.OccupantImpact.ToProto(), cfg.SystemHealth.EquipmentImpact.ToProto()))
-	if err != nil {
-		d.logger.Warn("NewClient error", zap.Error(err))
-		return err
-	}
-
-	d.systemCheck = systemCheck
-
-	opcClient, err := d.connectOpcClient(ctx, cfg, systemCheck)
+	opcClient, err := d.connectOpcClient(ctx, cfg)
 	if err != nil {
 		d.logger.Warn("Connect error", zap.Error(err))
 		return err
@@ -106,7 +99,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 		}
 		d.checks = append(d.checks, faultCheck)
 
-		opcDev := newDevice(&dev, d.logger, client, faultCheck)
+		opcDev := newDevice(&dev, d.logger, client, faultCheck, d.systemCheck)
 
 		for _, t := range dev.Traits {
 			switch t.Kind {
@@ -204,34 +197,27 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 	return nil
 }
 
-func (d *Driver) connectOpcClient(ctx context.Context, cfg config.Root, faultCheck *healthpb.FaultCheck) (*opcua.Client, error) {
-	rel := &healthpb.HealthCheck_Reliability{}
+func (d *Driver) connectOpcClient(ctx context.Context, cfg config.Root) (*opcua.Client, error) {
 	opcClient, err := opcua.NewClient(cfg.Conn.Endpoint)
 	if err != nil {
-		rel.State = healthpb.HealthCheck_Reliability_UNRELIABLE
-		rel.LastError = &healthpb.HealthCheck_Error{
-			SummaryText: "Internal Driver Error",
-			DetailsText: "Failed to create new OPC UA client",
-			Code:        statusToHealthCode(DriverConfigError),
+		if d.systemCheck != nil {
+			d.systemCheck.MarkFailed(err)
 		}
-		faultCheck.UpdateReliability(ctx, rel)
 		d.logger.Error("error creating new client", zap.Error(err))
 		return nil, err
 	}
 
 	err = opcClient.Connect(ctx)
 	if err != nil {
-		rel.State = healthpb.HealthCheck_Reliability_NO_RESPONSE
-		rel.LastError = &healthpb.HealthCheck_Error{
-			SummaryText: "Server Unreachable",
-			DetailsText: "The opcua server is unreachable",
-			Code:        statusToHealthCode(ServerUnreachable),
+		if d.systemCheck != nil {
+			d.systemCheck.MarkFailed(err)
 		}
-		faultCheck.UpdateReliability(ctx, rel)
 		d.logger.Error("error connecting to opc ua server", zap.Error(err))
 		return nil, err
 	}
-	faultCheck.UpdateReliability(ctx, healthpb.ReliabilityFromErr(nil))
+	if d.systemCheck != nil {
+		d.systemCheck.MarkRunning()
+	}
 	return opcClient, nil
 }
 

--- a/pkg/driver/opcua/driver.go
+++ b/pkg/driver/opcua/driver.go
@@ -222,17 +222,17 @@ func (d *Driver) connectOpcClient(ctx context.Context, cfg config.Root) (*opcua.
 }
 
 func (d *Driver) onStop() {
+	if d.systemCheck != nil {
+		d.systemCheck.Dispose()
+	}
 	d.dispose()
 }
 
 func (d *Driver) dispose() {
-	if d.systemCheck != nil {
-		d.systemCheck.Dispose()
-	}
-
 	for _, c := range d.checks {
 		if c != nil {
 			c.Dispose()
 		}
 	}
+	d.checks = nil
 }

--- a/pkg/driver/opcua/health.go
+++ b/pkg/driver/opcua/health.go
@@ -26,16 +26,6 @@ const (
 	floatTolerance = 1e-9
 )
 
-func getSystemHealthCheck(occupant healthpb.HealthCheck_OccupantImpact, equipment healthpb.HealthCheck_EquipmentImpact) *healthpb.HealthCheck {
-	return &healthpb.HealthCheck{
-		Id:              "systemStatusCheck",
-		DisplayName:     "System Status Check",
-		Description:     "Checks the opc ua server is reachable and the configured nodes are responding correctly",
-		OccupantImpact:  occupant,
-		EquipmentImpact: equipment,
-	}
-}
-
 func getDeviceHealthCheck(occupant healthpb.HealthCheck_OccupantImpact, equipment healthpb.HealthCheck_EquipmentImpact) *healthpb.HealthCheck {
 	return &healthpb.HealthCheck{
 		Id:              "deviceStatusCheck",


### PR DESCRIPTION
[3CS-75](https://vanti.youtrack.cloud/issue/3CS-75) Update the opcua, hikcentral and gallagher drivers to use the driver system health check. Below is it running at 3CS (the lift server is actually offline). 

I have started with these 3 and done them all at once as they are all single server drivers so easy to add the check.

<img width="950" height="300" alt="image" src="https://github.com/user-attachments/assets/e1c57be7-b99d-49e2-a708-ffc1d0486b1f" />
