### PR TITLE
fix(bacnet/health): improve BACnet device health checks and UI

### DIFF
--- a/pkg/driver/bacnet/comm/value.go
+++ b/pkg/driver/bacnet/comm/value.go
@@ -250,6 +250,11 @@ func IntValue(data any) (int64, error) {
 	switch v := data.(type) {
 	case error:
 		return 0, v
+	case bool:
+		if v {
+			return 1, nil
+		}
+		return 0, nil
 	case uint8:
 		return int64(v), nil
 	case uint16:

--- a/pkg/driver/bacnet/config/traits.go
+++ b/pkg/driver/bacnet/config/traits.go
@@ -39,6 +39,16 @@ type Trait struct {
 	// Each trait can have its own health check configuration.
 	// If not configured, occupant and equipment impact will default to UNSPECIFIED.
 	Health Health `json:"health"`
+	// PollKeepAlive is the interval between background keep-alive polls when no listeners are active.
+	// Defaults to 5m.
+	PollKeepAlive *Duration `json:"pollKeepAlive,omitempty"`
+}
+
+func (t *Trait) PollKeepAliveDuration() time.Duration {
+	if t.PollKeepAlive != nil && t.PollKeepAlive.Duration != 0 {
+		return t.PollKeepAlive.Duration
+	}
+	return 5 * time.Minute
 }
 
 func (t *Trait) PollPeriodDuration() time.Duration {

--- a/pkg/driver/bacnet/driver.go
+++ b/pkg/driver/bacnet/driver.go
@@ -319,6 +319,10 @@ func (d *Driver) configureDevice(ctx context.Context, rootAnnouncer node.Announc
 		return fmt.Errorf("device comm handshake: %w", ctxerr.Cause(ctx, err))
 	}
 
+	if deviceHealth != nil {
+		deviceHealth.MarkRunning()
+	}
+
 	// For WhoIs-discovered devices the controller IP is only known after findDevice succeeds.
 	if ctrlHealth == nil {
 		if udpAddr, addrErr := bacDevice.Addr.UDPAddr(); addrErr == nil {

--- a/pkg/driver/bacnet/driver.go
+++ b/pkg/driver/bacnet/driver.go
@@ -262,6 +262,9 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 			announcer = node.AnnounceFeatures(announcer, node.HasMetadata(trait.Metadata))
 		}
 		impl.AnnounceSelf(announcer)
+		if p, ok := impl.(merge.PollTaskProvider); ok {
+			p.PollTask().IdleKeepAlive(ctx, trait.PollKeepAliveDuration(), time.Minute)
+		}
 
 		d.checks = append(d.checks, faultCheck)
 	}

--- a/pkg/driver/bacnet/merge/access.go
+++ b/pkg/driver/bacnet/merge/access.go
@@ -182,3 +182,5 @@ func (a *access) GetAccessGrant(context.Context, *accesspb.GetAccessGrantsReques
 func (a *access) ListAccessGrants(context.Context, *accesspb.ListAccessGrantsRequest) (*accesspb.ListAccessGrantsResponse, error) {
 	return nil, errors.New("method ListAccessGrants not implemented")
 }
+
+func (a *access) PollTask() *task.Intermittent { return a.pollTask }

--- a/pkg/driver/bacnet/merge/air_quality.go
+++ b/pkg/driver/bacnet/merge/air_quality.go
@@ -183,3 +183,5 @@ func (aq *airQualitySensor) pollPeer(ctx context.Context) (*airqualitysensorpb.A
 	}
 	return aq.model.UpdateAirQuality(data)
 }
+
+func (aq *airQualitySensor) PollTask() *task.Intermittent { return aq.pollTask }

--- a/pkg/driver/bacnet/merge/air_temperature.go
+++ b/pkg/driver/bacnet/merge/air_temperature.go
@@ -356,3 +356,5 @@ func updateMode(modeCfg *airTempModeConfig, data *modeDataPoints, airTemp *airte
 
 	airTemp.Mode = m
 }
+
+func (t *airTemperature) PollTask() *task.Intermittent { return t.pollTask }

--- a/pkg/driver/bacnet/merge/electric.go
+++ b/pkg/driver/bacnet/merge/electric.go
@@ -246,3 +246,5 @@ func (t *electricTrait) pollPeer(ctx context.Context) (*electricpb.ElectricDeman
 
 	return t.model.UpdateDemand(dst)
 }
+
+func (t *electricTrait) PollTask() *task.Intermittent { return t.pollTask }

--- a/pkg/driver/bacnet/merge/emergency.go
+++ b/pkg/driver/bacnet/merge/emergency.go
@@ -198,3 +198,5 @@ func (t *emergencyImpl) pollPeer(ctx context.Context) (*emergencypb.Emergency, e
 
 	return t.model.UpdateEmergency(ctx, &emergencypb.UpdateEmergencyRequest{Emergency: data})
 }
+
+func (t *emergencyImpl) PollTask() *task.Intermittent { return t.pollTask }

--- a/pkg/driver/bacnet/merge/energy_storage.go
+++ b/pkg/driver/bacnet/merge/energy_storage.go
@@ -141,3 +141,5 @@ func (e *energyStorage) pollPeer(ctx context.Context) (*energystoragepb.EnergyLe
 
 	return e.model.UpdateEnergyLevel(data)
 }
+
+func (e *energyStorage) PollTask() *task.Intermittent { return e.pollTask }

--- a/pkg/driver/bacnet/merge/fan_speed.go
+++ b/pkg/driver/bacnet/merge/fan_speed.go
@@ -139,3 +139,5 @@ func (t *fanSpeed) pollPeer(ctx context.Context) (*fanspeedpb.FanSpeed, error) {
 	}
 	return t.model.UpdateFanSpeed(data)
 }
+
+func (t *fanSpeed) PollTask() *task.Intermittent { return t.pollTask }

--- a/pkg/driver/bacnet/merge/health.go
+++ b/pkg/driver/bacnet/merge/health.go
@@ -27,17 +27,14 @@ type healthConfig struct {
 type CheckConfig struct {
 	config.HealthCheck
 	Source *config.ValueSource `json:"source,omitempty"`
-	// If true, and measured value is true, the alarm is active.
-	// If false, and measured value is false, the alarm is active.
+	// Deprecated: use OKValue instead. Kept for JSON backwards compatibility;
+	// converted to OKValue=0 (activeHigh: true) or OKValue=1 (activeHigh: false) during config parsing if OKValue is not set.
 	ActiveHigh *bool  `json:"activeHigh,omitempty"`
 	Summary    string `json:"summary,omitempty"`
-	// OKValue switches the check to error code mode. The BACnet point value is read as an
-	// integer and compared to OKValue. If they differ, a fault is raised with the actual
-	// read value surfaced in the description. Takes precedence over ActiveHigh when set.
+	// OKValue is the expected integer value of the BACnet point. If the read value differs,
+	// a fault is raised with the actual value surfaced in the description.
 	OKValue *int64 `json:"okValue,omitempty"`
 }
-
-const defaultActiveHigh = true
 
 func readHealthConfig(raw []byte) (cfg healthConfig, err error) {
 	err = json.Unmarshal(raw, &cfg)
@@ -52,9 +49,13 @@ func readHealthConfig(raw []byte) (cfg healthConfig, err error) {
 		if check.Source == nil {
 			return cfg, fmt.Errorf("health check %q is missing required field 'source'", name)
 		}
-		if check.OKValue == nil && check.ActiveHigh == nil {
-			check.ActiveHigh = new(bool)
-			*check.ActiveHigh = defaultActiveHigh
+		if check.OKValue == nil {
+			okVal := int64(0)
+			if check.ActiveHigh != nil && !*check.ActiveHigh {
+				// activeHigh: false means fault when point reads low (0), so OK value is 1.
+				okVal = 1
+			}
+			check.OKValue = &okVal
 		}
 	}
 	return
@@ -145,30 +146,6 @@ func (h *Health) pollPeer(ctx context.Context) error {
 	var readValues []config.ValueSource
 	var requestNames []string
 
-	readProcessor := func(source *config.ValueSource, activeHigh bool, id, pointName, errorCode, summary string) {
-		readValues = append(readValues, *source)
-		requestNames = append(requestNames, pointName)
-		resProcessors = append(resProcessors, func(response any) error {
-			measured, err := comm.BoolValue(response)
-			if err != nil {
-				return comm.ErrReadProperty{Prop: pointName, Cause: err}
-			}
-
-			if measured == activeHigh {
-				if check, ok := h.DeviceChecks[id]; ok {
-					raisePointAlarm(pointName, errorCode, summary, fmt.Sprintf("%v", response), check)
-				} else {
-					h.logger.Warn("no fault check configured for " + pointName)
-				}
-			} else {
-				if check, ok := h.DeviceChecks[id]; ok {
-					removePointAlarm(errorCode, check)
-				}
-			}
-			return nil
-		})
-	}
-
 	readErrorCodeProcessor := func(source *config.ValueSource, okValue int64, id, pointName, errorCode, summary string) {
 		readValues = append(readValues, *source)
 		requestNames = append(requestNames, pointName)
@@ -183,7 +160,7 @@ func (h *Health) pollPeer(ctx context.Context) error {
 				return nil
 			}
 			if val != okValue {
-				raisePointAlarm(pointName, errorCode, summary, fmt.Sprintf("%d", val), check)
+				raisePointAlarm(pointName, errorCode, summary, fmt.Sprintf("%d (expected: %d)", val, okValue), check)
 			} else {
 				removePointAlarm(errorCode, check)
 			}
@@ -196,11 +173,7 @@ func (h *Health) pollPeer(ctx context.Context) error {
 		if summary == "" {
 			summary = "Error Detected"
 		}
-		if checkCfg.OKValue != nil {
-			readErrorCodeProcessor(checkCfg.Source, *checkCfg.OKValue, checkCfg.Id, checkCfg.DisplayName, checkCfg.ErrorCode, summary)
-		} else {
-			readProcessor(checkCfg.Source, *checkCfg.ActiveHigh, checkCfg.Id, checkCfg.DisplayName, checkCfg.ErrorCode, summary)
-		}
+		readErrorCodeProcessor(checkCfg.Source, *checkCfg.OKValue, checkCfg.Id, checkCfg.DisplayName, checkCfg.ErrorCode, summary)
 	}
 
 	responses := comm.ReadProperties(ctx, h.client, h.known, readValues...)

--- a/pkg/driver/bacnet/merge/light.go
+++ b/pkg/driver/bacnet/merge/light.go
@@ -224,3 +224,5 @@ func (l *light) findSceneByName(name string) (*sceneCfg, error) {
 	}
 	return nil, errSceneNotFound
 }
+
+func (l *light) PollTask() *task.Intermittent { return l.pollTask }

--- a/pkg/driver/bacnet/merge/meter.go
+++ b/pkg/driver/bacnet/merge/meter.go
@@ -127,3 +127,5 @@ func (t *meterTrait) pollPeer(ctx context.Context) (*meterpb.MeterReading, error
 	}
 	return t.model.UpdateMeterReading(data)
 }
+
+func (t *meterTrait) PollTask() *task.Intermittent { return t.pollTask }

--- a/pkg/driver/bacnet/merge/mode.go
+++ b/pkg/driver/bacnet/merge/mode.go
@@ -238,3 +238,5 @@ func newModeInfoServer(cfg modeConfig) *modepb.InfoServer {
 		},
 	}
 }
+
+func (t *mode) PollTask() *task.Intermittent { return t.pollTask }

--- a/pkg/driver/bacnet/merge/occupancy.go
+++ b/pkg/driver/bacnet/merge/occupancy.go
@@ -133,3 +133,5 @@ func (o *occupancy) pollPeer(ctx context.Context) (*occupancysensorpb.Occupancy,
 
 	return o.model.SetOccupancy(data)
 }
+
+func (o *occupancy) PollTask() *task.Intermittent { return o.pollTask }

--- a/pkg/driver/bacnet/merge/on_off.go
+++ b/pkg/driver/bacnet/merge/on_off.go
@@ -156,3 +156,5 @@ func (o *onOff) pollPeer(ctx context.Context) (*onoffpb.OnOff, error) {
 	}
 	return o.model.UpdateOnOff(data)
 }
+
+func (o *onOff) PollTask() *task.Intermittent { return o.pollTask }

--- a/pkg/driver/bacnet/merge/securityevent.go
+++ b/pkg/driver/bacnet/merge/securityevent.go
@@ -273,3 +273,5 @@ func (se *securityEvent) cfgDefaults(data *securityeventpb.SecurityEvent) {
 		}
 	}
 }
