### PR TITLE
driver/bacnet: use more common floors/xx/drivers instead of floor-xx/drivers

### DIFF
--- a/pkg/driver/bacnet/write.go
+++ b/pkg/driver/bacnet/write.go
@@ -106,7 +106,7 @@ func writeToDir(dir string, floor string, scPrefix string, bacnetCfg *ConfigForF
 	// copy over any customisations we have made
 	driverCfg = bacnetCfg.Root
 	driverCfg.BaseConfig = driver.BaseConfig{
-		Name: path.Join(scPrefix, fmt.Sprintf("floor-%s", floor), "drivers", subsystem),
+		Name: path.Join(scPrefix, "floors", floor, "drivers", subsystem),
 		Type: DriverName,
 	}
 


### PR DESCRIPTION
we use `floors/xx/drivers` and `floors/xx/devices` etc. more commonly than `floor-%s/drivers`. Change the config writer here to help standardise our naming, the device naming is unchanged.