### PR TITLE
feat/bacnet controller health

### DIFF
--- a/pkg/driver/bacnet/config/root.go
+++ b/pkg/driver/bacnet/config/root.go
@@ -46,6 +46,10 @@ type Root struct {
 	// SystemHealth represents the system-level health check configuration. If not configured,
 	// occupant and equipment impact will default to UNSPECIFIED.
 	SystemHealth Health `json:"systemHealth"`
+
+	// ControllerHealthThreshold is the % proportion of devices on a BACnet controller (IP address)
+	// that must be failing before the controller itself is marked unhealthy. Range [0, 100], default 50%
+	ControllerHealthThreshold int `json:"controllerHealthThreshold,omitempty"`
 }
 
 // ReadFile reads from the named file a config Root.
@@ -73,8 +77,9 @@ func ReadBytes(data []byte) (root Root, err error) {
 
 func Defaults() Root {
 	return Root{
-		DeviceNamePrefix: "bacnet/device/",
-		ObjectNamePrefix: "obj/",
+		DeviceNamePrefix:          "bacnet/device/",
+		ObjectNamePrefix:          "obj/",
+		ControllerHealthThreshold: 50,
 	}
 }
 

--- a/pkg/driver/bacnet/controller_health_test.go
+++ b/pkg/driver/bacnet/controller_health_test.go
@@ -1,0 +1,119 @@
+package bacnet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
+)
+
+func newTestControllerHealth(t *testing.T, threshold int) (*healthpb.Registry, *controllerHealth) {
+	t.Helper()
+	r := healthpb.NewRegistry()
+	checks := r.ForOwner("test-owner")
+	fc, err := checks.NewFaultCheck("test-controller", createControllerHealthCheck(
+		healthpb.HealthCheck_OCCUPANT_IMPACT_UNSPECIFIED,
+		healthpb.HealthCheck_EQUIPMENT_IMPACT_UNSPECIFIED,
+	))
+	if err != nil {
+		t.Fatalf("NewFaultCheck: %v", err)
+	}
+	return r, newControllerHealth(fc, threshold)
+}
+
+func controllerReliabilityState(r *healthpb.Registry) healthpb.HealthCheck_Reliability_State {
+	c := r.GetCheck("test-controller", healthpb.AbsID("test-owner", "controllerStatusCheck"))
+	if c == nil {
+		return healthpb.HealthCheck_Reliability_STATE_UNSPECIFIED
+	}
+	return c.GetReliability().GetState()
+}
+
+func isUnhealthy(r *healthpb.Registry) bool {
+	s := controllerReliabilityState(r)
+	return s != healthpb.HealthCheck_Reliability_STATE_UNSPECIFIED &&
+		s != healthpb.HealthCheck_Reliability_RELIABLE
+}
+
+func TestControllerHealth_TwoDevices_50Threshold(t *testing.T) {
+	ctx := context.Background()
+	r, ch := newTestControllerHealth(t, 50)
+	ch.register("dev1")
+	ch.register("dev2")
+
+	// both failing → unhealthy (2/2 = 100% >= 50%)
+	ch.setFailing(ctx, "dev1")
+	ch.setFailing(ctx, "dev2")
+	if !isUnhealthy(r) {
+		t.Error("expected controller unhealthy when all devices fail")
+	}
+
+	// 1/2 = 50% meets threshold → still unhealthy
+	ch.setOK(ctx, "dev1")
+	if !isUnhealthy(r) {
+		t.Error("expected controller still unhealthy at exactly 50% (1/2)")
+	}
+
+	// 0/2 = 0% → healthy
+	ch.setOK(ctx, "dev2")
+	if isUnhealthy(r) {
+		t.Error("expected controller healthy when no devices fail")
+	}
+}
+
+func TestControllerHealth_ThreeDevices_50Threshold(t *testing.T) {
+	ctx := context.Background()
+	r, ch := newTestControllerHealth(t, 50)
+	ch.register("dev1")
+	ch.register("dev2")
+	ch.register("dev3")
+
+	// 1/3 ≈ 33% < 50% → healthy
+	ch.setFailing(ctx, "dev1")
+	if isUnhealthy(r) {
+		t.Error("expected controller healthy when 1/3 devices fail")
+	}
+
+	// 2/3 ≈ 67% >= 50% → unhealthy
+	ch.setFailing(ctx, "dev2")
+	if !isUnhealthy(r) {
+		t.Error("expected controller unhealthy when 2/3 devices fail")
+	}
+
+	// recover one → 1/3 < 50% → healthy again
+	ch.setOK(ctx, "dev2")
+	if isUnhealthy(r) {
+		t.Error("expected controller healthy after recovering to 1/3 failing")
+	}
+}
+
+func TestControllerHealth_RegisterIdempotent(t *testing.T) {
+	ctx := context.Background()
+	_, ch := newTestControllerHealth(t, 50)
+	ch.register("dev1")
+	ch.register("dev1") // duplicate should not double-count
+
+	ch.setFailing(ctx, "dev1")
+	if len(ch.states) != 1 {
+		t.Errorf("expected 1 device state entry, got %d", len(ch.states))
+	}
+}
+
+func TestControllerHealth_100Threshold(t *testing.T) {
+	ctx := context.Background()
+	r, ch := newTestControllerHealth(t, 100)
+	ch.register("dev1")
+	ch.register("dev2")
+
+	// 1/2 = 50% < 100% → healthy
+	ch.setFailing(ctx, "dev1")
+	if isUnhealthy(r) {
+		t.Error("expected controller healthy when only 1/2 fail at 100% threshold")
+	}
+
+	// 2/2 = 100% >= 100% → unhealthy
+	ch.setFailing(ctx, "dev2")
+	if !isUnhealthy(r) {
+		t.Error("expected controller unhealthy when all devices fail at 100% threshold")
+	}
+}

