### PR TITLE
feat/brightness slider

### DIFF
--- a/pkg/proto/lightpb/light.pb.go
+++ b/pkg/proto/lightpb/light.pb.go
@@ -46,7 +46,12 @@ type Brightness struct {
 	// The target level_percent. Ignored on write. On read zero values should be ignored iff target_preset is present.
 	TargetLevelPercent float32 `protobuf:"fixed32,4,opt,name=target_level_percent,json=targetLevelPercent,proto3" json:"target_level_percent,omitempty"`
 	// The target preset. Ignored on write. If present ignore target_level_percent
-	TargetPreset  *LightPreset `protobuf:"bytes,5,opt,name=target_preset,json=targetPreset,proto3" json:"target_preset,omitempty"`
+	TargetPreset *LightPreset `protobuf:"bytes,5,opt,name=target_preset,json=targetPreset,proto3" json:"target_preset,omitempty"`
+	// The confidence in the reported level_percent as a percentage. [0-100].
+	// Absent means confidence is not reported; treat the level as fully confident.
+	// A value of 0 means the level is unknown.
+	// Values below 20 indicate low confidence and the level should be shown with a caveat.
+	Confidence    *float32 `protobuf:"fixed32,6,opt,name=confidence,proto3,oneof" json:"confidence,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -114,6 +119,13 @@ func (x *Brightness) GetTargetPreset() *LightPreset {
 		return x.TargetPreset
 	}
 	return nil
+}
+
+func (x *Brightness) GetConfidence() float32 {
+	if x != nil && x.Confidence != nil {
+		return *x.Confidence
+	}
+	return 0
 }
 
 type LightPreset struct {
@@ -594,14 +606,18 @@ var File_smartcore_bos_light_v1_light_proto protoreflect.FileDescriptor
 
 const file_smartcore_bos_light_v1_light_proto_rawDesc = "" +
 	"\n" +
-	"\"smartcore/bos/light/v1/light.proto\x12\x16smartcore.bos.light.v1\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!smartcore/bos/types/v1/info.proto\x1a#smartcore/bos/types/v1/number.proto\x1a\"smartcore/bos/types/v1/tween.proto\"\xb4\x02\n" +
+	"\"smartcore/bos/light/v1/light.proto\x12\x16smartcore.bos.light.v1\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!smartcore/bos/types/v1/info.proto\x1a#smartcore/bos/types/v1/number.proto\x1a\"smartcore/bos/types/v1/tween.proto\"\xe8\x02\n" +
 	"\n" +
 	"Brightness\x12#\n" +
 	"\rlevel_percent\x18\x01 \x01(\x02R\flevelPercent\x12;\n" +
 	"\x06preset\x18\x02 \x01(\v2#.smartcore.bos.light.v1.LightPresetR\x06preset\x12H\n" +
 	"\x10brightness_tween\x18\x03 \x01(\v2\x1d.smartcore.bos.types.v1.TweenR\x0fbrightnessTween\x120\n" +
 	"\x14target_level_percent\x18\x04 \x01(\x02R\x12targetLevelPercent\x12H\n" +
-	"\rtarget_preset\x18\x05 \x01(\v2#.smartcore.bos.light.v1.LightPresetR\ftargetPreset\"7\n" +
+	"\rtarget_preset\x18\x05 \x01(\v2#.smartcore.bos.light.v1.LightPresetR\ftargetPreset\x12#\n" +
+	"\n" +
+	"confidence\x18\x06 \x01(\x02H\x00R\n" +
+	"confidence\x88\x01\x01B\r\n" +
+	"\v_confidence\"7\n" +
 	"\vLightPreset\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05title\x18\x02 \x01(\tR\x05title\"\x84\x02\n" +
@@ -706,6 +722,7 @@ func file_smartcore_bos_light_v1_light_proto_init() {
 	if File_smartcore_bos_light_v1_light_proto != nil {
 		return
 	}
+	file_smartcore_bos_light_v1_light_proto_msgTypes[0].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/proto/smartcore/bos/light/v1/light.proto
+++ b/proto/smartcore/bos/light/v1/light.proto
@@ -52,6 +52,12 @@ message Brightness {
   float target_level_percent = 4;
   // The target preset. Ignored on write. If present ignore target_level_percent
   LightPreset target_preset = 5;
+
+  // The confidence in the reported level_percent as a percentage. [0-100].
+  // Absent means confidence is not reported; treat the level as fully confident.
+  // A value of 0 means the level is unknown.
+  // Values below 20 indicate low confidence and the level should be shown with a caveat.
+  optional float confidence = 6;
 }
 
 message LightPreset {

--- a/ui/ops/src/traits/airTemperature/AirTemperatureCard.vue
+++ b/ui/ops/src/traits/airTemperature/AirTemperatureCard.vue
@@ -9,30 +9,23 @@
         </template>
       </v-list-item>
     </v-list>
-    <v-progress-linear
-        height="34"
+    <v-slider
         class="mx-4 my-2"
-        :model-value="tempProgress"
-        bg-color="neutral-lighten-1"
-        bg-opacity="1"
-        color="accent"/>
-    <v-card-actions class="px-4">
-      <v-spacer/>
-      <v-btn
-          size="small"
-          variant="tonal"
-          @click="changeSetPoint(-0.5)"
-          :disabled="blockActions || (props.value?.temperatureSetPoint === undefined)">
-        Down
-      </v-btn>
-      <v-btn
-          size="small"
-          variant="tonal"
-          @click="changeSetPoint(0.5)"
-          :disabled="blockActions || (props.value?.temperatureSetPoint === undefined)">
-        Up
-      </v-btn>
-    </v-card-actions>
+        color="accent"
+        track-color="neutral-lighten-1"
+        :disabled="blockActions || setPoint === undefined"
+        hide-details
+        :min="tempRange.low"
+        :max="tempRange.high"
+        :step="0.5"
+        v-model="sliderSetPoint">
+      <template #prepend>
+        <v-icon>mdi-thermometer</v-icon>
+      </template>
+      <template #append>
+        <span class="text-body-1 slider-label">{{ sliderSetPointStr }}</span>
+      </template>
+    </v-slider>
     <v-progress-linear color="primary" indeterminate :active="updateValue.loading"/>
   </v-card>
 </template>
@@ -42,7 +35,8 @@ import {newActionTracker} from '@/api/resource';
 import useAuthSetup from '@/composables/useAuthSetup';
 import {useAirTemperature} from '@/traits/airTemperature/airTemperature.js';
 import {camelToSentence} from '@/util/string';
-import {reactive} from 'vue';
+import debounce from 'debounce';
+import {computed, reactive, ref, watch} from 'vue';
 
 const {blockActions} = useAuthSetup();
 
@@ -61,20 +55,30 @@ const emit = defineEmits([
 ]);
 
 const {
-  tempProgress,
+  setPoint,
+  tempRange,
   airTempData
 } = useAirTemperature(() => props.value);
 
 const updateValue = reactive(newActionTracker());
 
-/**
- * @param {number} value
- */
-function changeSetPoint(value) {
-  if (props.value?.temperatureSetPoint?.valueCelsius !== undefined) {
-    emit('updateAirTemperature', props.value.temperatureSetPoint.valueCelsius + value);
+// Local ref for optimistic slider updates — syncs from server but not while user is dragging
+const localSetPoint = ref(setPoint.value ?? tempRange.value.low);
+watch(setPoint, (v) => { if (v !== undefined) localSetPoint.value = v; }, {immediate: true});
+
+const emitSetPointDebounced = debounce((v) => emit('updateAirTemperature', v), 200);
+
+const sliderSetPoint = computed({
+  get: () => localSetPoint.value,
+  set: (v) => {
+    localSetPoint.value = v;
+    emitSetPointDebounced(v);
   }
-}
+});
+
+const sliderSetPointStr = computed(() => {
+  return setPoint.value !== undefined ? localSetPoint.value.toFixed(1) + '°C' : '-';
+});
 
 </script>
 
@@ -83,7 +87,8 @@ function changeSetPoint(value) {
   min-height: auto;
 }
 
-.v-progress-linear {
-  width: auto;
+.slider-label {
+  min-width: 4em;
+  text-align: right;
 }
 </style>

--- a/ui/ops/src/traits/light/LightCard.vue
+++ b/ui/ops/src/traits/light/LightCard.vue
@@ -21,7 +21,13 @@
         <v-icon>{{ icon }}</v-icon>
       </template>
       <template #append>
-        <span class="text-body-1 slider-label">{{ levelStr }}</span>
+        <v-tooltip v-if="lowConfidence" location="top">
+          <template #activator="{ props: tooltipProps }">
+            <span v-bind="tooltipProps" class="text-body-1 slider-label">{{ levelStr }}*</span>
+          </template>
+          Low confidence reading
+        </v-tooltip>
+        <span v-else class="text-body-1 slider-label">{{ levelStr }}</span>
       </template>
     </v-slider>
     <v-card-actions class="px-4">
@@ -86,7 +92,7 @@ const props = defineProps({
 const {value, loading: pullLoading} = usePullBrightness(() => props.name);
 const {response: support, loading: supportLoading} = useDescribeBrightness(() => props.name);
 const {updateBrightness, loading: updateLoading} = useUpdateBrightness(() => props.name);
-const {levelStr, level, icon, presets, currentPresetTitle} = useBrightness(value, support);
+const {levelStr, level, icon, lowConfidence, presets, currentPresetTitle} = useBrightness(value, support);
 
 const loading = computed(() => pullLoading.value || supportLoading.value || updateLoading.value);
 

--- a/ui/ops/src/traits/light/LightCard.vue
+++ b/ui/ops/src/traits/light/LightCard.vue
@@ -5,21 +5,28 @@
       <v-list-subheader class="text-title-caps-large text-neutral-lighten-3">Lighting</v-list-subheader>
       <v-list-item class="py-1">
         <v-list-item-title class="text-body-small text-capitalize">Brightness</v-list-item-title>
-        <template #append>
-          <v-list-item-subtitle class="text-capitalize text-body-1">{{ levelStr }}</v-list-item-subtitle>
-        </template>
       </v-list-item>
     </v-list>
-    <v-progress-linear
-        height="34"
+    <v-slider
         class="mx-4 my-2"
-        :model-value="level"
-        bg-color="neutral-lighten-1"
-        bg-opacity="1"
-        color="accent"/>
+        color="accent"
+        track-color="neutral-lighten-1"
+        :disabled="blockActions || !value"
+        hide-details
+        :min="0"
+        :max="100"
+        :step="1"
+        v-model="sliderBrightness">
+      <template #prepend>
+        <v-icon>{{ icon }}</v-icon>
+      </template>
+      <template #append>
+        <span class="text-body-1 slider-label">{{ levelStr }}</span>
+      </template>
+    </v-slider>
     <v-card-actions class="px-4">
       <v-btn
-          v-for="control in brightnessControl.left"
+          v-for="control in brightnessControl"
           :disabled="control.disabled"
           :key="control.label"
           size="small"
@@ -28,15 +35,6 @@
         {{ control.label }}
       </v-btn>
       <v-spacer/>
-      <v-btn
-          v-for="control in brightnessControl.right"
-          :disabled="control.disabled"
-          :key="control.label"
-          size="small"
-          variant="tonal"
-          @click="control.onClick">
-        {{ control.label }}
-      </v-btn>
     </v-card-actions>
 
     <!-- Presets -->
@@ -74,7 +72,8 @@ import {
   usePullBrightness,
   useUpdateBrightness
 } from '@/traits/light/light.js';
-import {computed} from 'vue';
+import debounce from 'debounce';
+import {computed, ref, watch} from 'vue';
 
 const {blockActions} = useAuthSetup();
 const props = defineProps({
@@ -87,9 +86,23 @@ const props = defineProps({
 const {value, loading: pullLoading} = usePullBrightness(() => props.name);
 const {response: support, loading: supportLoading} = useDescribeBrightness(() => props.name);
 const {updateBrightness, loading: updateLoading} = useUpdateBrightness(() => props.name);
-const {levelStr, level, presets, currentPresetTitle} = useBrightness(value, support);
+const {levelStr, level, icon, presets, currentPresetTitle} = useBrightness(value, support);
 
 const loading = computed(() => pullLoading.value || supportLoading.value || updateLoading.value);
+
+// Local ref for optimistic slider updates — syncs from server but not while user is dragging
+const localLevel = ref(0);
+watch(level, (v) => { localLevel.value = v; }, {immediate: true});
+
+const updateBrightnessDebounced = debounce((v) => updateBrightness(v), 200);
+
+const sliderBrightness = computed({
+  get: () => localLevel.value,
+  set: (v) => {
+    localLevel.value = v;
+    updateBrightnessDebounced(v);
+  }
+});
 
 /**
  * @param {string} title
@@ -101,18 +114,6 @@ function getColor(title, currentPresetTitle) {
 }
 
 /**
- * Update the brightness level.
- *
- * @param {number} level
- * @return {Promise<Brightness.AsObject>}
- */
-function updateBrightnessLevel(level) {
-  return updateBrightness(level);
-}
-
-/**
- * Update the brightness preset.
- *
  * @param {LightPreset.AsObject} preset
  * @return {Promise<Brightness.AsObject>}
  */
@@ -120,34 +121,24 @@ function updateBrightnessPreset(preset) {
   return updateBrightness({preset: preset});
 }
 
-const brightnessControl = computed(() => {
-  return {
-    left: [
-      {
-        disabled: blockActions.value,
-        label: 'On',
-        onClick: () => updateBrightnessLevel(100)
-      },
-      {
-        disabled: blockActions.value,
-        label: 'Off',
-        onClick: () => updateBrightnessLevel(0)
-      }
-    ],
-    right: [
-      {
-        disabled: blockActions.value || level.value >= 100,
-        label: 'Up',
-        onClick: () => updateBrightnessLevel(level.value + 1)
-      },
-      {
-        disabled: blockActions.value || level.value <= 0,
-        label: 'Down',
-        onClick: () => updateBrightnessLevel(level.value - 1)
-      }
-    ]
-  };
-});
+const brightnessControl = computed(() => [
+  {
+    disabled: blockActions.value,
+    label: 'On',
+    onClick: () => {
+      localLevel.value = 100;
+      updateBrightness(100);
+    }
+  },
+  {
+    disabled: blockActions.value,
+    label: 'Off',
+    onClick: () => {
+      localLevel.value = 0;
+      updateBrightness(0);
+    }
+  }
+]);
 </script>
 
 <style lang="scss" scoped>
@@ -155,8 +146,9 @@ const brightnessControl = computed(() => {
   min-height: auto;
 }
 
-.v-progress-linear {
-  width: auto;
+.slider-label {
+  min-width: 3em;
+  text-align: right;
 }
 
 .preset :deep(.v-btn__content) {

--- a/ui/ops/src/traits/light/light.js
+++ b/ui/ops/src/traits/light/light.js
@@ -118,6 +118,8 @@ export function useUpdateBrightness(name) {
  *   level: ComputedRef<number>,
  *   levelStr: ComputedRef<string>,
  *   icon: ComputedRef<string>,
+ *   confidence: ComputedRef<number|null>,
+ *   lowConfidence: ComputedRef<boolean>,
  *   presets: ComputedRef<Array<LightPreset.AsObject>>
  * }}
  */
@@ -128,9 +130,18 @@ export function useBrightness(value, support = null) {
   /** @type {ComputedRef<number>} */
   const level = computed(() => _v.value?.levelPercent || 0);
 
+  // null = omitted (no confidence reported), 0 = unknown, 1-100 = percentage confidence
+  /** @type {ComputedRef<number|null>} */
+  const confidence = computed(() => _v.value?.confidence ?? null);
+
+  /** @type {ComputedRef<boolean>} */
+  const lowConfidence = computed(() => confidence.value !== null && confidence.value > 0 && confidence.value < 20);
+
   /** @type {ComputedRef<string>} */
   const levelStr = computed(() => {
-    if (level.value === 0) {
+    if (confidence.value === 0) {
+      return 'Unknown';
+    } else if (level.value === 0) {
       return 'Off';
     } else if (level.value === 100) {
       return 'Max';
@@ -167,6 +178,8 @@ export function useBrightness(value, support = null) {
     level,
     levelStr,
     icon,
+    confidence,
+    lowConfidence,
     presets,
     currentPresetTitle
   };

--- a/ui/ui-gen/proto/smartcore/bos/light/v1/light_pb.d.ts
+++ b/ui/ui-gen/proto/smartcore/bos/light/v1/light_pb.d.ts
@@ -29,6 +29,11 @@ export class Brightness extends jspb.Message {
   hasTargetPreset(): boolean;
   clearTargetPreset(): Brightness;
 
+  getConfidence(): number;
+  setConfidence(value: number): Brightness;
+  hasConfidence(): boolean;
+  clearConfidence(): Brightness;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): Brightness.AsObject;
   static toObject(includeInstance: boolean, msg: Brightness): Brightness.AsObject;
@@ -44,7 +49,13 @@ export namespace Brightness {
     brightnessTween?: smartcore_bos_types_v1_tween_pb.Tween.AsObject;
     targetLevelPercent: number;
     targetPreset?: LightPreset.AsObject;
+    confidence?: number;
   };
+
+  export enum ConfidenceCase {
+    _CONFIDENCE_NOT_SET = 0,
+    CONFIDENCE = 6,
+  }
 }
 
 export class LightPreset extends jspb.Message {

--- a/ui/ui-gen/proto/smartcore/bos/light/v1/light_pb.js
+++ b/ui/ui-gen/proto/smartcore/bos/light/v1/light_pb.js
@@ -259,7 +259,8 @@ levelPercent: jspb.Message.getFloatingPointFieldWithDefault(msg, 1, 0.0),
 preset: (f = msg.getPreset()) && proto.smartcore.bos.light.v1.LightPreset.toObject(includeInstance, f),
 brightnessTween: (f = msg.getBrightnessTween()) && smartcore_bos_types_v1_tween_pb.Tween.toObject(includeInstance, f),
 targetLevelPercent: jspb.Message.getFloatingPointFieldWithDefault(msg, 4, 0.0),
-targetPreset: (f = msg.getTargetPreset()) && proto.smartcore.bos.light.v1.LightPreset.toObject(includeInstance, f)
+targetPreset: (f = msg.getTargetPreset()) && proto.smartcore.bos.light.v1.LightPreset.toObject(includeInstance, f),
+confidence: (f = jspb.Message.getOptionalFloatingPointField(msg, 6)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -318,6 +319,10 @@ proto.smartcore.bos.light.v1.Brightness.deserializeBinaryFromReader = function(m
       var value = new proto.smartcore.bos.light.v1.LightPreset;
       reader.readMessage(value,proto.smartcore.bos.light.v1.LightPreset.deserializeBinaryFromReader);
       msg.setTargetPreset(value);
+      break;
+    case 6:
+      var value = /** @type {number} */ (reader.readFloat());
+      msg.setConfidence(value);
       break;
     default:
       reader.skipField();
@@ -384,6 +389,13 @@ proto.smartcore.bos.light.v1.Brightness.serializeBinaryToWriter = function(messa
       5,
       f,
       proto.smartcore.bos.light.v1.LightPreset.serializeBinaryToWriter
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 6));
+  if (f != null) {
+    writer.writeFloat(
+      6,
+      f
     );
   }
 };
@@ -533,6 +545,42 @@ proto.smartcore.bos.light.v1.Brightness.prototype.clearTargetPreset = function()
  */
 proto.smartcore.bos.light.v1.Brightness.prototype.hasTargetPreset = function() {
   return jspb.Message.getField(this, 5) != null;
+};
+
+
+/**
+ * optional float confidence = 6;
+ * @return {number}
+ */
+proto.smartcore.bos.light.v1.Brightness.prototype.getConfidence = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 6, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.smartcore.bos.light.v1.Brightness} returns this
+ */
+proto.smartcore.bos.light.v1.Brightness.prototype.setConfidence = function(value) {
+  return jspb.Message.setField(this, 6, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.smartcore.bos.light.v1.Brightness} returns this
+ */
+proto.smartcore.bos.light.v1.Brightness.prototype.clearConfidence = function() {
+  return jspb.Message.setField(this, 6, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.light.v1.Brightness.prototype.hasConfidence = function() {
+  return jspb.Message.getField(this, 6) != null;
 };
 
 


### PR DESCRIPTION
- replaces the read only progress bars on light & air temp cards with sliders
- adds a `confidence` field to the light trait & light card to handle 'unknown' or 'stale' brightness, meant for pub/sub integrations where we can't poll