### PR TITLE
feat/bacnet-comms-rw

### DIFF
--- a/cmd/tools/bacnet-comm-test/README.md
+++ b/cmd/tools/bacnet-comm-test/README.md
@@ -1,11 +1,11 @@
 # bacnet-comm-test
 
-A diagnostic tool for testing connectivity to a BACnet/IP device. It connects to a device, reads its basic properties, lists all objects, and prints their present values.
+A diagnostic tool for testing connectivity to a BACnet/IP device. It connects to a device, reads its basic properties, lists all objects with their present values, and optionally writes a value to a point.
 
 ## Usage
 
 ```
-bacnet-comm-test <nic[:port]> <server[:port]> [device]
+bacnet-comm-test <nic[:port]> <server[:port]> [device] [-write Type:instance=value] [-priority 1-16]
 ```
 
 | Argument | Description |
@@ -13,6 +13,8 @@ bacnet-comm-test <nic[:port]> <server[:port]> [device]
 | `nic[:port]` | Local network interface name and optional UDP port to bind (default port: 47808) |
 | `server[:port]` | BACnet device IP address and optional port (default port: 47808) |
 | `device` | BACnet device instance number (default: 4194303, the wildcard) |
+| `-write Type:instance=value` | Write a value to an object's present-value after reading (optional) |
+| `-priority 1-16` | BACnet write priority (default: 8 — Manual Operator) |
 
 ### Choosing a local port
 
@@ -52,10 +54,52 @@ Connect using a named Windows interface and a non-default local port:
 bacnet-comm-test "WiFi:47809" 10.104.20.204:56923 393219
 ```
 
-## Output
+Write a float value to an analog object:
 
 ```
-2026/06/01 09:56:00 Auto-detected interface: WiFi
+bacnet-comm-test "WiFi:47809" 10.104.20.204:56923 393219 -write AnalogValue:1=21.5
+```
+
+Write a boolean value to a binary object:
+
+```
+bacnet-comm-test "WiFi:47809" 10.104.20.204:56923 393219 -write BinaryValue:0=true
+```
+
+Write an integer value to a multi-state object:
+
+```
+bacnet-comm-test "WiFi:47809" 10.104.20.204:56923 393219 -write MultiStateValue:2=3
+```
+
+Override the write priority:
+
+```
+bacnet-comm-test "WiFi:47809" 10.104.20.204:56923 393219 -write AnalogValue:1=21.5 -priority 16
+```
+
+### Write value types
+
+The value type is inferred from the string:
+
+| Value format | Go type | BACnet encoding | Typical use |
+|---|---|---|---|
+| `true` / `false` | `bool` | Boolean | Binary objects |
+| Integer (no decimal) | `uint32` | Unsigned | Multi-state objects |
+| Decimal (e.g. `21.5`, `18.0`) | `float32` | Real | Analog objects |
+
+> **Important:** Analog objects (AnalogInput, AnalogOutput, AnalogValue) require a decimal value.
+> Writing `18` will fail — use `18.0` instead.
+
+### Write priority
+
+BACnet priority 1 (highest) to 16 (lowest). The default is **8 (Manual Operator)**, which overrides most automated setpoints. Use a lower number (higher priority) if the write is being silently overridden by automation.
+
+## Output
+
+### Read-only
+
+```
 2026/06/01 09:56:00 Connecting to {0 0 6 [10 104 20 204 222 91] []}
 2026/06/01 09:56:00 Device 393219  vendor=61440  maxApdu=1476
 2026/06/01 09:56:00 Fetching object list...
@@ -70,6 +114,16 @@ Device                         393219     Room Simulator                        
 ...
 
 Total: 12 objects
+```
+
+### With `-write`
+
+After the object table, the write result and read-back value are printed:
+
+```
+Writing 22.0 to AnalogValue:1 (priority 8)...
+Write succeeded
+Read back AnalogValue:1 present-value = 22
 ```
 
 Objects that do not support `Present-Value` (such as the Device object itself) are shown with `-`.

--- a/cmd/tools/bacnet-comm-test/README.md
+++ b/cmd/tools/bacnet-comm-test/README.md
@@ -5,14 +5,14 @@ A diagnostic tool for testing connectivity to a BACnet/IP device. It connects to
 ## Usage
 
 ```
