### PR TITLE
ui/ops: standardise OpenClose composable names

### DIFF
--- a/ui/ops/src/routes/devices/components/DeviceSideBarContent.vue
+++ b/ui/ops/src/routes/devices/components/DeviceSideBarContent.vue
@@ -26,7 +26,7 @@
           :info="info"
           :update-tracker="updateTracker"
           :name="deviceId"
-          @update-positions="update"/>
+          @update-open-close="update"/>
     </with-open-close>
     <with-air-quality v-if="traits['smartcore.traits.AirQualitySensor']" :name="deviceId" v-slot="{resource}">
       <v-divider class="mt-4 mb-1"/>

--- a/ui/ops/src/traits/openClose/OpenCloseCard.vue
+++ b/ui/ops/src/traits/openClose/OpenCloseCard.vue
@@ -43,7 +43,7 @@
 
 <script setup>
 import useAuthSetup from '@/composables/useAuthSetup';
-import {useOpenClosePositions} from '@/traits/openClose/openClose.js';
+import {useOpenClose} from '@/traits/openClose/openClose.js';
 import {computed, ref, watch} from 'vue';
 
 const {blockActions} = useAuthSetup();
@@ -67,10 +67,10 @@ const props = defineProps({
   }
 });
 const emit = defineEmits([
-  'updatePositions' // OpenClosePositions.AsObject
+  'updateOpenClose' // OpenClosePositions.AsObject
 ]);
 
-const {state, openStr, openPercent} = useOpenClosePositions(() => props.value);
+const {state, openStr, openPercent} = useOpenClose(() => props.value);
 
 const support = computed(() => props.info?.response ?? props.info ?? null);
 const presets = computed(() => support.value?.presetsList ?? []);
