### PR TITLE
pkg/driver: set device type on all driver announcements

### DIFF
--- a/pkg/driver/airthings/driver.go
+++ b/pkg/driver/airthings/driver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/driver/airthings/config"
 	"github.com/smart-core-os/sc-bos/pkg/driver/airthings/local"
 	"github.com/smart-core-os/sc-bos/pkg/node"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/statuspb"
 	"github.com/smart-core-os/sc-bos/pkg/task/service"
 	"github.com/smart-core-os/sc-bos/pkg/util/statusmap"
@@ -86,7 +87,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 
 		for _, device := range location.Devices {
 			n := device.Name
-			announcer.Announce(n, node.HasMetadata(device.Metadata))
+			announcer.Announce(n, node.HasMetadata(device.Metadata), node.HasDeviceType(metadatapb.Metadata_DEVICE))
 			status.UpdateProblem(n, &statuspb.StatusLog_Problem{
 				Level:       statuspb.StatusLog_NOMINAL,
 				Description: "Device configured successfully",

--- a/pkg/driver/bacnet/driver.go
+++ b/pkg/driver/bacnet/driver.go
@@ -26,6 +26,7 @@ import (
 	driverhealth "github.com/smart-core-os/sc-bos/pkg/driver/health"
 	"github.com/smart-core-os/sc-bos/pkg/node"
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/task"
 	"github.com/smart-core-os/sc-bos/pkg/task/service"
 )
@@ -86,9 +87,7 @@ func NewDriver(services driver.Services) *Driver {
 func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 	// AnnounceContext only makes sense if using MonoApply, which we are in NewDriver
 	rootAnnouncer := d.announcer.Replace(ctx)
-	if cfg.Metadata != nil {
-		rootAnnouncer = node.AnnounceFeatures(rootAnnouncer, node.HasMetadata(cfg.Metadata))
-	}
+	rootAnnouncer = node.AnnounceFeatures(rootAnnouncer, node.HasMetadata(cfg.Metadata))
 	// we start fresh each time config is updated
 	d.Clear()
 
@@ -114,9 +113,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 		scDeviceName := cfg.DeviceNamePrefix + deviceName
 
 		// even if devices are offline, they still have metadata
-		if device.Metadata != nil {
-			rootAnnouncer.Announce(device.Name, node.HasMetadata(device.Metadata))
-		}
+		rootAnnouncer.Announce(device.Name, node.HasDeviceType(metadatapb.Metadata_DEVICE), node.HasMetadata(device.Metadata))
 
 		faultCheck, err := d.health.NewFaultCheck(scDeviceName, createDeviceHealthCheck(device.Health.OccupantImpact.ToProto(), device.Health.EquipmentImpact.ToProto()))
 		if errors.Is(err, healthpb.ErrAlreadyExists) {
@@ -257,10 +254,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 			continue
 		}
 
-		announcer := rootAnnouncer
-		if trait.Metadata != nil {
-			announcer = node.AnnounceFeatures(announcer, node.HasMetadata(trait.Metadata))
-		}
+		announcer := node.AnnounceFeatures(rootAnnouncer, node.HasDeviceType(metadatapb.Metadata_DEVICE), node.HasMetadata(trait.Metadata))
 		impl.AnnounceSelf(announcer)
 
 		d.checks = append(d.checks, faultCheck)
@@ -334,9 +328,7 @@ func (d *Driver) configureDevice(ctx context.Context, rootAnnouncer node.Announc
 
 	d.storeDevice(deviceName, bacDevice, device.DefaultWritePriority)
 
-	if device.Metadata != nil {
-		rootAnnouncer = node.AnnounceFeatures(rootAnnouncer, node.HasMetadata(device.Metadata))
-	}
+	rootAnnouncer = node.AnnounceFeatures(rootAnnouncer, node.HasMetadata(device.Metadata))
 
 	// Wrap the per-request error callback to also update controller-level health.
 	updateFn := func(rCtx context.Context, dh *healthpb.FaultCheck, name, request string, reqErr error) {
@@ -393,10 +385,7 @@ func (d *Driver) configureDevice(ctx context.Context, rootAnnouncer node.Announc
 			continue
 		}
 
-		announcer := rootAnnouncer
-		if object.co.Metadata != nil {
-			announcer = node.AnnounceFeatures(announcer, node.HasMetadata(object.co.Metadata))
-		}
+		announcer := node.AnnounceFeatures(rootAnnouncer, node.HasMetadata(object.co.Metadata))
 		impl.AnnounceSelf(announcer)
 	}
 

--- a/pkg/driver/gallagher/accesszones.go
+++ b/pkg/driver/gallagher/accesszones.go
@@ -157,7 +157,7 @@ func (azc *AccessZoneController) refreshAccessZones(announcer node.Announcer, sc
 				node.HasServer(accesspb.RegisterAccessApiServer, accesspb.AccessApiServer(z)),
 				node.HasTrait(accesspb.TraitName),
 			))
-			z.undo = append(z.undo, announcer.Announce(z.ScName, node.HasMetadata(z.Meta)))
+			z.undo = append(z.undo, announcer.Announce(z.ScName, node.HasMetadata(z.Meta), node.HasDeviceType(metadatapb.Metadata_VIRTUAL)))
 			azc.zones[id] = z
 		}
 		azc.getAccessZoneDetails(azc.zones[id])

--- a/pkg/driver/gallagher/doors.go
+++ b/pkg/driver/gallagher/doors.go
@@ -130,7 +130,7 @@ func (dc *DoorController) refreshDoors(announcer node.Announcer, scNamePrefix st
 				},
 			}
 
-			d.Undo = append(d.Undo, announcer.Announce(d.ScName, node.HasMetadata(d.Meta)))
+			d.Undo = append(d.Undo, announcer.Announce(d.ScName, node.HasMetadata(d.Meta), node.HasDeviceType(metadatapb.Metadata_DEVICE)))
 			dc.doors[id] = d
 		}
 	}