-bacnet-comm-test <nic[:port]> <server[:port]> [device] [-write Type:instance=value] [-priority 1-16]
+bacnet-comm-test -nic <nic[:port]> -server <server[:port]> [-device <instance>] [-write Type:instance=value] [-priority 1-16]
 ```
 
-| Argument | Description |
+| Flag | Description |
 |---|---|
-| `nic[:port]` | Local network interface name and optional UDP port to bind (default port: 47808) |
-| `server[:port]` | BACnet device IP address and optional port (default port: 47808) |
-| `device` | BACnet device instance number (default: 4194303, the wildcard) |
+| `-nic nic[:port]` | Local network interface name and optional UDP port to bind (default port: 47808) |
+| `-server server[:port]` | BACnet device IP address and optional port (default port: 47808) |
+| `-device instance` | BACnet device instance number (default: 4194303, the wildcard) |
 | `-write Type:instance=value` | Write a value to an object's present-value after reading (optional) |
 | `-priority 1-16` | BACnet write priority (default: 8 — Manual Operator) |
 
@@ -21,7 +21,7 @@ bacnet-comm-test <nic[:port]> <server[:port]> [device] [-write Type:instance=val
 The default local port is 47808 (the standard BACnet port). If another process on your machine is already using that port — for example a BACnet simulator — you will receive no responses. Use a different local port to avoid the conflict:
 
 ```
-bacnet-comm-test "WiFi:47809" 10.104.20.204:56923 393219
+bacnet-comm-test -nic "WiFi:47809" -server 10.104.20.204:56923 -device 393219
 ```
 
 ### Finding the right interface
@@ -39,43 +39,43 @@ On Linux, use the interface name from `ip addr` (e.g. `eth0`).
 Connect to a device on the standard BACnet port, using the wildcard device ID:
 
 ```
-bacnet-comm-test eth0 192.168.1.100
+bacnet-comm-test -nic eth0 -server 192.168.1.100
 ```
 
 Connect to a device on a non-standard port with a known device instance:
 
 ```
-bacnet-comm-test eth0 192.168.1.100:56923 393219
+bacnet-comm-test -nic eth0 -server 192.168.1.100:56923 -device 393219
 ```
 
 Connect using a named Windows interface and a non-default local port:
 
 ```
-bacnet-comm-test "WiFi:47809" 10.104.20.204:56923 393219
+bacnet-comm-test -nic "WiFi:47809" -server 10.104.20.204:56923 -device 393219
 ```
 
 Write a float value to an analog object:
 
 ```
-bacnet-comm-test "WiFi:47809" 10.104.20.204:56923 393219 -write AnalogValue:1=21.5
+bacnet-comm-test -nic "WiFi:47809" -server 10.104.20.204:56923 -device 393219 -write AnalogValue:1=21.5
 ```
 
 Write a boolean value to a binary object:
 
 ```
-bacnet-comm-test "WiFi:47809" 10.104.20.204:56923 393219 -write BinaryValue:0=true
+bacnet-comm-test -nic "WiFi:47809" -server 10.104.20.204:56923 -device 393219 -write BinaryValue:0=true
 ```
 
 Write an integer value to a multi-state object:
 
 ```
-bacnet-comm-test "WiFi:47809" 10.104.20.204:56923 393219 -write MultiStateValue:2=3
+bacnet-comm-test -nic "WiFi:47809" -server 10.104.20.204:56923 -device 393219 -write MultiStateValue:2=3
 ```
 
 Override the write priority:
 
 ```