--- a/pkg/driver/bacnet/driver.go
+++ b/pkg/driver/bacnet/driver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/netip"
 	"os"
 	"sync"
 	"time"
@@ -54,21 +55,30 @@ type Driver struct {
 	devices *known.Map
 
 	health      *healthpb.Checks
-	systemCheck *healthpb.FaultCheck
+	systemCheck service.SystemCheck
 	checks      []*healthpb.FaultCheck
 	healthTasks []task.StopFn
+
+	controllerMu      sync.Mutex
+	controllerHealths map[string]*controllerHealth
 }
 
 func NewDriver(services driver.Services) *Driver {
 	d := &Driver{
-		announcer: node.NewReplaceAnnouncer(services.Node),
-		devices:   known.NewMap(),
-		health:    services.Health,
-		logger:    services.Logger.Named("bacnet"),
+		announcer:   node.NewReplaceAnnouncer(services.Node),
+		devices:     known.NewMap(),
+		health:      services.Health,
+		systemCheck: services.SystemCheck,
+		logger:      services.Logger.Named("bacnet"),
 	}
 	d.Service = service.New(service.MonoApply(d.applyConfig),
 		service.WithParser(config.ReadBytes),
-		service.WithOnStop[config.Root](d.Clear))
+		service.WithOnStop[config.Root](func() {
+			d.Clear()
+			if d.systemCheck != nil {
+				d.systemCheck.Dispose()
+			}
+		}))
 	return d
 }
 
@@ -81,17 +91,14 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 	// we start fresh each time config is updated
 	d.Clear()
 
-	systemCheck, err := d.health.NewFaultCheck(cfg.Name, createSystemHealthCheck(cfg.SystemHealth.OccupantImpact.ToProto(), cfg.SystemHealth.EquipmentImpact.ToProto()))
+	err := d.initClient(ctx, cfg, d.systemCheck)
 	if err != nil {
 		return err
 	}
 
-	d.systemCheck = systemCheck
-
-	err = d.initClient(ctx, cfg, systemCheck)
-	if err != nil {
-		return err
-	}
+	d.controllerMu.Lock()
+	d.controllerHealths = make(map[string]*controllerHealth)
+	d.controllerMu.Unlock()
 
 	devices := known.SyncContext(d.mu.RLocker(), d.devices)
 
@@ -123,6 +130,18 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 			d.checks = append(d.checks, faultCheck)
 		}
 