--- a/pkg/driver/gallagher/driver.go
+++ b/pkg/driver/gallagher/driver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/driver"
 	"github.com/smart-core-os/sc-bos/pkg/driver/gallagher/config"
 	"github.com/smart-core-os/sc-bos/pkg/node"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/occupancysensorpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/securityeventpb"
 	"github.com/smart-core-os/sc-bos/pkg/task/service"
@@ -93,6 +94,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 	announcer.Announce(cfg.ScNamePrefix,
 		node.HasServer(securityeventpb.RegisterSecurityEventApiServer, securityeventpb.SecurityEventApiServer(sc)),
 		node.HasTrait(securityeventpb.TraitName),
+		node.HasDeviceType(metadatapb.Metadata_SERVICE),
 	)
 	grp.Go(func() error {
 		return sc.run(ctx, cfg.RefreshAlarms)
@@ -103,6 +105,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 		announcer.Announce(path.Join(cfg.ScNamePrefix, "occupancy"),
 			node.HasServer(occupancysensorpb.RegisterOccupancySensorApiServer, occupancysensorpb.OccupancySensorApiServer(occupancyCtrl)),
 			node.HasTrait(trait.OccupancySensor),
+			node.HasDeviceType(metadatapb.Metadata_VIRTUAL),
 		)
 		grp.Go(func() error {
 			if err := occupancyCtrl.run(ctx); err != nil {

--- a/pkg/driver/gallagher/driver.go
+++ b/pkg/driver/gallagher/driver.go
@@ -94,7 +94,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 	announcer.Announce(cfg.ScNamePrefix,
 		node.HasServer(securityeventpb.RegisterSecurityEventApiServer, securityeventpb.SecurityEventApiServer(sc)),
 		node.HasTrait(securityeventpb.TraitName),
-		node.HasDeviceType(metadatapb.Metadata_SERVICE),
+		node.HasDeviceType(metadatapb.Metadata_VIRTUAL),
 	)
 	grp.Go(func() error {
 		return sc.run(ctx, cfg.RefreshAlarms)

--- a/pkg/driver/helvarnet/driver.go
+++ b/pkg/driver/helvarnet/driver.go
@@ -16,6 +16,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/proto/emergencylightpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/lightpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/occupancysensorpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/udmipb"
 	"github.com/smart-core-os/sc-bos/pkg/task/service"
@@ -125,7 +126,8 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 			node.HasServer(lightpb.RegisterLightApiServer, lightpb.LightApiServer(lightingGroup)),
 			node.HasServer(lightpb.RegisterLightInfoServer, lightpb.LightInfoServer(lightingGroup)),
 			node.HasTrait(trait.Light),
-			node.HasMetadata(l.Meta))
+			node.HasMetadata(l.Meta),
+			node.HasDeviceType(metadatapb.Metadata_GROUP))
 	}
 
 	for _, l := range cfg.Lights {
@@ -150,7 +152,8 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 			node.HasTrait(trait.Light),
 			node.HasServer(udmipb.RegisterUdmiServiceServer, udmipb.UdmiServiceServer(lum)),
 			node.HasTrait(udmipb.TraitName),
-			node.HasMetadata(l.Meta))
+			node.HasMetadata(l.Meta),
+			node.HasDeviceType(metadatapb.Metadata_DEVICE))
 		grp.Go(func() error {
 			return lum.queryDevice(ctx, cfg.RefreshStatus.Duration, faultCheck, ctrlHealth)
 		})
@@ -171,7 +174,8 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 			node.HasTrait(trait.OccupancySensor),
 			node.HasServer(udmipb.RegisterUdmiServiceServer, udmipb.UdmiServiceServer(p)),
 			node.HasTrait(udmipb.TraitName),
-			node.HasMetadata(pir.Meta))
+			node.HasMetadata(pir.Meta),
+			node.HasDeviceType(metadatapb.Metadata_DEVICE))
 		grp.Go(func() error {
 			return p.runUpdateState(ctx, cfg.RefreshOccupancy.Duration)
 		})
@@ -204,7 +208,8 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 			node.HasTrait(emergencylightpb.TraitName),
 			node.HasServer(udmipb.RegisterUdmiServiceServer, udmipb.UdmiServiceServer(emergencyLight)),
 			node.HasTrait(udmipb.TraitName),
-			node.HasMetadata(em.Meta))
+			node.HasMetadata(em.Meta),
+			node.HasDeviceType(metadatapb.Metadata_DEVICE))
 		grp.Go(func() error {
 			return emergencyLight.queryDevice(ctx, cfg.RefreshStatus.Duration, faultCheck, ctrlHealth)
 		})

