### PR TITLE
pkg/app: announce automations with AUTOMATION device type

### DIFF
--- a/pkg/app/controller.go
+++ b/pkg/app/controller.go
@@ -747,6 +747,7 @@ func (c *Controller) Run(ctx context.Context) (err error) {
 	}
 	announceAutoServices(c, autoServices, c.SystemConfig.AutoFactories)
 	go logServiceMapChanges(ctx, c.Logger.Named("auto"), autoServices)
+	go announceAutoDeviceTypes(ctx, c.Node, autoServices)
 	// load and start the zones
 	zoneServices, err := c.startZones(initialConfig.Zones)
 	if err != nil {

--- a/pkg/app/services.go
+++ b/pkg/app/services.go
@@ -290,6 +290,24 @@ func announceServices[M ~map[string]T, T any](c *Controller, name string, servic
 	return announceNodeServer(c.Node, name, srv)
 }
 
+func announceAutoDeviceTypes(ctx context.Context, n *node.Node, m *service.Map) {
+	undos := make(map[string]node.Undo)
+	now, changes := m.GetAndListenState(ctx)
+	for _, record := range now {
+		undos[record.Id] = n.Announce(record.Id, node.HasDeviceType(metadatapb.Metadata_AUTOMATION))
+	}
+	for change := range changes {
+		if change.NewValue == nil {
+			if undo, ok := undos[change.OldValue.Id]; ok {
+				undo()
+				delete(undos, change.OldValue.Id)
+			}
+		} else if _, ok := undos[change.NewValue.Id]; !ok {
+			undos[change.NewValue.Id] = n.Announce(change.NewValue.Id, node.HasDeviceType(metadatapb.Metadata_AUTOMATION))
+		}
+	}
+}
+
 func announceAutoServices[M ~map[string]T, T any](c *Controller, services *service.Map, factories M) node.Undo {
 	// special because the config name isn't the name we announce as
 	srv := serviceapi.NewApi(services,

--- a/pkg/task/service/map.go
+++ b/pkg/task/service/map.go
@@ -240,6 +240,8 @@ func (m *Map) Listen(ctx context.Context) <-chan *Change {
 	return m.bus.Listen(ctx)
 }
 
+// GetAndListen returns a snapshot of all current records and a channel that receives subsequent record changes.
+// The channel is closed when ctx is done. A nil Change.NewValue indicates the record was removed.
 func (m *Map) GetAndListen(ctx context.Context) ([]*Record, <-chan *Change) {
 	// must listen before getting values
 	ch := m.bus.Listen(ctx)
@@ -266,6 +268,9 @@ func (m *Map) GetAndListen(ctx context.Context) ([]*Record, <-chan *Change) {
 	return values, out
 }
 
+// GetAndListenState returns a snapshot of all current service states and a channel that receives subsequent state
+// changes. The channel is closed when ctx is done. Each record in the snapshot and each StateChange.NewValue
+// represents a service that exists in the map; a nil NewValue indicates the service was removed.
 func (m *Map) GetAndListenState(ctx context.Context) ([]*StateRecord, <-chan *StateChange) {
 	var states []*StateRecord
 	out := make(chan *StateChange)


### PR DESCRIPTION
[SCB-1364](https://vanti.youtrack.cloud/issue/SCB-1364)

Each automation instance is now announced with HasDeviceType(Metadata_AUTOMATION) so it appears with the correct type in the devices list. The announcement is managed dynamically as automations are created and removed from the service map.

Also adds doc comments to service.Map.GetAndListen and GetAndListenState.