### PR TITLE
system/gateway: fix hot loop in scan caused by custom service descriptors

### DIFF
--- a/pkg/auth/policy/rego.go
+++ b/pkg/auth/policy/rego.go
@@ -58,18 +58,15 @@ func (p *cachedStatic) EvalPolicy(ctx context.Context, query string, input Attri
 	return partial.Rego(rego.Input(input)).Eval(ctx)
 }
 
-func (p *cachedStatic) getCacheEntry(query string) (*regoCacheEntry, bool) {
+func (p *cachedStatic) getOrCreateCacheEntry(query string) *regoCacheEntry {
 	p.cacheM.Lock()
 	defer p.cacheM.Unlock()
-	entry, ok := p.cache[query]
-	return entry, ok
-}
 
-func (p *cachedStatic) setCacheEntry(query string) *regoCacheEntry {
-	entry := &regoCacheEntry{done: make(chan struct{})}
-	p.cacheM.Lock()
-	defer p.cacheM.Unlock()
-	p.cache[query] = entry
+	entry, ok := p.cache[query]
+	if !ok {
+		entry = &regoCacheEntry{done: make(chan struct{})}
+		p.cache[query] = entry
+	}
 	return entry
 }
 
@@ -78,10 +75,7 @@ func (p *cachedStatic) setCacheEntry(query string) *regoCacheEntry {
 // the context error is returned.
 // If loadPartialCached returns a non-context error, then future calls with the same query will always return the same error.
 func (p *cachedStatic) loadPartialCached(ctx context.Context, query string) (rego.PartialResult, error) {
-	entry, ok := p.getCacheEntry(query)
-	if !ok {
-		entry = p.setCacheEntry(query)
-	}
+	entry := p.getOrCreateCacheEntry(query)
 
 	// each cache entry only gets one change to compile - it's a deterministic process, so if it fails once there's no
 	// point trying again later

--- a/pkg/system/gateway/scan.go
+++ b/pkg/system/gateway/scan.go
@@ -318,9 +318,43 @@ func (s *System) reflectNode(ctx context.Context, node *remoteNode) error {
 	}
 
 	// we now can fully describe the remote service
-	node.Services.Replace(remoteServices)
+	// Only replace if the services have actually changed to avoid triggering unnecessary announcements.
+	// This is critical to prevent a hot loop when devices use custom Smart Core traits:
+	// - reflectNode is polled every 10 seconds
+	// - For custom traits, reflection returns file descriptors each time
+	// - node.Services.Replace() would trigger service change events even when nothing changed
+	// - This causes continuous re-announcements (hot loop) for custom trait services
+	// By comparing service names first, we avoid Replace() when the service set is identical.
+	if !servicesEqual(node, remoteServices) {
+		node.Services.Replace(remoteServices)
+	}
 
 	return nil
+}
+
+// servicesEqual returns true if the services in node match remoteServices.
+// This comparison uses service full names because reflect.DeepEqual on protoreflect.ServiceDescriptor
+// can incorrectly report inequality for identical services due to pointer/implementation differences.
+func servicesEqual(node *remoteNode, remoteServices []protoreflect.ServiceDescriptor) bool {
+	if node.Services.Len() != len(remoteServices) {
+		return false
+	}
+
+	// build a set of current service names for comparison
+	currentNames := make(map[string]struct{}, node.Services.Len())
+	node.Services.All(func(_ int, svc protoreflect.ServiceDescriptor) bool {
+		currentNames[string(svc.FullName())] = struct{}{}
+		return true
+	})
+
+	// check if all remote services are in current services
+	for _, svc := range remoteServices {
+		if _, ok := currentNames[string(svc.FullName())]; !ok {
+			return false
+		}
+	}
+
+	return true
 }
 
 // retry semantics for long-running tasks that can succeed and fail at the same time

--- a/pkg/system/gateway/scan_test.go
+++ b/pkg/system/gateway/scan_test.go
@@ -20,6 +20,8 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -673,6 +675,233 @@ func assertChanVal[T any](t *testing.T, ch <-chan T, fn func(T)) {
 		t.Fatalf("expected value from channel, but none available")
 	}
 }
+
+func TestServicesEqual(t *testing.T) {
+	// Helper to get a real service descriptor for testing
+	getServiceDesc := func(t *testing.T, fullName string) protoreflect.ServiceDescriptor {
+		t.Helper()
+		desc, err := protoregistry.GlobalFiles.FindDescriptorByName(protoreflect.FullName(fullName))
+		if err != nil {
+			t.Fatalf("failed to find service descriptor for %q: %v", fullName, err)
+		}
+		svcDesc, ok := desc.(protoreflect.ServiceDescriptor)
+		if !ok {
+			t.Fatalf("%q is not a service descriptor", fullName)
+		}
+		return svcDesc
+	}
+
+	tests := []struct {
+		name           string
+		nodeServices   []string // service full names in the node
+		remoteServices []string // service full names to compare
+		want           bool
+	}{
+		{
+			name:           "empty sets are equal",
+			nodeServices:   []string{},
+			remoteServices: []string{},
+			want:           true,
+		},
+		{
+			name: "identical services - prevents hot loop on repeated reflection polling",
+			// This is the PRIMARY test case for the hot loop fix.
+			// When reflectNode() is called every 10 seconds (via poll), it fetches service
+			// descriptors via gRPC reflection. For custom project traits (e.g., "smartcore.vanti.UKPowerApi"),
+			// the reflection API returns file descriptors each time. Without servicesEqual(),
+			// node.Services.Replace() would be called every poll cycle, triggering service
+			// change events even though nothing changed, causing continuous re-announcements.
+			// servicesEqual() compares by FullName() which is stable across reflection calls.
+			nodeServices: []string{
+				"smartcore.bos.onoff.v1.OnOffApi",
+				"smartcore.bos.meter.v1.MeterApi",
+			},
+			remoteServices: []string{
+				"smartcore.bos.onoff.v1.OnOffApi",
+				"smartcore.bos.meter.v1.MeterApi",
+			},
+			want: true,
+		},
+		{
+			name: "order doesn't matter - services can be in any order",
+			// Custom traits returned from reflection may come in different orders.
+			// The comparison must be order-independent to avoid false negatives.
+			nodeServices: []string{
+				"smartcore.bos.meter.v1.MeterApi",
+				"smartcore.bos.onoff.v1.OnOffApi",
+			},
+			remoteServices: []string{
+				"smartcore.bos.onoff.v1.OnOffApi",
+				"smartcore.bos.meter.v1.MeterApi",
+			},
+			want: true,
+		},
+		{
+			name: "multiple services with similar names - tests FullName uniqueness",
+			// Custom project traits often have similar naming patterns (e.g., FooApi, FooInfo, FooHistory).
+			// The comparison must correctly distinguish between them.
+			nodeServices: []string{
+				"smartcore.bos.onoff.v1.OnOffApi",
+				"smartcore.bos.onoff.v1.OnOffInfo",
+				"smartcore.bos.meter.v1.MeterApi",
+				"smartcore.bos.meter.v1.MeterInfo",
+			},
+			remoteServices: []string{
+				"smartcore.bos.onoff.v1.OnOffApi",
+				"smartcore.bos.onoff.v1.OnOffInfo",
+				"smartcore.bos.meter.v1.MeterApi",
+				"smartcore.bos.meter.v1.MeterInfo",
+			},
+			want: true,
+		},
+		{
+			name:           "different number of services",
+			nodeServices:   []string{"smartcore.bos.onoff.v1.OnOffApi"},
+			remoteServices: []string{"smartcore.bos.onoff.v1.OnOffApi", "smartcore.bos.meter.v1.MeterApi"},
+			want:           false,
+		},
+		{
+			name:           "different services",
+			nodeServices:   []string{"smartcore.bos.onoff.v1.OnOffApi"},
+			remoteServices: []string{"smartcore.bos.meter.v1.MeterApi"},
+			want:           false,
+		},
+		{
+			name: "extra service in remote - device gained new trait",
+			// Simulates when a device adds a new custom trait.
+			// This should trigger Replace() to announce the new service.
+			nodeServices: []string{
+				"smartcore.bos.onoff.v1.OnOffApi",
+			},
+			remoteServices: []string{
+				"smartcore.bos.onoff.v1.OnOffApi",
+				"smartcore.bos.devices.v1.DevicesApi",
+			},
+			want: false,
+		},
+		{
+			name: "missing service in remote - device lost trait",
+			// Simulates when a device removes a custom trait.
+			// This should trigger Replace() to unannounce the removed service.
+			nodeServices: []string{
+				"smartcore.bos.onoff.v1.OnOffApi",
+				"smartcore.bos.devices.v1.DevicesApi",
+			},
+			remoteServices: []string{
+				"smartcore.bos.onoff.v1.OnOffApi",
+			},
+			want: false,
+		},
+		{
+			name: "single service mismatch in many - detects subtle differences",
+			// With many custom traits, a single trait change must be detected.
+			// This ensures we don't miss updates when dealing with devices that
+			// have many custom project-specific traits.
+			nodeServices: []string{
+				"smartcore.bos.onoff.v1.OnOffApi",
+				"smartcore.bos.meter.v1.MeterApi",
+				"smartcore.bos.devices.v1.DevicesApi",
+			},
+			remoteServices: []string{
+				"smartcore.bos.onoff.v1.OnOffApi",
+				"smartcore.bos.meter.v1.MeterApi",
+				"smartcore.bos.emergency.v1.EmergencyApi", // Different service
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock node with the specified services
+			rn := newRemoteNode("test-node", nil)
+			for _, svcName := range tt.nodeServices {
+				rn.Services.Set(getServiceDesc(t, svcName))
+			}
+
+			// Create remote services list
+			remoteServices := make([]protoreflect.ServiceDescriptor, 0, len(tt.remoteServices))
+			for _, svcName := range tt.remoteServices {
+				remoteServices = append(remoteServices, getServiceDesc(t, svcName))
+			}
+
+			// Test
+			got := servicesEqual(rn, remoteServices)
+			if got != tt.want {
+				t.Errorf("servicesEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestServicesEqual_CustomTraitScenario tests the behavior with service descriptors that simulate
+// custom project traits. While we can't create mock ServiceDescriptors due to unexported interface methods,
+// this test documents the real-world scenario and validates the comparison logic works correctly.
+//
+// In production, custom project traits are discovered via gRPC reflection and follow the naming pattern:
+//   - "smartcore.vanti.UKPowerApi" (Vanti project-specific UK power monitoring)
+//   - "smartcore.customer.BuildingSystemApi" (Customer project-specific building system)
+//   - "smartcore.projectrepo.SpecialSensorApi" (Generic project-specific sensor)
+//
+// The key insight is that servicesEqual() compares services by FullName() which remains stable across
+// reflection calls, preventing the hot loop even though the ServiceDescriptor instances differ.
+func TestServicesEqual_CustomTraitScenario(t *testing.T) {
+	// Simulate a device with both standard and "custom" traits
+	// In reality, custom traits would have names like:
+	//   - "smartcore.vanti.UKPowerApi"
+	//   - "smartcore.customer.BuildingSystemApi"
+	//   - "smartcore.projectrepo.SpecialSensorApi"
+	// These are fetched via reflection and would have identical FullNames on repeated polls.
+
+	// Get some real service descriptors
+	onOffDesc, _ := protoregistry.GlobalFiles.FindDescriptorByName("smartcore.bos.onoff.v1.OnOffApi")
+	meterDesc, _ := protoregistry.GlobalFiles.FindDescriptorByName("smartcore.bos.meter.v1.MeterApi")
+	devicesDesc, _ := protoregistry.GlobalFiles.FindDescriptorByName("smartcore.bos.devices.v1.DevicesApi")
+
+	onOffSvc := onOffDesc.(protoreflect.ServiceDescriptor)
+	meterSvc := meterDesc.(protoreflect.ServiceDescriptor)
+	devicesSvc := devicesDesc.(protoreflect.ServiceDescriptor)
+
+	rn := newRemoteNode("test-node", nil)
+
+	// Initial state: device has standard traits
+	rn.Services.Set(onOffSvc)
+	rn.Services.Set(meterSvc)
+
+	// First reflection poll - same services returned
+	remoteServices := []protoreflect.ServiceDescriptor{onOffSvc, meterSvc}
+	if !servicesEqual(rn, remoteServices) {
+		t.Error("Expected services to be equal on first poll (hot loop prevention)")
+	}
+
+	// Second reflection poll - SAME services but potentially different descriptor instances
+	// In production with custom traits, reflection would return new instances with same FullName
+	// We simulate this by calling FindDescriptorByName again (gets same descriptor from registry)
+	onOffDesc2, _ := protoregistry.GlobalFiles.FindDescriptorByName("smartcore.bos.onoff.v1.OnOffApi")
+	meterDesc2, _ := protoregistry.GlobalFiles.FindDescriptorByName("smartcore.bos.meter.v1.MeterApi")
+	remoteServices2 := []protoreflect.ServiceDescriptor{
+		onOffDesc2.(protoreflect.ServiceDescriptor),
+		meterDesc2.(protoreflect.ServiceDescriptor),
+	}
+	if !servicesEqual(rn, remoteServices2) {
+		t.Error("Expected services to be equal on second poll even with potentially different instances")
+	}
+
+	// Device adds a new trait (simulates custom trait being added)
+	remoteServices3 := []protoreflect.ServiceDescriptor{onOffSvc, meterSvc, devicesSvc}
+	if servicesEqual(rn, remoteServices3) {
+		t.Error("Expected services to be different when new trait added")
+	}
+
+	// Update node state
+	rn.Services.Replace(remoteServices3)
+
+	// Third poll - verify the new state is recognized as equal
+	if !servicesEqual(rn, remoteServices3) {
+		t.Error("Expected services to be equal after update")
+	}
+}
+
 
 func newLocalConn(t *testing.T) (*bufconn.Listener, *grpc.ClientConn) {
 	t.Helper()


### PR DESCRIPTION
Custom traits found in project repositories cause a hot loop as scan cannot distinguish between these identical proto descriptors.
The hot loop caused repeated device announcements which eventually cause long lags in any calls to the edge-gateway.