--- a/pkg/driver/hikcentral/driver.go
+++ b/pkg/driver/hikcentral/driver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/driver/hikcentral/config"
 	"github.com/smart-core-os/sc-bos/pkg/node"
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/mqttpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/ptzpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/udmipb"
@@ -93,6 +94,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 			node.HasTrait(trait.Ptz),
 			node.HasServer(udmipb.RegisterUdmiServiceServer, udmipb.UdmiServiceServer(cam)),
 			node.HasTrait(udmipb.TraitName),
+			node.HasDeviceType(metadatapb.Metadata_DEVICE),
 		)
 		cameras = append(cameras, cam)
 	}

--- a/pkg/driver/mock/driver.go
+++ b/pkg/driver/mock/driver.go
@@ -147,6 +147,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 		undos = append(undos, d.announcer.Announce(dt.name,
 			node.HasMetadata(device.Metadata),
 			node.HasServer(mockpb.RegisterMockDeviceApiServer, mockpb.MockDeviceApiServer(d.controller)),
+			node.HasDeviceType(metadatapb.Metadata_DEVICE),
 		))
 
 		for _, traitMd := range device.Traits {

--- a/pkg/driver/opcua/driver.go
+++ b/pkg/driver/opcua/driver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/node"
 	"github.com/smart-core-os/sc-bos/pkg/proto/electricpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/meterpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/transportpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/udmipb"
@@ -86,11 +87,11 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 
 	client := NewClient(opcClient, d.logger, cfg.Conn.SubscriptionInterval.Duration, cfg.Conn.ClientId)
 
-	a.Announce(cfg.Name, node.HasMetadata(cfg.Meta))
+	a.Announce(cfg.Name, node.HasMetadata(cfg.Meta), node.HasDeviceType(metadatapb.Metadata_SERVICE))
 
 	grp, ctx := errgroup.WithContext(ctx)
 	for _, dev := range cfg.Devices {
-		allFeatures := []node.Feature{node.HasMetadata(dev.Meta)}
+		allFeatures := []node.Feature{node.HasMetadata(dev.Meta), node.HasDeviceType(metadatapb.Metadata_DEVICE)}
 
 		faultCheck, err := d.health.NewFaultCheck(dev.Name, getDeviceHealthCheck(dev.Health.OccupantImpact.ToProto(), dev.Health.EquipmentImpact.ToProto()))
 		if err != nil {

--- a/pkg/driver/opcua/driver.go
+++ b/pkg/driver/opcua/driver.go
@@ -87,7 +87,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 
 	client := NewClient(opcClient, d.logger, cfg.Conn.SubscriptionInterval.Duration, cfg.Conn.ClientId)
 
-	a.Announce(cfg.Name, node.HasMetadata(cfg.Meta), node.HasDeviceType(metadatapb.Metadata_SERVICE))
+	a.Announce(cfg.Name, node.HasMetadata(cfg.Meta))
 
 	grp, ctx := errgroup.WithContext(ctx)
 	for _, dev := range cfg.Devices {

--- a/pkg/driver/pestsense/driver.go
+++ b/pkg/driver/pestsense/driver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/driver"
 	"github.com/smart-core-os/sc-bos/pkg/driver/pestsense/config"
 	"github.com/smart-core-os/sc-bos/pkg/node"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/occupancysensorpb"
 	"github.com/smart-core-os/sc-bos/pkg/task/service"
 	"github.com/smart-core-os/sc-bos/pkg/trait"
@@ -83,7 +84,8 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 		announcer.Announce(device.Name,
 			node.HasMetadata(device.Metadata),
 			node.HasServer(occupancysensorpb.RegisterOccupancySensorApiServer, occupancysensorpb.OccupancySensorApiServer(sensor)),
-			node.HasTrait(trait.OccupancySensor))
+			node.HasTrait(trait.OccupancySensor),
+			node.HasDeviceType(metadatapb.Metadata_DEVICE))
 	}
 
 	var responseHandler mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message) {

--- a/pkg/driver/se/wiser-knx/driver.go
+++ b/pkg/driver/se/wiser-knx/driver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/driver"
 	"github.com/smart-core-os/sc-bos/pkg/node"
 	"github.com/smart-core-os/sc-bos/pkg/proto/lightpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/modepb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/typespb"
 	"github.com/smart-core-os/sc-bos/pkg/task/service"
@@ -61,9 +62,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg Config) error {
 	d.client = NewInsecureClient(cfg.Host, cfg.Username, pass)
 
 	for _, dev := range cfg.Devices {
-		if dev.Metadata != nil {
-			announcer.Announce(dev.Name, node.HasMetadata(dev.Metadata))
-		}
+		announcer.Announce(dev.Name, node.HasDeviceType(metadatapb.Metadata_DEVICE), node.HasMetadata(dev.Metadata))
 
 		if dev.Address == "" && len(dev.Addresses) == 0 {
 			return fmt.Errorf("address or addresses is required")

--- a/pkg/driver/shelly/trv/driver.go
+++ b/pkg/driver/shelly/trv/driver.go
@@ -9,6 +9,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/driver/shelly/trv/config"
 	"github.com/smart-core-os/sc-bos/pkg/node"
 	"github.com/smart-core-os/sc-bos/pkg/proto/airtemperaturepb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/task/service"
 	"github.com/smart-core-os/sc-bos/pkg/trait"
 )
@@ -50,6 +51,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 		announcer.Announce(device.Name,
 			node.HasServer(airtemperaturepb.RegisterAirTemperatureApiServer, airtemperaturepb.AirTemperatureApiServer(trv.airTemperatureServer)),
 			node.HasTrait(trait.AirTemperature),
+			node.HasDeviceType(metadatapb.Metadata_DEVICE),
 		)
 	}
 

--- a/pkg/driver/steinel/hpd/driver.go
+++ b/pkg/driver/steinel/hpd/driver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/proto/airtemperaturepb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/brightnesssensorpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/occupancysensorpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/soundsensorpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/udmipb"
@@ -83,6 +84,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 		node.HasTrait(soundsensorpb.TraitName),
 		node.HasServer(udmipb.RegisterUdmiServiceServer, udmipb.UdmiServiceServer(d.udmiServiceServer)),
 		node.HasTrait(udmipb.TraitName),
+		node.HasDeviceType(metadatapb.Metadata_DEVICE),
 	)
 
 	faultCheck, err := d.health.NewFaultCheck(cfg.Name, commsHealthCheck)

--- a/pkg/driver/xovis/driver.go
+++ b/pkg/driver/xovis/driver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/node"
 	"github.com/smart-core-os/sc-bos/pkg/proto/enterleavesensorpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/occupancysensorpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/udmipb"
 	"github.com/smart-core-os/sc-bos/pkg/resource"
@@ -89,7 +90,7 @@ func (d *Driver) applyConfig(ctx context.Context, conf config.Root) error {
 
 	// announce new devices
 	for _, dev := range conf.Devices {
-		features := []node.Feature{node.HasMetadata(dev.Metadata)}
+		features := []node.Feature{node.HasMetadata(dev.Metadata), node.HasDeviceType(metadatapb.Metadata_DEVICE)}
 
 		faultCheck, err := d.health.NewFaultCheck(dev.Name, commsHealthCheck)
 		if err != nil {


### PR DESCRIPTION
[SCB-1363](https://vanti.youtrack.cloud/projects/SCB/issues/SCB-1363)
Add device type metadata to announcements in drivers. Most are DEVICES but there are some exceptions.
Also removes redundant nil guards on HasMetadata calls.