+
+func (s *securityEventImpl) PollTask() *task.Intermittent { return s.pollTask }

--- a/pkg/driver/bacnet/merge/sound_sensor.go
+++ b/pkg/driver/bacnet/merge/sound_sensor.go
@@ -126,3 +126,5 @@ func (s *soundSensor) pollPeer(ctx context.Context) (*soundsensorpb.SoundLevel, 
 	}
 	return s.model.UpdateSoundLevel(data)
 }
+
+func (s *soundSensor) PollTask() *task.Intermittent { return s.pollTask }

--- a/pkg/driver/bacnet/merge/temperature.go
+++ b/pkg/driver/bacnet/merge/temperature.go
@@ -153,3 +153,5 @@ func (t *temperature) pollPeer(ctx context.Context) (*temperaturepb.Temperature,
 	}
 	return t.model.UpdateTemperature(data)
 }
+
+func (t *temperature) PollTask() *task.Intermittent { return t.pollTask }

--- a/pkg/driver/bacnet/merge/trait.go
+++ b/pkg/driver/bacnet/merge/trait.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/driver/bacnet/config"
 	"github.com/smart-core-os/sc-bos/pkg/driver/bacnet/known"
 	"github.com/smart-core-os/sc-bos/pkg/node"
+	"github.com/smart-core-os/sc-bos/pkg/task"
 	"github.com/smart-core-os/sc-bos/pkg/proto/accesspb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/meterpb"
