### PR TITLE
auth/policy: migrate OPA imports and rego files to v1 API

### DIFF
--- a/pkg/app/controller.go
+++ b/pkg/app/controller.go
@@ -16,8 +16,7 @@ import (
 	"time"
 
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
-	//lint:ignore SA1019 the old OPA interface remains supported - we may migrate in future
-	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/rs/cors"
 	"github.com/timshannon/bolthold"
 	"go.uber.org/multierr"

--- a/pkg/auth/policy/default/README.md
+++ b/pkg/auth/policy/default/README.md
@@ -2,7 +2,7 @@
 
 TL;DR admins can do anything anywhere, zones are restricted by name, roles restrict permissions.
 
-Test these rules by running `opa test . --v0-compatible` from this directory.
+Test these rules by running `opa test .` from this directory.
 
 We've split the policies into rules and utilities:
 

--- a/pkg/auth/policy/default/http.rego
+++ b/pkg/auth/policy/default/http.rego
@@ -2,23 +2,23 @@ package http
 
 import data.scutil.token.token_has_role
 
-allow {
+allow if {
   log_level_permission
   input.path == "/__/log/level"
 }
 
-allow {
+allow if {
   # everyone can get the service version
   input.path == "/__/version"
 }
 
-allow {
+allow if {
   pprof_permission
   startswith(input.path, "/__/debug/pprof/")
 }
 
-log_level_permission { token_has_role("admin") }
-log_level_permission { token_has_role("super-admin") }
+log_level_permission if token_has_role("admin")
+log_level_permission if token_has_role("super-admin")
 
-pprof_permission { token_has_role("admin") }
-pprof_permission { token_has_role("super-admin") }
+pprof_permission if token_has_role("admin")
+pprof_permission if token_has_role("super-admin")

--- a/pkg/auth/policy/default/rpc.rego
+++ b/pkg/auth/policy/default/rpc.rego
@@ -1,43 +1,35 @@
 package scutil.rpc
 
-import future.keywords.in
-
-read_verbs = {
+read_verbs := {
   "Get",
   "List",
   "Pull",
   "Describe"
 }
 
-write_verbs = {
+write_verbs := {
   "Create",
   "Update",
   "Delete"
 }
 
-verb_match(verbs) {
-  regex.match(concat("", ["^(", concat("|", verbs), ")[A-Z]"]), input.method)
-}
+verb_match(verbs) if regex.match(concat("", ["^(", concat("|", verbs), ")[A-Z]"]), input.method)
 
-read_request {
-  verb_match(read_verbs)
-}
+read_request if verb_match(read_verbs)
 
-write_request {
-  verb_match(write_verbs)
-}
+write_request if verb_match(write_verbs)
 
-rpc_match(service, method) {
+rpc_match(service, method) if {
   input.service == service
   input.method == method
 }
 
-rpc_match_methods(service, methods) {
+rpc_match_methods(service, methods) if {
   input.service == service
   input.method in methods
 }
 
-rpc_match_verbs(service, verbs) {
+rpc_match_verbs(service, verbs) if {
   input.service == service
   verb_match(verbs)
 }

--- a/pkg/auth/policy/default/smartcore.bos.alert.v1.AlertApi.rego
+++ b/pkg/auth/policy/default/smartcore.bos.alert.v1.AlertApi.rego
@@ -3,7 +3,7 @@ package smartcore.bos.alert.v1.AlertApi
 import data.scutil.token.token_has_role
 import data.scutil.rpc.verb_match
 
-allow {
+allow if {
   token_has_role("operator")
   verb_match({"Acknowledge", "Unacknowledge"})
 }

--- a/pkg/auth/policy/default/smartcore.bos.dataretention.v1.DataRetentionApi.rego
+++ b/pkg/auth/policy/default/smartcore.bos.dataretention.v1.DataRetentionApi.rego
@@ -7,23 +7,23 @@ import data.scutil.token.token_has_permission
 default allow := false
 
 # Unrestricted access for admin roles and valid certificates.
-allow { token_has_role("admin") }
-allow { token_has_role("super-admin") }
-allow { input.certificate_valid }
-allow { token_has_role("commissioner") }
+allow if token_has_role("admin")
+allow if token_has_role("super-admin")
+allow if input.certificate_valid
+allow if token_has_role("commissioner")
 
 # Operators and viewers may read data retention statistics.
-allow {
-  token_has_role("operator")
-  read_request
+allow if {
+	token_has_role("operator")
+	read_request
 }
-allow {
-  token_has_role("viewer")
-  read_request
+allow if {
+	token_has_role("viewer")
+	read_request
 }
 
 # Tenant permission-based read access.
-allow {
-  token_has_permission("trait:read")
-  read_request
+allow if {
+	token_has_permission("trait:read")
+	read_request
 }

--- a/pkg/auth/policy/default/smartcore.bos.driver.dali.v1.DaliApi.rego
+++ b/pkg/auth/policy/default/smartcore.bos.driver.dali.v1.DaliApi.rego
@@ -1,9 +1,8 @@
 package smartcore.bos.driver.dali.v1.DaliApi
 
-import future.keywords.in
 import data.scutil.token.token_has_role
 
-allow {
+allow if {
   token_has_role("operator")
   input.method in ["StartTest", "StopTest"]
 }

--- a/pkg/auth/policy/default/smartcore.bos.enrollment.v1.EnrollmentApi.rego
+++ b/pkg/auth/policy/default/smartcore.bos.enrollment.v1.EnrollmentApi.rego
@@ -1,10 +1,8 @@
 package smartcore.bos.enrollment.v1.EnrollmentApi
 
-import data.scutil.token.token_has_role
 import data.scutil.rpc.read_request
-import data.scutil.rpc.verb_match
 
 # Allow anybody to request information about their enrollment.
 # This is useful for status monitoring.
-allow { read_request }
-allow { input.method == "TestEnrollment" }
+allow if read_request
+allow if input.method == "TestEnrollment"

--- a/pkg/auth/policy/default/smartcore.bos.hub.v1.HubApi.rego
+++ b/pkg/auth/policy/default/smartcore.bos.hub.v1.HubApi.rego
@@ -5,8 +5,6 @@ import data.scutil.rpc.verb_match
 
 # Allow anybody to request information about nodes.
 # This is useful for status monitoring.
-allow { read_request }
+allow if read_request
 
-allow {
-  verb_match({"Inspect", "Test"})
-}
+allow if verb_match({"Inspect", "Test"})

--- a/pkg/auth/policy/default/smartcore.bos.rego
+++ b/pkg/auth/policy/default/smartcore.bos.rego
@@ -1,23 +1,21 @@
 package smartcore.bos
 
-import future.keywords.in
-
 import data.scutil.rpc.read_request
 import data.scutil.token.token_has_permission
 import data.system.known_traits
 
-trait_request {
+trait_request if {
   some trait in known_traits
   input.service in trait.grpc_services
 }
 
-allow {
+allow if {
   trait_request
   read_request
   token_has_permission("trait:read")
 }
 
-allow {
+allow if {
   trait_request
   token_has_permission("trait:write")
 }

--- a/pkg/auth/policy/default/smartcore.bos.services.v1.ServicesApi.rego
+++ b/pkg/auth/policy/default/smartcore.bos.services.v1.ServicesApi.rego
@@ -7,34 +7,34 @@ import data.scutil.rpc.read_request
 default allow := false # take over all permissions for this service
 
 # admin based access is unrestricted
-allow {token_has_role("admin")}
-allow {token_has_role("super-admin")}
+allow if token_has_role("admin")
+allow if token_has_role("super-admin")
 # certificate based access is unrestricted, this may change in future
-allow {input.certificate_valid}
+allow if input.certificate_valid
 
 # Commissioners can do anything with services
-allow {token_has_role("commissioner")}
+allow if token_has_role("commissioner")
 
 # Operators are allowed extra privileges to start/stop any service/automation.
 # Also operators can fully manage zones as they see fit.
-allow {
+allow if {
   token_has_role("operator")
   read_request
 }
-allow {
+allow if {
   token_has_role("operator")
   verb_match({"Stop", "Start"})
 }
-allow {
+allow if {
   token_has_role("operator")
   endswith(input.request.name, "/zones")
 }
-allow {
+allow if {
   token_has_role("operator")
   input.request.name == "zones"
 }
 
-allow {
+allow if {
   token_has_role("viewer")
   read_request
 }
@@ -42,5 +42,5 @@ allow {
 # signage has no rights here
 
 # Allow anyone to get service metadata about any service.
-allow { input.method == "GetServiceMetadata" }
-allow { input.method == "PullServiceMetadata" }
+allow if input.method == "GetServiceMetadata"
+allow if input.method == "PullServiceMetadata"

--- a/pkg/auth/policy/default/smartcore.bos.tenants.v1.TenantApi.rego
+++ b/pkg/auth/policy/default/smartcore.bos.tenants.v1.TenantApi.rego
@@ -3,7 +3,7 @@ package smartcore.bos.tenants.v1.TenantApi
 import data.scutil.token.token_has_role
 import data.scutil.rpc.verb_match
 
-allow {
+allow if {
   token_has_role("operator")
   verb_match({"Add", "Remove", "Regenerate"})
 }

--- a/pkg/auth/policy/default/smartcore.rego
+++ b/pkg/auth/policy/default/smartcore.rego
@@ -8,19 +8,25 @@ import data.scutil.rpc.write_request
 # Common rules for services that follow Smart Core conventions.
 
 # admin based access is unrestricted
-allow {token_has_role("admin")}
-allow {token_has_role("super-admin")}
+allow if token_has_role("admin")
+allow if token_has_role("super-admin")
 # certificate based access is unrestricted, this may change in future
-allow {input.certificate_valid}
+allow if input.certificate_valid
 
 # Commissioners can do anything apart from create new users
-allow { token_has_role("commissioner") }
+allow if token_has_role("commissioner")
 # Operators can read or update anything by default.
 # SerivceApi has special rules for this role.
-allow { token_has_role("operator"); read_request }
-allow { token_has_role("operator"); write_request }
+allow if {
+  token_has_role("operator")
+  read_request
+}
+allow if {
+  token_has_role("operator")
+  write_request
+}
 # Viewers have read-only access, no write or mutation rpcs allowed
-allow {
+allow if {
   token_has_role("viewer")
   read_request
 }

--- a/pkg/auth/policy/default/smartcore.traits.rego
+++ b/pkg/auth/policy/default/smartcore.traits.rego
@@ -1,15 +1,11 @@
 package smartcore.traits
 
-import future.keywords.in
-
 import data.scutil.token.token_has_permission
 import data.scutil.rpc.read_request
 
-allow {
+allow if {
   token_has_permission("trait:read")
   read_request
 }
 
-allow {
-  token_has_permission("trait:write")
-}
+allow if token_has_permission("trait:write")

--- a/pkg/auth/policy/default/test_general.rego
+++ b/pkg/auth/policy/default/test_general.rego
@@ -1,9 +1,7 @@
 package scos
 
-import future.keywords.in
-
-user_request(service, method, request, roles) := input {
-  input := {
+user_request(service, method, request, roles) := result if {
+  result := {
     "service": service,
     "method": method,
     "stream": {"is_server_stream": false, "is_client_stream": false, "open": false},
@@ -22,51 +20,47 @@ user_request(service, method, request, roles) := input {
 
 # --- Old-style traits (pre-migration names) ---
 
-test_viewer_GetBrightness {
+test_viewer_GetBrightness if {
   data.smartcore.allow with input as user_request("smartcore.traits.LightApi", "GetBrightness", {}, ["viewer"])
 }
-test_viewer_UpdateBrightness {
+test_viewer_UpdateBrightness if {
   not data.smartcore.traits.LightApi.allow with input as user_request("smartcore.traits.LightApi", "UpdateBrightness", {}, ["viewer"])
   not data.smartcore.traits.allow with input as user_request("smartcore.traits.LightApi", "UpdateBrightness", {}, ["viewer"])
   not data.smartcore.allow with input as user_request("smartcore.traits.LightApi", "UpdateBrightness", {}, ["viewer"])
   not data.grpc_default.allow with input as user_request("smartcore.traits.LightApi", "UpdateBrightness", {}, ["viewer"])
 }
 
-test_operator_GetBrightness {
+test_operator_GetBrightness if {
   data.smartcore.allow with input as user_request("smartcore.traits.LightApi", "GetBrightness", {}, ["operator"])
 }
-test_operator_UpdateBrightness {
+test_operator_UpdateBrightness if {
   data.smartcore.allow with input as user_request("smartcore.traits.LightApi", "UpdateBrightness", {}, ["operator"])
 }
-test_operator_StartService {
+test_operator_StartService if {
   data.smartcore.bos.services.v1.ServicesApi.allow with input as user_request("smartcore.bos.services.v1.ServicesApi", "StartService", {}, ["operator"])
 }
-test_operator_ConfigureService {
+test_operator_ConfigureService if {
   not data.smartcore.bos.services.v1.ServicesApi.allow with input as user_request("smartcore.bos.services.v1.ServicesApi", "ConfigureService", {}, ["operator"])
   not data.smartcore.bos.allow with input as user_request("smartcore.bos.services.v1.ServicesApi", "ConfigureService", {}, ["operator"])
   not data.smartcore.allow with input as user_request("smartcore.bos.services.v1.ServicesApi", "ConfigureService", {}, ["operator"])
   not data.grpc_default.allow with input as user_request("smartcore.bos.services.v1.ServicesApi", "ConfigureService", {}, ["operator"])
 }
-test_operator_ConfigureService_zones {
-  input := user_request("smartcore.bos.services.v1.ServicesApi", "ConfigureService", {
-    "name": "zones"
-  }, ["operator"])
-  data.smartcore.bos.services.v1.ServicesApi.allow with input as input
+test_operator_ConfigureService_zones if {
+  req := user_request("smartcore.bos.services.v1.ServicesApi", "ConfigureService", {"name": "zones"}, ["operator"])
+  data.smartcore.bos.services.v1.ServicesApi.allow with input as req
 }
-test_operator_ConfigureService_zones {
-  input := user_request("smartcore.bos.services.v1.ServicesApi", "ConfigureService", {
-    "name": "ns/1/zones"
-  }, ["operator"])
-  data.smartcore.bos.services.v1.ServicesApi.allow with input as input
+test_operator_ConfigureService_zones if {
+  req := user_request("smartcore.bos.services.v1.ServicesApi", "ConfigureService", {"name": "ns/1/zones"}, ["operator"])
+  data.smartcore.bos.services.v1.ServicesApi.allow with input as req
 }
-test_operator_DaliApi {
+test_operator_DaliApi if {
   data.smartcore.bos.driver.dali.v1.DaliApi.allow with input as user_request("smartcore.bos.driver.dali.v1.DaliApi", "StartTest", {}, ["operator"])
   data.smartcore.bos.driver.dali.v1.DaliApi.allow with input as user_request("smartcore.bos.driver.dali.v1.DaliApi", "StopTest", {}, ["operator"])
   not data.smartcore.bos.driver.dali.v1.DaliApi.allow with input as user_request("smartcore.bos.driver.dali.v1.DaliApi", "DeleteTestResult", {}, ["operator"])
 }
 
-tenant_request(service, method, request, zones) := input {
-  input := {
+tenant_request(service, method, request, zones) := result if {
+  result := {
     "service": service,
     "method": method,
     "stream": {"is_server_stream": false, "is_client_stream": false, "open": false},
@@ -92,13 +86,13 @@ tenant_request(service, method, request, zones) := input {
   }
 }
 
-test_zone_exact {
+test_zone_exact if {
   data.smartcore.traits.allow with input as tenant_request("smartcore.traits.LightApi", "GetBrightness", {"name": "zone/1"}, ["zone/1"])
 }
-test_zone_parent {
+test_zone_parent if {
   data.smartcore.traits.allow with input as tenant_request("smartcore.traits.LightApi", "GetBrightness", {"name": "zone/1/child"}, ["zone/1"])
 }
-test_zone_mismatch {
+test_zone_mismatch if {
   not data.smartcore.traits.LightApi.allow with input as tenant_request("smartcore.traits.LightApi", "GetBrightness", {"name": "zone/2"}, ["zone/1"])
   not data.smartcore.traits.allow with input as tenant_request("smartcore.traits.LightApi", "GetBrightness", {"name": "zone/2"}, ["zone/1"])
   not data.smartcore.allow with input as tenant_request("smartcore.traits.LightApi", "GetBrightness", {"name": "zone/2"}, ["zone/1"])
@@ -107,19 +101,19 @@ test_zone_mismatch {
 
 # --- New-style bos trait service (post-migration names) ---
 
-test_bos_viewer_GetBrightness {
+test_bos_viewer_GetBrightness if {
   data.smartcore.allow with input as user_request("smartcore.bos.light.v1.LightApi", "GetBrightness", {}, ["viewer"])
 }
-test_bos_viewer_UpdateBrightness {
+test_bos_viewer_UpdateBrightness if {
   not data.smartcore.bos.light.v1.LightApi.allow with input as user_request("smartcore.bos.light.v1.LightApi", "UpdateBrightness", {}, ["viewer"])
   not data.smartcore.bos.allow with input as user_request("smartcore.bos.light.v1.LightApi", "UpdateBrightness", {}, ["viewer"])
   not data.smartcore.allow with input as user_request("smartcore.bos.light.v1.LightApi", "UpdateBrightness", {}, ["viewer"])
   not data.grpc_default.allow with input as user_request("smartcore.bos.light.v1.LightApi", "UpdateBrightness", {}, ["viewer"])
 }
-test_bos_operator_GetBrightness {
+test_bos_operator_GetBrightness if {
   data.smartcore.allow with input as user_request("smartcore.bos.light.v1.LightApi", "GetBrightness", {}, ["operator"])
 }
-test_bos_operator_UpdateBrightness {
+test_bos_operator_UpdateBrightness if {
   data.smartcore.allow with input as user_request("smartcore.bos.light.v1.LightApi", "UpdateBrightness", {}, ["operator"])
 }
 
@@ -128,17 +122,17 @@ test_bos_operator_UpdateBrightness {
 # standalone `opa test` does not have that data available.
 mock_known_traits := [{"grpc_services": ["smartcore.bos.light.v1.LightApi"]}]
 
-test_bos_zone_exact {
+test_bos_zone_exact if {
   data.smartcore.bos.allow
     with input as tenant_request("smartcore.bos.light.v1.LightApi", "GetBrightness", {"name": "zone/1"}, ["zone/1"])
     with data.system.known_traits as mock_known_traits
 }
-test_bos_zone_parent {
+test_bos_zone_parent if {
   data.smartcore.bos.allow
     with input as tenant_request("smartcore.bos.light.v1.LightApi", "GetBrightness", {"name": "zone/1/child"}, ["zone/1"])
     with data.system.known_traits as mock_known_traits
 }
-test_bos_zone_mismatch {
+test_bos_zone_mismatch if {
   not data.smartcore.bos.light.v1.LightApi.allow
     with input as tenant_request("smartcore.bos.light.v1.LightApi", "GetBrightness", {"name": "zone/2"}, ["zone/1"])
     with data.system.known_traits as mock_known_traits

--- a/pkg/auth/policy/default/token.rego
+++ b/pkg/auth/policy/default/token.rego
@@ -1,7 +1,5 @@
 package scutil.token
 
-import future.keywords.in
-
 roles := {
   "admin", # unrestricted user access
   "commissioner",
@@ -11,34 +9,34 @@ roles := {
   "viewer"
 }
 
-valid_claims = claims {
+valid_claims := claims if {
   input.token_valid
   claims := input.token_claims
 }
 
-token_roles = roles {
+token_roles := roles if {
   claims := valid_claims
   roles := claims.roles
 }
 
-token_permission_assignments = assignments {
+token_permission_assignments := assignments if {
   claims := valid_claims
   assignments := claims.permissions
 }
 
-token_has_role(role) {
+token_has_role(role) if {
   role in roles
   claims := valid_claims
   claims.system_roles[_] == role
 }
 
-token_has_permission_direct(permission) {
+token_has_permission_direct(permission) if {
   some assignment in token_permission_assignments
   assignment.permission == permission
   not assignment.scoped
 }
 
-token_has_permission_direct(permission) {
+token_has_permission_direct(permission) if {
   some assignment in token_permission_assignments
   assignment.permission == permission
   assignment.scoped
@@ -46,7 +44,7 @@ token_has_permission_direct(permission) {
   startswith(input.request.name, concat("/", [assignment.resource, ""]))
 }
 
-token_has_permission_direct(permission) {
+token_has_permission_direct(permission) if {
   some assignment in token_permission_assignments
   assignment.permission == permission
   assignment.scoped
@@ -54,11 +52,11 @@ token_has_permission_direct(permission) {
   input.request.name == assignment.resource
 }
 
-token_has_permission(permission) {
+token_has_permission(permission) if {
   token_has_permission_direct(permission)
 }
 
-token_has_permission(permission) {
+token_has_permission(permission) if {
   some parent_permission
   permission in inherit_permissions[parent_permission]
   token_has_permission_direct(parent_permission)

--- a/pkg/auth/policy/interceptor_test.go
+++ b/pkg/auth/policy/interceptor_test.go
@@ -9,8 +9,8 @@ import (
 
 	"sync"
 
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -300,21 +300,19 @@ var regoFiles = map[string]string{
 	"smartcore.rego": `package smartcore
 
 # This simple rule allows any request whose name is "allow", all other requests are denied
-allow {
-	input.request.name == "allow"
-}
+allow if input.request.name == "allow"
 `,
 	"smartcore.bos.onoff.v1.OnOffApi.rego": `package smartcore.bos.onoff.v1.OnOffApi
 
 # This rule allows people to turn any device on (but not off)
-allow {
+allow if {
 	input.method == "UpdateOnOff"
 	input.request.onOff.state == "ON"
 }
 `,
 	"http.rego": `package http
 
-allow { input.method == "GET" }
-allow { input.path == "/foo" }
+allow if input.method == "GET"
+allow if input.path == "/foo"
 `,
 }

--- a/pkg/auth/policy/policy.go
+++ b/pkg/auth/policy/policy.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/v1/rego"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/pkg/auth/policy/policy_test.go
+++ b/pkg/auth/policy/policy_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/v1/rego"
 
 	"github.com/smart-core-os/sc-bos/internal/auth/permission"
 	"github.com/smart-core-os/sc-bos/pkg/auth/token"

--- a/pkg/auth/policy/rego.go
+++ b/pkg/auth/policy/rego.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/rego"
-	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
 
 	"github.com/smart-core-os/sc-bos/pkg/node/alltraits"
 	"github.com/smart-core-os/sc-bos/pkg/trait"
@@ -50,12 +50,11 @@ func newCachedStatic(compiler *ast.Compiler) *cachedStatic {
 }
 
 func (p *cachedStatic) EvalPolicy(ctx context.Context, query string, input Attributes) (rego.ResultSet, error) {
-	partial, err := p.loadPartialCached(ctx, query)
+	pq, err := p.loadPreparedCached(ctx, query)
 	if err != nil {
 		return nil, err
 	}
-
-	return partial.Rego(rego.Input(input)).Eval(ctx)
+	return pq.Eval(ctx, rego.EvalInput(input))
 }
 
 func (p *cachedStatic) getOrCreateCacheEntry(query string) *regoCacheEntry {
@@ -73,11 +72,11 @@ func (p *cachedStatic) getOrCreateCacheEntry(query string) *regoCacheEntry {
 // Results are cached; the partial evaluation is performed once the first time and re-used for subsequent calls.
 // If the provided context is cancelled before the result is ready, the process will continue in the background and
 // the context error is returned.
-// If loadPartialCached returns a non-context error, then future calls with the same query will always return the same error.
-func (p *cachedStatic) loadPartialCached(ctx context.Context, query string) (rego.PartialResult, error) {
+// If loadPreparedCached returns a non-context error, then future calls with the same query will always return the same error.
+func (p *cachedStatic) loadPreparedCached(ctx context.Context, query string) (rego.PreparedEvalQuery, error) {
 	entry := p.getOrCreateCacheEntry(query)
 
-	// each cache entry only gets one change to compile - it's a deterministic process, so if it fails once there's no
+	// each cache entry only gets one chance to compile - it's a deterministic process, so if it fails once there's no
 	// point trying again later
 	entry.once.Do(func() {
 		// run asynchronously so the compilation can complete in the background if ctx is cancelled early
@@ -102,21 +101,21 @@ func (p *cachedStatic) loadPartialCached(ctx context.Context, query string) (reg
 				rego.Query(query),
 				rego.Store(defaultStore),
 			)
-			entry.partialResult, entry.err = r.PartialResult(bgctx)
+			entry.preparedQuery, entry.err = r.PrepareForEval(bgctx, rego.WithPartialEval())
 		}()
 	})
 	select {
 	case <-entry.done:
-		return entry.partialResult, entry.err
+		return entry.preparedQuery, entry.err
 	case <-ctx.Done():
-		return rego.PartialResult{}, ctx.Err()
+		return rego.PreparedEvalQuery{}, ctx.Err()
 	}
 }
 
 type regoCacheEntry struct {
 	once          sync.Once
 	done          chan struct{}
-	partialResult rego.PartialResult
+	preparedQuery rego.PreparedEvalQuery
 	err           error
 }
 

--- a/pkg/auth/policy/rego_test.go
+++ b/pkg/auth/policy/rego_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/v1/rego"
 	"google.golang.org/grpc/status"
 
 	"github.com/smart-core-os/sc-bos/pkg/auth/token"

--- a/pkg/auth/policy/staticcheck.conf
+++ b/pkg/auth/policy/staticcheck.conf
@@ -1,1 +1,0 @@
-checks = ["inherit", "-SA1019"]


### PR DESCRIPTION
We're using the deprecated OPA v0 API.

1. Switch to using the OPA v1 API when using Rego
2. Rewrite all Rego policy files to account for language changes in v1