### PR TITLE
driver/helvarnet: add controller level health checks

### DIFF
--- a/pkg/driver/bacnet/health.go
+++ b/pkg/driver/bacnet/health.go
@@ -117,6 +117,9 @@ func (c *controllerHealth) register(name string) {
 func (c *controllerHealth) setFailing(ctx context.Context, name string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.states[name] {
+		return
+	}
 	c.states[name] = true
 	c.recalculate(ctx)
 }
@@ -125,6 +128,9 @@ func (c *controllerHealth) setFailing(ctx context.Context, name string) {
 func (c *controllerHealth) setOK(ctx context.Context, name string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if !c.states[name] {
+		return
+	}
 	c.states[name] = false
 	c.recalculate(ctx)
 }

--- a/pkg/driver/helvarnet/config/root.go
+++ b/pkg/driver/helvarnet/config/root.go
@@ -52,6 +52,9 @@ type Root struct {
 	// RetrySleepDuration is the duration to wait before retrying a failed operation, defaults 500 microseconds.
 	// It is unlikely that this value needs to be changed, if it is, it is recommended to keep it low.
 	RetrySleepDuration *jsontypes.Duration `json:"retrySleepDuration,omitempty,omitzero"`
+	// ControllerHealthThreshold is the % of devices on a controller (IP address) that must be
+	// failing before the controller itself is marked unhealthy. Range [0, 100], default 50.
+	ControllerHealthThreshold int `json:"controllerHealthThreshold,omitempty"`
 }
 
 // Device represents a HelvarNet device, which can be a light, lighting group, or PIR sensor.
@@ -132,6 +135,10 @@ func ParseConfig(data []byte) (Root, error) {
 
 	if root.RetrySleepDuration == nil {
 		root.RetrySleepDuration = &jsontypes.Duration{Duration: 500 * time.Microsecond}
+	}
+
+	if root.ControllerHealthThreshold == 0 {
+		root.ControllerHealthThreshold = 50
 	}
 
 	for _, device := range root.EmergencyLights {

--- a/pkg/driver/helvarnet/driver.go
+++ b/pkg/driver/helvarnet/driver.go
@@ -65,6 +65,22 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 	grp, ctx := errgroup.WithContext(ctx)
 	d.clients = make(map[string]*tcpClient)
 	faultChecks := make(map[string]*healthpb.FaultCheck)
+	controllerChecks := make(map[string]*controllerHealth)
+
+	getOrCreateControllerCheck := func(ip string) *controllerHealth {
+		if ch, ok := controllerChecks[ip]; ok {
+			return ch
+		}
+		key := cfg.Name + "/" + ip
+		fc, err := d.health.NewFaultCheck(key, getControllerHealthCheck())
+		if err != nil {
+			d.logger.Error("failed to create controller health check", zap.String("ip", ip), zap.Error(err))
+			return nil
+		}
+		ch := newControllerHealth(fc, cfg.ControllerHealthThreshold)
+		controllerChecks[ip] = ch
+		return ch
+	}
 
 	createFaultCheck := func(name string) *healthpb.FaultCheck {
 		faultCheck, ok := faultChecks[name]
@@ -123,6 +139,10 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 		lum := newLight(d.clients[l.IpAddress], d.logger, l, d.database, false)
 
 		faultCheck := createFaultCheck(l.Name)
+		ctrlHealth := getOrCreateControllerCheck(l.IpAddress)
+		if ctrlHealth != nil {
+			ctrlHealth.register(l.Name)
+		}
 
 		rootAnnouncer.Announce(l.Name,
 			node.HasServer(lightpb.RegisterLightApiServer, lightpb.LightApiServer(lum)),
@@ -131,7 +151,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 			node.HasTrait(udmipb.TraitName),
 			node.HasMetadata(l.Meta))
 		grp.Go(func() error {
-			return lum.queryDevice(ctx, cfg.RefreshStatus.Duration, faultCheck)
+			return lum.queryDevice(ctx, cfg.RefreshStatus.Duration, faultCheck, ctrlHealth)
 		})
 
 	}
@@ -171,6 +191,10 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 		}
 
 		faultCheck := createFaultCheck(em.Name)
+		ctrlHealth := getOrCreateControllerCheck(em.IpAddress)
+		if ctrlHealth != nil {
+			ctrlHealth.register(em.Name)
+		}
 
 		rootAnnouncer.Announce(em.Name,
 			node.HasServer(lightpb.RegisterLightApiServer, lightpb.LightApiServer(emergencyLight)),
@@ -181,7 +205,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 			node.HasTrait(udmipb.TraitName),
 			node.HasMetadata(em.Meta))
 		grp.Go(func() error {
-			return emergencyLight.queryDevice(ctx, cfg.RefreshStatus.Duration, faultCheck)
+			return emergencyLight.queryDevice(ctx, cfg.RefreshStatus.Duration, faultCheck, ctrlHealth)
 		})
 	}
 
@@ -194,6 +218,9 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 		}
 		for _, fc := range faultChecks {
 			fc.Dispose()
+		}
+		for _, ch := range controllerChecks {
+			ch.faultCheck.Dispose()
 		}
 		if err != nil {
 			d.logger.Error("run error", zap.Error(err))

--- a/pkg/driver/helvarnet/health.go
+++ b/pkg/driver/helvarnet/health.go
@@ -2,7 +2,9 @@ package helvarnet
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"sync"
 
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
 )
@@ -12,6 +14,7 @@ const (
 	BadResponseCode       = -2
 	UnrecognisedErrorCode = -100
 	SystemName            = "HelvarNet Lighting"
+	ControllerUnhealthy   = "ControllerUnhealthy"
 )
 
 type State struct {
@@ -117,6 +120,92 @@ func updateDeviceFaults(ctx context.Context, status int64, fc *healthpb.FaultChe
 		} else {
 			setDeviceFaults(statuses, fc)
 		}
+	}
+}
+
+func getControllerHealthCheck() *healthpb.HealthCheck {
+	return &healthpb.HealthCheck{
+		Id:              "controllerStatusCheck",
+		DisplayName:     "Controller Status Check",
+		Description:     "Checks the Helvarnet controller is reachable and a sufficient proportion of its devices are responding",
+		OccupantImpact:  healthpb.HealthCheck_COMFORT,
+		EquipmentImpact: healthpb.HealthCheck_FUNCTION,
+	}
+}
+
+// controllerHealth aggregates per-device health states for a single Helvarnet controller (IP address).
+// When the proportion of failing devices reaches the threshold, the controller's FaultCheck is marked unhealthy.
+type controllerHealth struct {
+	faultCheck *healthpb.FaultCheck
+	threshold  int // [0,100]: % of failing devices that triggers unhealthy
+
+	mu     sync.Mutex
+	states map[string]bool // device name → true if currently failing
+}
+
+func newControllerHealth(fc *healthpb.FaultCheck, threshold int) *controllerHealth {
+	return &controllerHealth{
+		faultCheck: fc,
+		threshold:  threshold,
+		states:     make(map[string]bool),
+	}
+}
+
+// register adds a device to controller tracking. Idempotent — safe to call multiple times.
+func (c *controllerHealth) register(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.states[name]; !exists {
+		c.states[name] = false
+	}
+}
+
+// setFailing marks the named device as failing and recalculates controller health.
+func (c *controllerHealth) setFailing(ctx context.Context, name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.states[name] = true
+	c.recalculate(ctx)
+}
+
+// setOK marks the named device as healthy and recalculates controller health.
+func (c *controllerHealth) setOK(ctx context.Context, name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.states[name] = false
+	c.recalculate(ctx)
+}
+
+// recalculate must be called with c.mu held.
+func (c *controllerHealth) recalculate(ctx context.Context) {
+	total := len(c.states)
+	if total == 0 {
+		return
+	}
+	failing := 0
+	for _, isFailing := range c.states {
+		if isFailing {
+			failing++
+		}
+	}
+	if failing*100/total >= c.threshold {
+		c.faultCheck.UpdateReliability(ctx, &healthpb.HealthCheck_Reliability{
+			State: healthpb.HealthCheck_Reliability_CONN_TRANSIENT_FAILURE,
+			LastError: &healthpb.HealthCheck_Error{
+				SummaryText: fmt.Sprintf("%d/%d devices on controller are failing", failing, total),
+				Code: &healthpb.HealthCheck_Error_Code{
+					Code:   ControllerUnhealthy,
+					System: SystemName,
+				},
+			},
+		})
+	} else {
+		c.faultCheck.RemoveFault(&healthpb.HealthCheck_Error{
+			Code: &healthpb.HealthCheck_Error_Code{
+				Code:   ControllerUnhealthy,
+				System: SystemName,
+			},
+		})
 	}
 }
 