@@ -114,7 +114,7 @@ function onSliderEnd(v) {
   // fields like resistance / target_open_percent / open_percent_tween aren't
   // reset to defaults.
   const direction = state.value?.direction ?? 0;
-  emit('updatePositions', {
+  emit('updateOpenClose', {
     states: {statesList: [{openPercent: v, direction}]},
     updateMask: {pathsList: ['states.open_percent']}
   });
@@ -125,6 +125,6 @@ function onSliderEnd(v) {
  */
 function setPreset(name) {
   if (!name) return;
-  emit('updatePositions', {preset: {name}});
+  emit('updateOpenClose', {preset: {name}});
 }
 </script>

--- a/ui/ops/src/traits/openClose/OpenCloseCell.vue
+++ b/ui/ops/src/traits/openClose/OpenCloseCell.vue
@@ -11,7 +11,7 @@
 
 <script setup>
 import StatusAlert from '@/components/StatusAlert.vue';
-import {useOpenClosePositions} from '@/traits/openClose/openClose.js';
+import {useOpenClose} from '@/traits/openClose/openClose.js';
 import {computed} from 'vue';
 
 const props = defineProps({
@@ -29,7 +29,7 @@ const props = defineProps({
   }
 });
 
-const {openStr, openIcon, openClass} = useOpenClosePositions(() => props.value);
+const {openStr, openIcon, openClass} = useOpenClose(() => props.value);
 const doorState = computed(() => {
   return {
     icon: openIcon.value,

--- a/ui/ops/src/traits/openClose/WithOpenClose.vue
+++ b/ui/ops/src/traits/openClose/WithOpenClose.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-    <slot :resource="openCloseValue" :info="info" :update="doUpdatePositions" :update-tracker="updateTracker"/>
+    <slot :resource="openCloseValue" :info="info" :update="doUpdateOpenClose" :update-tracker="updateTracker"/>
   </div>
 </template>
 
 <script setup>
-import {useDescribePositions, usePullOpenClosePositions, useUpdateOpenClosePositions} from '@/traits/openClose/openClose.js';
+import {useDescribeOpenClose, usePullOpenClose, useUpdateOpenClose} from '@/traits/openClose/openClose.js';
 import {reactive} from 'vue';
 
 const props = defineProps({
@@ -24,8 +24,8 @@ const props = defineProps({
   }
 });
 
-const openCloseValue = reactive(usePullOpenClosePositions(() => props.request ?? props.name, () => props.paused));
-const info = reactive(useDescribePositions(() => props.name));
-const updateTracker = reactive(useUpdateOpenClosePositions(() => props.name));
-const doUpdatePositions = updateTracker.updatePositions;
+const openCloseValue = reactive(usePullOpenClose(() => props.request ?? props.name, () => props.paused));
+const info = reactive(useDescribeOpenClose(() => props.name));
+const updateTracker = reactive(useUpdateOpenClose(() => props.name));
+const doUpdateOpenClose = updateTracker.updateOpenClose;
 </script>

--- a/ui/ops/src/traits/openClose/openClose.js
+++ b/ui/ops/src/traits/openClose/openClose.js
@@ -31,7 +31,7 @@ import {computed, onScopeDispose, reactive, toRefs, toValue} from 'vue';
  * @param {MaybeRefOrGetter<boolean>=} paused
  * @return {ToRefs<ResourceValue<OpenClosePositions.AsObject, PullOpenClosePositionsResponse>>}
  */
-export function usePullOpenClosePositions(query, paused = false) {
+export function usePullOpenClose(query, paused = false) {
   const openCloseValue = reactive(
       /** @type {ResourceValue<OpenClosePositions.AsObject, PullOpenClosePositionsResponse>} */
       newResourceValue()
@@ -58,10 +58,10 @@ export function usePullOpenClosePositions(query, paused = false) {
  *   loading: Ref<boolean>,
  *   response: Ref<OpenClosePositions.AsObject|null>,
  *   error: Ref<*>,
- *   updatePositions: (req: Partial<UpdateOpenClosePositionsRequest.AsObject>|Partial<OpenClosePositions.AsObject>) => Promise<OpenClosePositions.AsObject>
+ *   updateOpenClose: (req: Partial<UpdateOpenClosePositionsRequest.AsObject>|Partial<OpenClosePositions.AsObject>) => Promise<OpenClosePositions.AsObject>
  * }}
  */
-export function useUpdateOpenClosePositions(name) {
+export function useUpdateOpenClose(name) {
   const tracker = reactive(
       /** @type {ActionTracker<OpenClosePositions.AsObject>} */
       newActionTracker()
@@ -81,7 +81,7 @@ export function useUpdateOpenClosePositions(name) {
 
   return {
     ...toRefs(tracker),
-    updatePositions: (req) => {
+    updateOpenClose: (req) => {
       return updateOpenClosePositions(toRequestObject(req), tracker);
     }
   };
@@ -91,7 +91,7 @@ export function useUpdateOpenClosePositions(name) {
  * @param {MaybeRefOrGetter<string|DescribePositionsRequest.AsObject>} query
  * @return {ToRefs<ActionTracker<PositionsSupport.AsObject>>}
  */
-export function useDescribePositions(query) {
+export function useDescribeOpenClose(query) {
   const tracker = reactive(
       /** @type {ActionTracker<PositionsSupport.AsObject>} */
       newActionTracker()
@@ -121,7 +121,7 @@ export function useDescribePositions(query) {
  *   openPercent: ComputedRef<number|undefined>,
  *   state: ComputedRef<OpenClosePosition.AsObject>}}
  */
-export function useOpenClosePositions(value) {
+export function useOpenClose(value) {
   const _v = computed(() => toValue(value));
 
   const state = computed(() => _v.value?.statesList[0]);

--- a/ui/ops/src/traits/traits.js
+++ b/ui/ops/src/traits/traits.js
@@ -9,7 +9,7 @@ import {usePullFanSpeed} from '@/traits/fanSpeed/fanSpeed.js';
 import {usePollBrightness, usePullBrightness} from '@/traits/light/light.js';
 import {usePullMeterReading} from '@/traits/meter/meter.js';
 import {usePullOccupancy} from '@/traits/occupancy/occupancy.js';
-import {usePullOpenClosePositions} from '@/traits/openClose/openClose.js';
+import {usePullOpenClose} from '@/traits/openClose/openClose.js';
 import {usePullCurrentStatus} from '@/traits/status/status.js';
 import {computed} from 'vue';
 
@@ -63,8 +63,8 @@ export const pullTraitByType = {
   'smartcore.bos.Meter:Reading': usePullMeterReading,
   'smartcore.traits.OccupancySensor': usePullOccupancy,
   'smartcore.traits.OccupancySensor:Occupancy': usePullOccupancy,
-  'smartcore.traits.OpenClose': usePullOpenClosePositions,
-  'smartcore.traits.OpenClose:Position': usePullOpenClosePositions,
+  'smartcore.traits.OpenClose': usePullOpenClose,
+  'smartcore.traits.OpenClose:Position': usePullOpenClose,
   'smartcore.bos.Status': usePullCurrentStatus,
   'smartcore.bos.Status:CurrentStatus': usePullCurrentStatus
 };


### PR DESCRIPTION
## Summary

- Drops the `Positions` suffix from all OpenClose composable exports so they follow the same `use{TraitName}` convention as OnOff and AirTemperature
- Fixes `useDescribePositions` which had silently lost its `OpenClose` prefix
- Aligns the emitted component event to `updateOpenClose` (was `updatePositions`)

| Before | After |
|--------|-------|
| `usePullOpenClosePositions` | `usePullOpenClose` |
| `useUpdateOpenClosePositions` | `useUpdateOpenClose` |
| `useDescribePositions` | `useDescribeOpenClose` |
| `useOpenClosePositions` | `useOpenClose` |
| emit `updatePositions` | emit `updateOpenClose` |

The API layer (`open-close.js`) is unchanged — those names map directly to gRPC method names.

## Test plan

- [ ] `cd ui/ops && yarn lint:nofix` passes (verified locally — 0 errors)
- [ ] Open a device with the OpenClose trait in the device sidebar and confirm the slider still works