@@ -114,4 +115,10 @@ func removePointAlarm(code string, fc *healthpb.FaultCheck) {
 			Code: code,
 		},
 	})
+}
+
+// PollTaskProvider is implemented by traits that expose their background poll task,
+// allowing the driver to attach keepalive behaviour independently of client subscriptions.
+type PollTaskProvider interface {
+	PollTask() *task.Intermittent
 }

--- a/pkg/driver/bacnet/merge/transport.go
+++ b/pkg/driver/bacnet/merge/transport.go
@@ -494,3 +494,5 @@ func (t *transport) PullTransport(request *transportpb.PullTransportRequest, ser
 	}
 	return t.ModelServer.PullTransport(request, server)
 }
+
+func (t *transport) PollTask() *task.Intermittent { return t.pollTask }

--- a/pkg/driver/bacnet/merge/udmi.go
+++ b/pkg/driver/bacnet/merge/udmi.go
@@ -268,3 +268,5 @@ func (f *udmiMerge) pointsToPointSet(points udmi.PointsEvent) (*udmipb.MqttMessa
 		Payload: string(b),
 	}, nil
 }
+
+func (f *udmiMerge) PollTask() *task.Intermittent { return f.pollTask }

--- a/pkg/task/intermittent.go
+++ b/pkg/task/intermittent.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"sync"
+	"time"
 )
 
 // StartFn is called by an Intermittent to start a background operation.