--- a/pkg/driver/helvarnet/health.go
+++ b/pkg/driver/helvarnet/health.go
@@ -164,6 +164,9 @@ func (c *controllerHealth) register(name string) {
 func (c *controllerHealth) setFailing(ctx context.Context, name string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.states[name] {
+		return
+	}
 	c.states[name] = true
 	c.recalculate(ctx)
 }
@@ -172,6 +175,9 @@ func (c *controllerHealth) setFailing(ctx context.Context, name string) {
 func (c *controllerHealth) setOK(ctx context.Context, name string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if !c.states[name] {
+		return
+	}
 	c.states[name] = false
 	c.recalculate(ctx)
 }

--- a/pkg/driver/helvarnet/light.go
+++ b/pkg/driver/helvarnet/light.go
@@ -293,7 +293,7 @@ func (l *Light) refreshData(ctx context.Context) {
 }
 
 // queryDevice runs queries on a schedule to check the statuses of the device.
-func (l *Light) queryDevice(ctx context.Context, t time.Duration, fc *healthpb.FaultCheck) error {
+func (l *Light) queryDevice(ctx context.Context, t time.Duration, fc *healthpb.FaultCheck, ctrlHealth *controllerHealth) error {
 
 	ticker := time.NewTicker(t)
 	defer ticker.Stop()
@@ -311,6 +311,13 @@ func (l *Light) queryDevice(ctx context.Context, t time.Duration, fc *healthpb.F
 			}
 			l.helvarnetStatus = s
 			updateDeviceFaults(ctx, l.helvarnetStatus, fc)
+			if ctrlHealth != nil {
+				if l.helvarnetStatus < 0 {
+					ctrlHealth.setFailing(ctx, l.conf.Name)
+				} else {
+					ctrlHealth.setOK(ctx, l.conf.Name)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
adds controller level health checks which give named checks to IP controllers and report if they are healthy. similar to the recently added ones for the BACnet driver.

<img width="566" height="920" alt="image" src="https://github.com/user-attachments/assets/7495b81b-7e25-4959-afd1-b06d358d902a" />