+		// For devices with a known IP, eagerly register them with their controller check.
+		// WhoIs devices (no Comm.IP) are registered lazily inside configureDevice.
+		var ctrlHealth *controllerHealth
+		if device.Comm != nil && device.Comm.IP != nil {
+			ctrlHealth, err = d.getOrCreateControllerCheck(ctx, cfg, device.Comm.IP.Addr())
+			if err != nil {
+				logger.Error("failed to create controller health check", zap.Error(err))
+			} else {
+				ctrlHealth.register(scDeviceName)
+			}
+		}
+
 		go func() {
 			// This is more complicated than I think it should be.
 			// The issue is that the Context passed to Task is cancelled when the task returns.
@@ -150,7 +169,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 				announcer := cfgAnnouncer.Replace(announceCtx)
 
 				// It's ok for configureDevices to receive the task context here as ctx is only used for queries
-				err := d.configureDevice(ctx, announcer, cfg, device, devices, faultCheck, logger)
+				err := d.configureDevice(ctx, announcer, cfg, device, devices, faultCheck, ctrlHealth, logger)
 
 				if err != nil {
 					if errors.Is(err, context.Canceled) {
@@ -249,37 +268,32 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 	return nil
 }
 
-func (d *Driver) initClient(ctx context.Context, cfg config.Root, faultCheck *healthpb.FaultCheck) error {
-	rel := &healthpb.HealthCheck_Reliability{}
+func (d *Driver) initClient(ctx context.Context, cfg config.Root, systemCheck service.SystemCheck) error {
 	client, err := gobacnet.NewClient(cfg.LocalInterface, int(cfg.LocalPort),
 		gobacnet.WithMaxConcurrentTransactions(cfg.MaxConcurrentTransactions), gobacnet.WithLogLevel(logrus.InfoLevel))
 	if err != nil {
-		rel.State = healthpb.HealthCheck_Reliability_UNRELIABLE
-		rel.LastError = &healthpb.HealthCheck_Error{
-			SummaryText: "Internal Driver Error",
-			DetailsText: fmt.Sprintf("Failed to create BACnet client: %v", err),
-			Code:        statusToHealthCode(DriverConfigError),
+		if systemCheck != nil {
+			systemCheck.MarkFailed(fmt.Errorf("failed to create BACnet client: %w", err))
 		}
-		faultCheck.UpdateReliability(ctx, rel)
 		return err
 	}
 	d.client = client
-	if address, err := client.LocalUDPAddress(); err == nil {
+	if address, err := client.LocalUDPAddress(); err != nil {
+		if systemCheck != nil {
+			systemCheck.MarkFailed(fmt.Errorf("failed to get local UDP address: %w", err))
+		}
+		return err
+	} else {
 		d.logger.Debug("bacnet client configured", zap.Stringer("local", address),
 			zap.String("localInterface", cfg.LocalInterface), zap.Uint16("localPort", cfg.LocalPort))
-	} else {
-		rel.State = healthpb.HealthCheck_Reliability_UNRELIABLE
-		rel.LastError = &healthpb.HealthCheck_Error{
-			SummaryText: "Internal Driver Error",
-			DetailsText: "Failed to get local UDP address",
-			Code:        statusToHealthCode(DriverConfigError),
-		}
-		faultCheck.UpdateReliability(ctx, rel)
 	}
-	return err
+	if systemCheck != nil {
+		systemCheck.MarkRunning()
+	}
+	return nil
 }
 
-func (d *Driver) configureDevice(ctx context.Context, rootAnnouncer node.Announcer, cfg config.Root, device config.Device, devices known.Context, deviceHealth *healthpb.FaultCheck, logger *zap.Logger) error {
+func (d *Driver) configureDevice(ctx context.Context, rootAnnouncer node.Announcer, cfg config.Root, device config.Device, devices known.Context, deviceHealth *healthpb.FaultCheck, ctrlHealth *controllerHealth, logger *zap.Logger) error {
 	deviceName := adapt.DeviceName(device)
 	scDeviceName := cfg.DeviceNamePrefix + deviceName
 
@@ -300,8 +314,27 @@ func (d *Driver) configureDevice(ctx context.Context, rootAnnouncer node.Announc
 				},
 			})
 		}
+		if ctrlHealth != nil {
+			ctrlHealth.setFailing(ctx, scDeviceName)
+		}
 
 		return fmt.Errorf("device comm handshake: %w", ctxerr.Cause(ctx, err))
+	}
+
+	// For WhoIs-discovered devices the controller IP is only known after findDevice succeeds.
+	if ctrlHealth == nil {
+		if udpAddr, addrErr := bacDevice.Addr.UDPAddr(); addrErr == nil {
+			ip, ok := netip.AddrFromSlice(udpAddr.IP)
+			if ok {
+				ctrlHealth, _ = d.getOrCreateControllerCheck(ctx, cfg, ip.Unmap())
+				if ctrlHealth != nil {
+					ctrlHealth.register(scDeviceName)
+				}
+			}
+		}
+	}
+	if ctrlHealth != nil {
+		ctrlHealth.setOK(ctx, scDeviceName)
 	}
 
 	d.storeDevice(deviceName, bacDevice, device.DefaultWritePriority)
@@ -310,7 +343,19 @@ func (d *Driver) configureDevice(ctx context.Context, rootAnnouncer node.Announc
 		rootAnnouncer = node.AnnounceFeatures(rootAnnouncer, node.HasMetadata(device.Metadata))
 	}
 
-	adapt.Device(scDeviceName, d.client, bacDevice, devices, deviceHealth, updateRequestErrorStatus).AnnounceSelf(rootAnnouncer)
+	// Wrap the per-request error callback to also update controller-level health.
+	updateFn := func(rCtx context.Context, dh *healthpb.FaultCheck, name, request string, reqErr error) {
+		updateRequestErrorStatus(rCtx, dh, name, request, reqErr)
+		if ctrlHealth != nil {
+			if reqErr != nil {
+				ctrlHealth.setFailing(rCtx, scDeviceName)
+			} else {
+				ctrlHealth.setOK(rCtx, scDeviceName)
+			}
+		}
+	}
+
+	adapt.Device(scDeviceName, d.client, bacDevice, devices, deviceHealth, updateFn).AnnounceSelf(rootAnnouncer)
 
 	// aka "[bacnet/devices/]{deviceName}/[obj/]"
 	prefix := fmt.Sprintf("%s/%s", scDeviceName, cfg.ObjectNamePrefix)
@@ -339,7 +384,7 @@ func (d *Driver) configureDevice(ctx context.Context, rootAnnouncer node.Announc
 		// no error, we added the device before we entered the loop so it should exist
 		_ = d.storeObject(bacDevice, co, bo)
 
-		impl, err := adapt.Object(prefix, d.client, bacDevice, co, deviceHealth, updateRequestErrorStatus)
+		impl, err := adapt.Object(prefix, d.client, bacDevice, co, deviceHealth, updateFn)
 		if errors.Is(err, adapt.ErrNoDefault) {
 			// logger.Debug("No default adaptation trait for object")
 			continue
@@ -393,11 +438,6 @@ func (d *Driver) Clear() {
 }
 
 func (d *Driver) dispose() {
-	if d.systemCheck != nil {
-		d.systemCheck.Dispose()
-		d.systemCheck = nil
-	}
-
 	for _, stop := range d.healthTasks {
 		if stop != nil {
 			stop()
@@ -411,4 +451,29 @@ func (d *Driver) dispose() {
 		}
 	}
 	d.checks = nil
+
+	d.controllerMu.Lock()
+	for _, ch := range d.controllerHealths {
+		ch.faultCheck.Dispose()
+	}
+	d.controllerHealths = nil
+	d.controllerMu.Unlock()
+}
+
+// getOrCreateControllerCheck returns the controllerHealth for the given IP, creating it if needed.
+// The returned controllerHealth is already stored in d.controllerHealths.
+func (d *Driver) getOrCreateControllerCheck(ctx context.Context, cfg config.Root, ip netip.Addr) (*controllerHealth, error) {
+	key := cfg.Name + "/" + ip.String()
+	d.controllerMu.Lock()
+	defer d.controllerMu.Unlock()
+	if ch, ok := d.controllerHealths[key]; ok {
+		return ch, nil
+	}
+	fc, err := d.health.NewFaultCheck(key, createControllerHealthCheck(cfg.SystemHealth.OccupantImpact.ToProto(), cfg.SystemHealth.EquipmentImpact.ToProto()))
+	if err != nil {
+		return nil, err
+	}
+	ch := newControllerHealth(fc, cfg.ControllerHealthThreshold)
+	d.controllerHealths[key] = ch
+	return ch, nil
 }

--- a/pkg/driver/bacnet/health.go
+++ b/pkg/driver/bacnet/health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/smart-core-os/sc-bos/pkg/driver/bacnet/merge"
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
@@ -11,19 +12,9 @@ import (
 )
 
 const (
-	DriverConfigError = "DriverConfig"
-	DeviceUnreachable = "DeviceUnreachable"
+	DeviceUnreachable   = "DeviceUnreachable"
+	ControllerUnhealthy = "ControllerUnhealthy"
 )
-
-func createSystemHealthCheck(occupant healthpb.HealthCheck_OccupantImpact, equipment healthpb.HealthCheck_EquipmentImpact) *healthpb.HealthCheck {
-	return &healthpb.HealthCheck{
-		Id:              "systemStatusCheck",
-		DisplayName:     "System Status Check",
-		Description:     "Checks the bacnet controller is reachable and the configured nodes are responding correctly",
-		OccupantImpact:  occupant,
-		EquipmentImpact: equipment,
-	}
-}
 
 func createDeviceHealthCheck(occupant healthpb.HealthCheck_OccupantImpact, equipment healthpb.HealthCheck_EquipmentImpact) *healthpb.HealthCheck {
 	return &healthpb.HealthCheck{
@@ -82,5 +73,86 @@ func statusToHealthCode(code string) *healthpb.HealthCheck_Error_Code {
 	return &healthpb.HealthCheck_Error_Code{
 		Code:   code,
 		System: merge.SystemName,
+	}
+}
+
+func createControllerHealthCheck(occupant healthpb.HealthCheck_OccupantImpact, equipment healthpb.HealthCheck_EquipmentImpact) *healthpb.HealthCheck {
+	return &healthpb.HealthCheck{
+		Id:              "controllerStatusCheck",
+		DisplayName:     "Controller Status Check",
+		Description:     "Checks the BACnet controller is reachable and a sufficient proportion of its devices are responding",
+		OccupantImpact:  occupant,
+		EquipmentImpact: equipment,
+	}
+}
+
+// controllerHealth aggregates per-device health states for a single BACnet controller (IP address).
+// When the proportion of failing devices reaches the threshold, the controller's FaultCheck is marked unhealthy.
+type controllerHealth struct {
+	faultCheck *healthpb.FaultCheck
+	threshold  int // [0,100]: % proportion of failing devices that triggers unhealthy
+
+	mu     sync.Mutex
+	states map[string]bool // device SC name → true if currently failing
+}
+
+func newControllerHealth(fc *healthpb.FaultCheck, threshold int) *controllerHealth {
+	return &controllerHealth{
+		faultCheck: fc,
+		threshold:  threshold,
+		states:     make(map[string]bool),
+	}
+}
+
+// register adds a device to controller tracking. Idempotent — safe to call on each retry attempt.
+func (c *controllerHealth) register(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.states[name]; !exists {
+		c.states[name] = false
+	}
+}
+
+// setFailing marks the named device as failing and recalculates controller health.
+func (c *controllerHealth) setFailing(ctx context.Context, name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.states[name] = true
+	c.recalculate(ctx)
+}
+
+// setOK marks the named device as healthy and recalculates controller health.
+func (c *controllerHealth) setOK(ctx context.Context, name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.states[name] = false
+	c.recalculate(ctx)
+}
+
+// recalculate must be called with c.mu held.
+func (c *controllerHealth) recalculate(ctx context.Context) {
+	total := len(c.states)
+	if total == 0 {
+		return
+	}
+	failing := 0
+	for _, isFailing := range c.states {
+		if isFailing {
+			failing++
+		}
+	}
+	ratio := failing * 100 / total
+	if ratio >= c.threshold {
+		c.faultCheck.UpdateReliability(ctx, &healthpb.HealthCheck_Reliability{
+			State: healthpb.HealthCheck_Reliability_CONN_TRANSIENT_FAILURE,
+			LastError: &healthpb.HealthCheck_Error{
+				SummaryText: fmt.Sprintf("%d/%d devices on controller are failing", failing, total),
+				Code:        statusToHealthCode(ControllerUnhealthy),
+			},
+		})
+	} else {
+		c.faultCheck.RemoveFault(&healthpb.HealthCheck_Error{
+			Code: statusToHealthCode(ControllerUnhealthy),
+		})
 	}
 }

--- a/ui/ops/src/routes/system/components/SubsystemHealthCard.vue
+++ b/ui/ops/src/routes/system/components/SubsystemHealthCard.vue
@@ -32,7 +32,10 @@
       <template v-if="displayGroups.length > 0">
         <template v-for="group in displayGroups" :key="group.key">
           <!-- Group header row (only when the config entry is a named group) -->
-          <div v-if="group.label" class="group-header d-flex align-center py-1 mt-1">
+          <div
+              v-if="group.label"
+              class="group-header d-flex align-center py-1 mt-1 group-header--clickable"
+              @click="toggleGroup(group.key)">
             <normality-icon :model-value="{ normality: worstNormality(group.allItems) }" size="12" class="mr-1"/>
             <reliability-icon :model-value="{ reliability: { state: worstReliabilityState(group.allItems) } }" size="12" class="mr-2"/>
             <span class="text-caption font-weight-medium text-medium-emphasis flex-grow-1 text-truncate" :title="group.label">
@@ -41,95 +44,103 @@
             <span class="text-caption text-medium-emphasis flex-shrink-0 ml-1">
               {{ checkCountLabel(group.allItems) }}
             </span>
+            <v-icon
+                size="14"
+                class="ml-1 flex-shrink-0 expand-chevron"
+                :class="{ 'expand-chevron--open': !collapsedGroups.has(group.key) }">
+              mdi-chevron-down
+            </v-icon>
           </div>
 
-          <!-- Check entries; indented when inside a named group -->
-          <div :class="group.label ? 'pl-3' : ''">
-            <div v-for="entry in group.entries" :key="entry.check.name" style="position: relative;">
-              <!-- Clickable summary row -->
-              <div
-                  class="d-flex align-center check-row py-1"
-                  :class="{ 'check-row--expandable': hasDetail(entry) }"
-                  @click="hasDetail(entry) && toggleExpand(entry.check.name)">
-                <normality-icon :model-value="{ normality: worstNormality(entry.items) }" size="14" class="mr-1"/>
-                <reliability-icon :model-value="{ reliability: { state: worstReliabilityState(entry.items) } }" size="14" class="mr-2"/>
-                <span class="text-caption text-truncate flex-grow-1" :title="entry.check.displayName ?? entry.check.name">
-                  {{ entry.check.displayName ?? entry.check.name }}
-                </span>
-                <span class="text-caption text-medium-emphasis flex-shrink-0 ml-1">
-                  {{ checkCountLabel(entry.items) }}
-                </span>
-                <v-icon
-                    v-if="hasDetail(entry)"
-                    size="14"
-                    class="ml-1 flex-shrink-0 expand-chevron"
-                    :class="{ 'expand-chevron--open': expandedChecks.has(entry.check.name) }">
-                  mdi-chevron-down
-                </v-icon>
-              </div>
+          <!-- Check entries; indented when inside a named group; collapsed when the group header is toggled -->
+          <v-expand-transition>
+            <div v-if="!group.label || !collapsedGroups.has(group.key)" :class="group.label ? 'pl-3' : ''">
+              <div v-for="entry in group.entries" :key="entry.check.name" style="position: relative;">
+                <!-- Clickable summary row -->
+                <div
+                    class="d-flex align-center check-row py-1"
+                    :class="{ 'check-row--expandable': hasDetail(entry) }"
+                    @click="hasDetail(entry) && toggleExpand(entry.check.name)">
+                  <normality-icon :model-value="{ normality: worstNormality(entry.items) }" size="14" class="mr-1"/>
+                  <reliability-icon :model-value="{ reliability: { state: worstReliabilityState(entry.items) } }" size="14" class="mr-2"/>
+                  <span class="text-caption text-truncate flex-grow-1" :title="entry.check.displayName ?? entry.check.name">
+                    {{ entry.check.displayName ?? entry.check.name }}
+                  </span>
+                  <span class="text-caption text-medium-emphasis flex-shrink-0 ml-1">
+                    {{ checkCountLabel(entry.items) }}
+                  </span>
+                  <v-icon
+                      v-if="hasDetail(entry)"
+                      size="14"
+                      class="ml-1 flex-shrink-0 expand-chevron"
+                      :class="{ 'expand-chevron--open': expandedChecks.has(entry.check.name) }">
+                    mdi-chevron-down
+                  </v-icon>
+                </div>
 
-              <!-- Expandable detail -->
-              <v-expand-transition>
-                <div v-if="expandedChecks.has(entry.check.name)" class="check-detail pb-1">
-                  <template v-for="item in entry.items" :key="item.id">
-                    <!-- Item header when multiple checks exist under this entry -->
-                    <div v-if="entry.items.length > 1" class="text-caption font-weight-medium text-medium-emphasis mt-1 mb-0-5">
-                      {{ item.displayName || item.id }}
-                    </div>
-                    <!-- Description -->
-                    <div v-if="item.description" class="detail-line text-caption text-medium-emphasis">
-                      <v-icon size="12" class="mr-1">mdi-information-outline</v-icon>
-                      {{ item.description }}
-                    </div>
-                    <!-- Reliability state + offline-since timestamp -->
-                    <template v-if="item.reliability && item.reliability.state > reliableState">
-                      <div class="detail-line text-caption text-error">
-                        <v-icon size="12" class="mr-1" color="error">mdi-lan-disconnect</v-icon>
-                        {{ reliabilityStateToString(item.reliability.state) }}
-                        <span v-if="item.reliability.unreliableTime" class="text-medium-emphasis ml-1">
-                          since {{ formatTimestamp(item.reliability.unreliableTime) }}
-                        </span>
+                <!-- Expandable detail -->
+                <v-expand-transition>
+                  <div v-if="expandedChecks.has(entry.check.name)" class="check-detail pb-1">
+                    <template v-for="item in entry.items" :key="item.id">
+                      <!-- Item header when multiple checks exist under this entry -->
+                      <div v-if="entry.items.length > 1" class="text-caption font-weight-medium text-medium-emphasis mt-1 mb-0-5">
+                        {{ item.displayName || item.id }}
                       </div>
-                      <!-- Last error message -->
-                      <div v-if="item.reliability.lastError" class="detail-line text-caption text-error">
-                        <v-icon size="12" class="mr-1" color="error">mdi-alert-circle-outline</v-icon>
-                        {{ toSentenceCase(item.reliability.lastError.summaryText) }}
-                        <span v-if="item.reliability.lastError.detailsText" class="text-medium-emphasis d-block ml-4">
-                          {{ item.reliability.lastError.detailsText }}
-                        </span>
+                      <!-- Description -->
+                      <div v-if="item.description" class="detail-line text-caption text-medium-emphasis">
+                        <v-icon size="12" class="mr-1">mdi-information-outline</v-icon>
+                        {{ item.description }}
                       </div>
-                      <!-- Root cause -->
-                      <div v-if="item.reliability.cause" class="detail-line text-caption text-medium-emphasis">
-                        <v-icon size="12" class="mr-1">mdi-transit-connection-variant</v-icon>
-                        Caused by: {{ item.reliability.cause.displayName || item.reliability.cause.name }}
-                        <span v-if="item.reliability.cause.error && item.reliability.cause.error.summaryText" class="d-block ml-4">
-                          {{ toSentenceCase(item.reliability.cause.error.summaryText) }}
+                      <!-- Reliability state + offline-since timestamp -->
+                      <template v-if="item.reliability && item.reliability.state > reliableState">
+                        <div class="detail-line text-caption text-error">
+                          <v-icon size="12" class="mr-1" color="error">mdi-lan-disconnect</v-icon>
+                          {{ reliabilityStateToString(item.reliability.state) }}
+                          <span v-if="item.reliability.unreliableTime" class="text-medium-emphasis ml-1">
+                            since {{ formatTimestamp(item.reliability.unreliableTime) }}
+                          </span>
+                        </div>
+                        <!-- Last error message -->
+                        <div v-if="item.reliability.lastError" class="detail-line text-caption text-error">
+                          <v-icon size="12" class="mr-1" color="error">mdi-alert-circle-outline</v-icon>
+                          {{ toSentenceCase(item.reliability.lastError.summaryText) }}
+                          <span v-if="item.reliability.lastError.detailsText" class="text-medium-emphasis d-block ml-4">
+                            {{ item.reliability.lastError.detailsText }}
+                          </span>
+                        </div>
+                        <!-- Root cause -->
+                        <div v-if="item.reliability.cause" class="detail-line text-caption text-medium-emphasis">
+                          <v-icon size="12" class="mr-1">mdi-transit-connection-variant</v-icon>
+                          Caused by: {{ item.reliability.cause.displayName || item.reliability.cause.name }}
+                          <span v-if="item.reliability.cause.error && item.reliability.cause.error.summaryText" class="d-block ml-4">
+                            {{ toSentenceCase(item.reliability.cause.error.summaryText) }}
+                          </span>
+                        </div>
+                      </template>
+                      <!-- Abnormal-since timestamp (for normality issues unrelated to reliability) -->
+                      <div
+                          v-else-if="item.normality > normalNormality && item.abnormalTime"
+                          class="detail-line text-caption text-warning">
+                        <v-icon size="12" class="mr-1" color="warning">mdi-clock-alert-outline</v-icon>
+                        Abnormal since {{ formatTimestamp(item.abnormalTime) }}
+                      </div>
+                      <!-- Faults -->
+                      <div
+                          v-for="(fault, fi) in item.faults?.currentFaultsList"
+                          :key="fi"
+                          class="detail-line text-caption text-warning">
+                        <v-icon size="12" class="mr-1" color="warning">mdi-alert-outline</v-icon>
+                        {{ toSentenceCase(fault.summaryText) }}
+                        <span v-if="fault.detailsText" class="text-medium-emphasis d-block ml-4">
+                          {{ fault.detailsText }}
                         </span>
                       </div>
                     </template>
-                    <!-- Abnormal-since timestamp (for normality issues unrelated to reliability) -->
-                    <div
-                        v-else-if="item.normality > normalNormality && item.abnormalTime"
-                        class="detail-line text-caption text-warning">
-                      <v-icon size="12" class="mr-1" color="warning">mdi-clock-alert-outline</v-icon>
-                      Abnormal since {{ formatTimestamp(item.abnormalTime) }}
-                    </div>
-                    <!-- Faults -->
-                    <div
-                        v-for="(fault, fi) in item.faults?.currentFaultsList"
-                        :key="fi"
-                        class="detail-line text-caption text-warning">
-                      <v-icon size="12" class="mr-1" color="warning">mdi-alert-outline</v-icon>
-                      {{ toSentenceCase(fault.summaryText) }}
-                      <span v-if="fault.detailsText" class="text-medium-emphasis d-block ml-4">
-                        {{ fault.detailsText }}
-                      </span>
-                    </div>
-                  </template>
-                </div>
-              </v-expand-transition>
+                  </div>
+                </v-expand-transition>
+              </div>
             </div>
-          </div>
+          </v-expand-transition>
         </template>
       </template>
       <div v-else class="text-caption text-medium-emphasis" style="position: relative;">
@@ -262,6 +273,18 @@ function hasDetail(entry) {
 }
 
 const expandedChecks = ref(new Set());
+const collapsedGroups = ref(new Set());
+
+/** @param {string} key */
+function toggleGroup(key) {
+  const next = new Set(collapsedGroups.value);
+  if (next.has(key)) {
+    next.delete(key);
+  } else {
+    next.add(key);
+  }
+  collapsedGroups.value = next;
+}
 
 /** @param {string} name */
 function toggleExpand(name) {
@@ -354,6 +377,15 @@ const accentColor = computed(() => {
 
 .group-header:not(:first-child) {
   margin-top: 6px !important;
+}
+
+.group-header--clickable {
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.group-header--clickable:hover {
+  background: rgba(var(--v-theme-on-surface), 0.04);
 }
 
 .check-row:not(:last-child) {


### PR DESCRIPTION
[3CS-75](https://vanti.youtrack.cloud/issue/3CS-75) This change adds a 'controller level' health check concept to the BACnet driver. Each controller (distinguished by its IP address) automatically gets a named health check like `<driver-name>/<ip-address>`. The controller is unhealthy if a configurable percentage of its devices are erroring. This is what is looks like at 3CS (which is accurate as floors 6-9 are currently all off):

<img width="450" height="600" alt="image" src="https://github.com/user-attachments/assets/a44a0189-88e4-4195-99ff-639213582c66" />

Also adds a small change to the subsystem health page to make the floors collapsable