@@ -68,4 +69,33 @@ func (t *Intermittent) Attach(listener context.Context) error {
 	}()
 
 	return nil
+}
+
+// IdleKeepAlive immediately runs the operation once for runFor, then re-runs it
+// every idleFor thereafter, ensuring the operation stays fresh even with no active listeners.
+// If listeners are already attached when a run starts, Attach is a no-op increment
+// and the running operation is unaffected.
+// Runs until ctx is done.
+func (t *Intermittent) IdleKeepAlive(ctx context.Context, idleFor, runFor time.Duration) {
+	go func() {
+		t.runOnce(ctx, runFor)
+		timer := time.NewTimer(idleFor)
+		defer timer.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				t.runOnce(ctx, runFor)
+				timer.Reset(idleFor)
+			}
+		}
+	}()
+}
+
+func (t *Intermittent) runOnce(ctx context.Context, runFor time.Duration) {
+	attachCtx, cancel := context.WithTimeout(ctx, runFor)
+	defer cancel()
+	_ = t.Attach(attachCtx)
+	<-attachCtx.Done()
 }

--- a/ui/ops/src/traits/health/FaultsText.vue
+++ b/ui/ops/src/traits/health/FaultsText.vue
@@ -1,0 +1,41 @@
+<template>
+  <div v-if="faults.length > 0" class="fault-list">
+    <div v-for="(fault, i) in faults" :key="i" class="fault-item">
+      <v-tooltip v-if="fault.detailsText" :text="fault.detailsText" location="top" max-width="400">
+        <template #activator="{ props: tipProps }">
+          <span v-bind="tipProps" class="text-error fault-summary">
+            {{ fault.summaryText || fault.code?.code || 'Fault' }}
+          </span>
+        </template>
+      </v-tooltip>
+      <span v-else class="text-error">{{ fault.summaryText || fault.code?.code || 'Fault' }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import {computed} from 'vue';
+
+const props = defineProps({
+  modelValue: {
+    /** @type {import('vue').PropType<import('@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/health/v1/health_pb').HealthCheck.AsObject>} */
+    type: Object,
+    default: null
+  }
+});
+
+const faults = computed(() => props.modelValue?.faults?.currentFaultsList ?? []);
+</script>
+
+<style scoped>
+.fault-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.fault-summary {
+  cursor: help;
+  text-decoration: underline dotted;
+}
+</style>

--- a/ui/ops/src/traits/health/HealthCheckRow.vue
+++ b/ui/ops/src/traits/health/HealthCheckRow.vue
@@ -9,6 +9,11 @@
     </td>
     <td>
       <bounds-text v-if="hasBounds" :model-value="props.modelValue" class="ml-1"/>
+      <faults-text v-else-if="hasFaults" :model-value="props.modelValue"/>
+      <template v-else-if="lastErrorSummary">
+        <div class="text-caption text-medium-emphasis">{{ lastErrorSummary }}</div>
+        <div v-if="lastErrorDetails" class="text-caption text-medium-emphasis mt-1">{{ lastErrorDetails }}</div>
+      </template>
     </td>
     <td>
       <impacts-text :model-value="props.modelValue"/>
@@ -18,9 +23,11 @@
 
 <script setup>
 import BoundsText from '@/traits/health/BoundsText.vue';
+import FaultsText from '@/traits/health/FaultsText.vue';
 import ImpactsText from '@/traits/health/ImpactsText.vue';
 import NormalityTimeText from '@/traits/health/NormalityTimeText.vue';
 import ReliabilityTimeText from '@/traits/health/ReliabilityTimeText.vue';
+import {HealthCheck} from '@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/health/v1/health_pb';
 import {computed} from 'vue';
 
 const props = defineProps({
@@ -35,6 +42,19 @@ const name = computed(() => props.modelValue?.displayName ?? props.modelValue?.i
 const description = computed(() => props.modelValue?.description);
 
 const hasBounds = computed(() => Boolean(props.modelValue?.bounds));
+const hasFaults = computed(() => (props.modelValue?.faults?.currentFaultsList?.length ?? 0) > 0);
+
+const lastErrorSummary = computed(() => {
+  const rel = props.modelValue?.reliability;
+  if (!rel || rel.state === HealthCheck.Reliability.State.RELIABLE) return null;
+  return rel.lastError?.summaryText ?? null;
+});
+
+const lastErrorDetails = computed(() => {
+  const rel = props.modelValue?.reliability;
+  if (!rel || rel.state === HealthCheck.Reliability.State.RELIABLE) return null;
+  return rel.lastError?.detailsText ?? null;
+});
 </script>
 
 <style scoped>

--- a/ui/ops/src/traits/health/HealthCheckTable.vue
+++ b/ui/ops/src/traits/health/HealthCheckTable.vue
@@ -22,7 +22,15 @@
         show-expand
         no-data-text="No health checks">
       <template #item.device="{ item }">
-        <md-text :value="item.metadata"/>
+        <div class="d-flex align-center gap-2">
+          <md-text :value="item.metadata"/>
+          <v-btn
+              icon="mdi-information-outline"
+              size="x-small"
+              variant="text"
+              v-tooltip:bottom="'View UDMI points'"
+              @click.stop="openUdmiDialog(item)"/>
+        </div>
       </template>
       <template #item.normality="{ item }">
         <normality-last-change-cell :model-value="item"/>
@@ -71,6 +79,9 @@
         </tr>
       </template>
     </v-data-table-server>
+    <v-dialog v-model="udmiDialog.open" max-width="600">
+      <udmi-card :name="udmiDialog.device"/>
+    </v-dialog>
   </div>
 </template>
 
@@ -85,6 +96,7 @@ import {countChecks, useHealthCheckFilters} from '@/traits/health/health';
 import HealthCheckEnrichedRows from '@/traits/health/HealthCheckEnrichedRows.vue';
 import NormalityLastChangeCell from '@/traits/health/NormalityLastChangeCell.vue';
 import ReliabilityLastChangeCell from '@/traits/health/ReliabilityLastChangeCell.vue';
+import UdmiCard from '@/traits/udmi/UdmiCard.vue';
 import {computed, ref} from 'vue';
 
 const props = defineProps({
@@ -111,6 +123,13 @@ const expanded = computed({
     expandedRow.value = value.length > 0 ? value[value.length - 1] : null;
   }
 });
+
+const udmiDialog = ref({open: false, device: ''});
+
+function openUdmiDialog(item) {
+  udmiDialog.value.device = item.name;
+  udmiDialog.value.open = true;
+}
 
 const wantCount = ref(20);
 const _useDevicesOpts = computed(() => {

--- a/ui/ops/src/traits/health/HealthChecksCell.vue
+++ b/ui/ops/src/traits/health/HealthChecksCell.vue
@@ -15,7 +15,7 @@ const props = defineProps({
 });
 
 const totalCount = computed(() => props.modelValue?.length ?? 0);
-const abnormalCount = computed(() => props.modelValue?.filter(check => check.normality !== HealthCheck.Normality.NORMAL).length ?? 0);
+const abnormalCount = computed(() => props.modelValue?.filter(check => check.normality > HealthCheck.Normality.NORMAL).length ?? 0);
 const hasChecks = computed(() => totalCount.value > 0);
 const hasAbnormal = computed(() => abnormalCount.value > 0);
 

--- a/ui/ops/src/traits/health/NormalityLastChangeCell.vue
+++ b/ui/ops/src/traits/health/NormalityLastChangeCell.vue
@@ -30,7 +30,7 @@ const newestNormalCheck = computed(() => {
 const oldestAbnormalCheck = computed(() => {
   const checks = props.modelValue?.healthChecksList ?? [];
   return checks
-    .filter(check => check.normality !== HealthCheck.Normality.NORMAL)
+    .filter(check => check.normality > HealthCheck.Normality.NORMAL)
     .reduce((oldest, check) => {
       if (!oldest) return check;
       const checkTime = timestampToDate(check.abnormalTime);

--- a/ui/ops/src/traits/health/ReliabilityLastChangeCell.vue
+++ b/ui/ops/src/traits/health/ReliabilityLastChangeCell.vue
@@ -31,7 +31,7 @@ const newestReliableCheck = computed(() => {
 const oldestUnreliableCheck = computed(() => {
   const checks = props.modelValue?.healthChecksList ?? [];
   return checks
-    .filter(check => check.reliability?.state !== HealthCheck.Reliability.State.RELIABLE)
+    .filter(check => check.reliability?.state > HealthCheck.Reliability.State.RELIABLE)
     .reduce((oldest, check) => {
       if (!oldest) return check;
       const checkTime = timestampToDate(check.reliability?.unreliableTime);


### PR DESCRIPTION
## Summary

- **Refactor**: replaces the `activeHigh` bool mode in BACnet health checks with a unified `okValue` integer comparison path; existing configs are backwards-compatible (`activeHigh: true` → `okValue=0`, `activeHigh: false` → `okValue=1`) at parse time
- **Fix**: BACnet devices now transition from `UNKNOWN` to `RELIABLE` on successful reads (via `MarkRunning`); traits are eagerly polled during health checks to keep fault state fresh; `RemoveFault(DeviceUnreachable)` is used in place of `ClearFaults()` to avoid clearing unrelated faults on a successful read
- **Config**: per-trait `pollKeepAlive` interval is now configurable (default `5m`), replacing a hardcoded value
- **UI**: health check table rows now show fault details and reliability error text inline, and a UDMI points dialog is accessible from the health table; `UNSPECIFIED` normality/reliability values are excluded from abnormal checks

## Test plan

- [ ] Deploy a BACnet device with `activeHigh: true` config — confirm it still raises faults correctly after migration to `okValue`
- [ ] Deploy a BACnet device with `activeHigh: false` config — confirm fault fires when point reads 0 (not 1)
- [ ] Confirm a device that was stuck in `UNKNOWN` transitions to `RELIABLE` after a successful poll
- [ ] Open the health check table — verify fault descriptions show the read value and expected `okValue`
- [ ] Verify the UDMI points dialog opens from the health table
- [ ] Confirm `UNSPECIFIED` normality/reliability does not appear as an abnormal row