-bacnet-comm-test "WiFi:47809" 10.104.20.204:56923 393219 -write AnalogValue:1=21.5 -priority 16
+bacnet-comm-test -nic "WiFi:47809" -server 10.104.20.204:56923 -device 393219 -write AnalogValue:1=21.5 -priority 16
 ```
 
 ### Write value types

--- a/cmd/tools/bacnet-comm-test/README.md
+++ b/cmd/tools/bacnet-comm-test/README.md
@@ -1,0 +1,75 @@
+# bacnet-comm-test
+
+A diagnostic tool for testing connectivity to a BACnet/IP device. It connects to a device, reads its basic properties, lists all objects, and prints their present values.
+
+## Usage
+
+```
+bacnet-comm-test <nic[:port]> <server[:port]> [device]
+```
+
+| Argument | Description |
+|---|---|
+| `nic[:port]` | Local network interface name and optional UDP port to bind (default port: 47808) |
+| `server[:port]` | BACnet device IP address and optional port (default port: 47808) |
+| `device` | BACnet device instance number (default: 4194303, the wildcard) |
+
+### Choosing a local port
+
+The default local port is 47808 (the standard BACnet port). If another process on your machine is already using that port — for example a BACnet simulator — you will receive no responses. Use a different local port to avoid the conflict:
+
+```
+bacnet-comm-test "WiFi:47809" 10.104.20.204:56923 393219
+```
+
+### Finding the right interface
+
+On Windows, use the adapter's friendly name as shown in `ipconfig`. To list all interfaces and their addresses, run:
+
+```powershell
+Get-NetAdapter | Select-Object Name, InterfaceDescription
+```
+
+On Linux, use the interface name from `ip addr` (e.g. `eth0`).
+
+## Examples
+
+Connect to a device on the standard BACnet port, using the wildcard device ID:
+
+```
+bacnet-comm-test eth0 192.168.1.100
+```
+
+Connect to a device on a non-standard port with a known device instance:
+
+```
+bacnet-comm-test eth0 192.168.1.100:56923 393219
+```
+
+Connect using a named Windows interface and a non-default local port:
+
+```
+bacnet-comm-test "WiFi:47809" 10.104.20.204:56923 393219
+```
+
+## Output
+
+```
+2026/06/01 09:56:00 Auto-detected interface: WiFi
+2026/06/01 09:56:00 Connecting to {0 0 6 [10 104 20 204 222 91] []}
+2026/06/01 09:56:00 Device 393219  vendor=61440  maxApdu=1476
+2026/06/01 09:56:00 Fetching object list...
+2026/06/01 09:56:00 Fetching present values for 12 objects...
+
+Type                           Instance   Name                                     Present Value
+----------------------------------------------------------------------------------------------------
+AnalogInput                    0          Zone Temperature                         21.5
+AnalogInput                    1          Zone Humidity                            45.2
+BinaryInput                    0          Occupancy                                true
+Device                         393219     Room Simulator                           -
+...
+
+Total: 12 objects
+```
+
+Objects that do not support `Present-Value` (such as the Device object itself) are shown with `-`.

--- a/cmd/tools/bacnet-comm-test/main.go
+++ b/cmd/tools/bacnet-comm-test/main.go
@@ -21,13 +21,35 @@ import (
 
 func main() {
 	args := os.Args
-	if l := len(args); l < 3 || l > 4 {
-		log.Fatalf("Usage: <cmd> nic[:port] server[:port] [device]")
+	if l := len(args); l < 3 || l > 7 {
+		log.Fatalf("Usage: <cmd> nic[:port] server[:port] [device] [-write Type:instance=value] [-priority 1-16]")
 	}
 	nicPort, serverPort := args[1], args[2]
 	deviceStr := "4194303"
-	if len(args) == 4 {
-		deviceStr = args[3]
+	writeSpec := ""
+	writePriority := uint(8)
+	for i := 3; i < len(args); i++ {
+		if strings.HasPrefix(args[i], "-write=") {
+			writeSpec = strings.TrimPrefix(args[i], "-write=")
+		} else if args[i] == "-write" && i+1 < len(args) {
+			i++
+			writeSpec = args[i]
+		} else if strings.HasPrefix(args[i], "-priority=") {
+			p, err := strconv.ParseUint(strings.TrimPrefix(args[i], "-priority="), 10, 8)
+			if err != nil || p < 1 || p > 16 {
+				log.Fatal("bad priority: must be 1-16")
+			}
+			writePriority = uint(p)
+		} else if args[i] == "-priority" && i+1 < len(args) {
+			i++
+			p, err := strconv.ParseUint(args[i], 10, 8)
+			if err != nil || p < 1 || p > 16 {
+				log.Fatal("bad priority: must be 1-16")
+			}
+			writePriority = uint(p)
+		} else if deviceStr == "4194303" {
+			deviceStr = args[i]
+		}
 	}
 
 	localPort := 0 // defaults to 47808
@@ -110,24 +132,7 @@ func main() {
 
 	log.Printf("Fetching present values for %d objects...", len(entries))
 	for i := range entries {
-		e := &entries[i]
-		rp := bactypes.ReadPropertyData{
-			Object: bactypes.Object{
-				ID: bactypes.ObjectID{Type: e.objType, Instance: e.instance},
-				Properties: []bactypes.Property{{
-					ID:         property.PresentValue,
-					ArrayIndex: bactypes.ArrayAll,
-				}},
-			},
-		}
-		resp, err := client.ReadProperty(ctx, dev, rp)
-		if err != nil {
-			e.value = "-"
-		} else if len(resp.Object.Properties) > 0 {
-			e.value = fmt.Sprintf("%v", resp.Object.Properties[0].Data)
-		} else {
-			e.value = "-"
-		}
+		entries[i].value = readPresentValue(ctx, client, dev, entries[i].objType, entries[i].instance)
 	}
 
 	fmt.Printf("\n%-30s %-10s %-40s %s\n", "Type", "Instance", "Name", "Present Value")
@@ -136,4 +141,88 @@ func main() {
 		fmt.Printf("%-30s %-10d %-40s %s\n", e.objType, e.instance, e.name, e.value)
 	}
 	fmt.Printf("\nTotal: %d objects\n", len(entries))
+
+	if writeSpec == "" {
+		return
+	}
+
+	// Parse -write Type:instance=value
+	keyPart, rawValue, ok := strings.Cut(writeSpec, "=")
+	if !ok {
+		log.Fatalf("-write: expected Type:instance=value, got %q", writeSpec)
+	}
+	typePart, instancePart, ok := strings.Cut(keyPart, ":")
+	if !ok {
+		log.Fatalf("-write: expected Type:instance, got %q", keyPart)
+	}
+	writeType, ok := objecttype.FromString(typePart)
+	if !ok {
+		log.Fatalf("-write: unknown object type %q", typePart)
+	}
+	writeInstance, err := strconv.ParseUint(instancePart, 10, 32)
+	if err != nil {
+		log.Fatalf("-write: bad instance %q: %v", instancePart, err)
+	}
+	writeValue, err := parseWriteValue(rawValue)
+	if err != nil {
+		log.Fatalf("-write: bad value %q: %v", rawValue, err)
+	}
+
+	writeObjID := bactypes.ObjectID{Type: writeType, Instance: bactypes.ObjectInstance(writeInstance)}
+	wp := bactypes.ReadPropertyData{
+		Object: bactypes.Object{
+			ID: writeObjID,
+			Properties: []bactypes.Property{{
+				ID:         property.PresentValue,
+				ArrayIndex: bactypes.ArrayAll,
+				Data:       writeValue,
+			}},
+		},
+	}
+
+	fmt.Printf("\nWriting %v to %s:%d (priority %d)...\n", rawValue, writeType, writeInstance, writePriority)
+	if err := client.WriteProperty(ctx, dev, wp, writePriority); err != nil {
+		fmt.Printf("Write failed: %v\n", err)
+		fmt.Println("Hint: analog objects need a decimal value (e.g. 18.0); binary/multi-state use integers")
+	} else {
+		fmt.Println("Write succeeded")
+	}
+
+	readBack := readPresentValue(ctx, client, dev, writeType, bactypes.ObjectInstance(writeInstance))
+	fmt.Printf("Read back %s:%d present-value = %s\n", writeType, writeInstance, readBack)
+}
+
+func readPresentValue(ctx context.Context, client *gobacnet.Client, dev bactypes.Device, objType objecttype.ObjectType, instance bactypes.ObjectInstance) string {
+	rp := bactypes.ReadPropertyData{
+		Object: bactypes.Object{
+			ID: bactypes.ObjectID{Type: objType, Instance: instance},
+			Properties: []bactypes.Property{{
+				ID:         property.PresentValue,
+				ArrayIndex: bactypes.ArrayAll,
+			}},
+		},
+	}
+	resp, err := client.ReadProperty(ctx, dev, rp)
+	if err != nil || len(resp.Object.Properties) == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%v", resp.Object.Properties[0].Data)
+}
+
+// parseWriteValue converts a string to the appropriate BACnet Go type.
+// "true"/"false" → bool, integer strings → uint32, decimal strings → float32.
+func parseWriteValue(s string) (interface{}, error) {
+	switch strings.ToLower(s) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	}
+	if i, err := strconv.ParseUint(s, 10, 32); err == nil {
+		return uint32(i), nil
+	}
+	if f, err := strconv.ParseFloat(s, 32); err == nil {
+		return float32(f), nil
+	}
+	return nil, fmt.Errorf("cannot parse %q as bool, uint32, or float32", s)
 }

--- a/cmd/tools/bacnet-comm-test/main.go
+++ b/cmd/tools/bacnet-comm-test/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -20,40 +21,24 @@ import (
 )
 
 func main() {
-	args := os.Args
-	if l := len(args); l < 3 || l > 7 {
-		log.Fatalf("Usage: <cmd> nic[:port] server[:port] [device] [-write Type:instance=value] [-priority 1-16]")
+	nicPort := flag.String("nic", "", "local network interface name and optional UDP port (e.g. eth0 or \"WiFi:47809\")")
+	serverPort := flag.String("server", "", "BACnet device IP address and optional port (e.g. 192.168.1.100 or 192.168.1.100:56923)")
+	deviceStr := flag.String("device", "4194303", "BACnet device instance number (default: 4194303 wildcard)")
+	writeSpec := flag.String("write", "", "write a present value after reading: Type:instance=value")
+	writePriorityFlag := flag.Uint("priority", 8, "BACnet write priority 1-16 (default: 8, Manual Operator)")
+	flag.Parse()
+
+	if *nicPort == "" || *serverPort == "" {
+		flag.Usage()
+		os.Exit(1)
 	}
-	nicPort, serverPort := args[1], args[2]
-	deviceStr := "4194303"
-	writeSpec := ""
-	writePriority := uint(8)
-	for i := 3; i < len(args); i++ {
-		if strings.HasPrefix(args[i], "-write=") {
-			writeSpec = strings.TrimPrefix(args[i], "-write=")
-		} else if args[i] == "-write" && i+1 < len(args) {
-			i++
-			writeSpec = args[i]
-		} else if strings.HasPrefix(args[i], "-priority=") {
-			p, err := strconv.ParseUint(strings.TrimPrefix(args[i], "-priority="), 10, 8)
-			if err != nil || p < 1 || p > 16 {
-				log.Fatal("bad priority: must be 1-16")
-			}
-			writePriority = uint(p)
-		} else if args[i] == "-priority" && i+1 < len(args) {
-			i++
-			p, err := strconv.ParseUint(args[i], 10, 8)
-			if err != nil || p < 1 || p > 16 {
-				log.Fatal("bad priority: must be 1-16")
-			}
-			writePriority = uint(p)
-		} else if deviceStr == "4194303" {
-			deviceStr = args[i]
-		}
+	if *writePriorityFlag < 1 || *writePriorityFlag > 16 {
+		log.Fatal("bad priority: must be 1-16")
 	}
+	writePriority := *writePriorityFlag
 
 	localPort := 0 // defaults to 47808
-	nic, localPortStr, _ := strings.Cut(nicPort, ":")
+	nic, localPortStr, _ := strings.Cut(*nicPort, ":")
 	if localPortStr != "" {
 		var err error
 		localPort, err = strconv.Atoi(localPortStr)
@@ -62,9 +47,9 @@ func main() {
 		}
 	}
 
-	deviceNum, err := strconv.ParseInt(deviceStr, 10, 32)
+	deviceNum, err := strconv.ParseInt(*deviceStr, 10, 32)
 	if err != nil {
-		log.Fatal("bad device", deviceStr, err)
+		log.Fatal("bad device", *deviceStr, err)
 	}
 
 	client, err := gobacnet.NewClient(nic, localPort)
@@ -73,7 +58,7 @@ func main() {
 	}
 	defer client.Close()
 
-	uri, err := url.ParseRequestURI("bacnet://" + serverPort)
+	uri, err := url.ParseRequestURI("bacnet://" + *serverPort)
 	if err != nil {
 		log.Fatal("server", err)
 	}
@@ -142,14 +127,14 @@ func main() {
 	}
 	fmt.Printf("\nTotal: %d objects\n", len(entries))
 
-	if writeSpec == "" {
+	if *writeSpec == "" {
 		return
 	}
 
 	// Parse -write Type:instance=value
-	keyPart, rawValue, ok := strings.Cut(writeSpec, "=")
+	keyPart, rawValue, ok := strings.Cut(*writeSpec, "=")
 	if !ok {
-		log.Fatalf("-write: expected Type:instance=value, got %q", writeSpec)
+		log.Fatalf("-write: expected Type:instance=value, got %q", *writeSpec)
 	}
 	typePart, instancePart, ok := strings.Cut(keyPart, ":")
 	if !ok {

--- a/cmd/tools/bacnet-comm-test/main.go
+++ b/cmd/tools/bacnet-comm-test/main.go
@@ -3,15 +3,20 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/smart-core-os/gobacnet"
+	"github.com/smart-core-os/gobacnet/property"
 	bactypes "github.com/smart-core-os/gobacnet/types"
+	"github.com/smart-core-os/gobacnet/types/objecttype"
 )
 
 func main() {
@@ -26,7 +31,7 @@ func main() {
 	}
 
 	localPort := 0 // defaults to 47808
-	nic, localPortStr, _ := net.SplitHostPort(nicPort)
+	nic, localPortStr, _ := strings.Cut(nicPort, ":")
 	if localPortStr != "" {
 		var err error
 		localPort, err = strconv.Atoi(localPortStr)
@@ -45,8 +50,6 @@ func main() {
 		log.Fatal(err)
 	}
 	defer client.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	defer cancel()
 
 	uri, err := url.ParseRequestURI("bacnet://" + serverPort)
 	if err != nil {
@@ -65,10 +68,72 @@ func main() {
 		log.Fatal("bad server ip", uri.Hostname())
 	}
 	bacAddr := bactypes.UDPToAddress(&net.UDPAddr{IP: ip, Port: int(portNum)})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	log.Printf("Connecting to %v", bacAddr)
 	devices, err := client.RemoteDevices(ctx, bacAddr, bactypes.ObjectInstance(deviceNum))
 	if err != nil {
 		log.Fatalf("Error reading device info! %v", err)
 	}
-	log.Printf("Success! {devices=%+v}", devices)
+	if len(devices) == 0 {
+		log.Fatal("no devices returned")
+	}
+	dev := devices[0]
+	log.Printf("Device %d  vendor=%d  maxApdu=%d", dev.ID.Instance, dev.Vendor, dev.MaxApdu)
+
+	log.Printf("Fetching object list...")
+	dev, err = client.Objects(ctx, dev)
+	if err != nil {
+		log.Fatalf("Error reading objects! %v", err)
+	}
+
+	type entry struct {
+		objType  objecttype.ObjectType
+		instance bactypes.ObjectInstance
+		name     string
+		value    string
+	}
+	var entries []entry
+	for objType, instances := range dev.Objects {
+		for instance, obj := range instances {
+			entries = append(entries, entry{objType, instance, obj.Name, ""})
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].objType != entries[j].objType {
+			return entries[i].objType < entries[j].objType
+		}
+		return entries[i].instance < entries[j].instance
+	})
+
+	log.Printf("Fetching present values for %d objects...", len(entries))
+	for i := range entries {
+		e := &entries[i]
+		rp := bactypes.ReadPropertyData{
+			Object: bactypes.Object{
+				ID: bactypes.ObjectID{Type: e.objType, Instance: e.instance},
+				Properties: []bactypes.Property{{
+					ID:         property.PresentValue,
+					ArrayIndex: bactypes.ArrayAll,
+				}},
+			},
+		}
+		resp, err := client.ReadProperty(ctx, dev, rp)
+		if err != nil {
+			e.value = "-"
+		} else if len(resp.Object.Properties) > 0 {
+			e.value = fmt.Sprintf("%v", resp.Object.Properties[0].Data)
+		} else {
+			e.value = "-"
+		}
+	}
+
+	fmt.Printf("\n%-30s %-10s %-40s %s\n", "Type", "Instance", "Name", "Present Value")
+	fmt.Println(strings.Repeat("-", 100))
+	for _, e := range entries {
+		fmt.Printf("%-30s %-10d %-40s %s\n", e.objType, e.instance, e.name, e.value)
+	}
+	fmt.Printf("\nTotal: %d objects\n", len(entries))
 }


### PR DESCRIPTION
improve tools/bacnet-comm-test to be able to fully demonstrate r/w comms with a remote BACnet controller & compare values on either side.

- add functionality to list objects and their values and add readme.
- fix small bug when trying to use without explicit local port.
- add ability to write a value to a point
