### PR TITLE
opcua: support enum mapping for Transport position

### DIFF
--- a/pkg/driver/opcua/conv/value.go
+++ b/pkg/driver/opcua/conv/value.go
@@ -79,6 +79,27 @@ func ToString(data any) (string, error) {
 	return "", fmt.Errorf("unsupported conversion %T -> string for val %v", data, data)
 }
 
+// ToEnumString converts a value to its string representation, applying the enum
+// mapping if one is provided.
+//
+// When enum is non-nil and contains an entry keyed by the value's string
+// representation, the mapped string is returned. This lets raw OPC UA values be
+// remapped onto meaningful labels - for example mapping a lift's actual position
+// index (which may include Kone "dummy floors") onto the real floor number.
+//
+// If enum is nil, or has no entry for the value, the plain string representation
+// is returned unchanged, preserving behaviour for sources configured without an enum.
+func ToEnumString(data any, enum map[string]string) (string, error) {
+	s, err := ToString(data)
+	if err != nil {
+		return "", err
+	}
+	if v, ok := enum[s]; ok {
+		return v, nil
+	}
+	return s, nil
+}
+
 // ToTraitEnum takes the value read from the OPC UA node and looks up the value in the enum map defined in the config.
 // If value is found, this value is then used to look up the enum value in the proto pb <EnumName>_value field.
 func ToTraitEnum[T constraints.Integer](data any, enum map[string]string, traitMap map[string]int32) (T, error) {

--- a/pkg/driver/opcua/conv/value_test.go
+++ b/pkg/driver/opcua/conv/value_test.go
@@ -250,6 +250,68 @@ func TestToString(t *testing.T) {
 	}
 }
 
+func TestToEnumString(t *testing.T) {
+	// e.g. a Kone lift position index that includes dummy floors mapped to real floor labels.
+	floorMap := map[string]string{
+		"0": "G",
+		"1": "1",
+		"2": "2",
+		"4": "3",
+	}
+
+	tests := []struct {
+		name      string
+		input     any
+		enum      map[string]string
+		want      string
+		wantError bool
+	}{
+		{
+			name:  "maps int value to real floor",
+			input: int32(4),
+			enum:  floorMap,
+			want:  "3",
+		},
+		{
+			name:  "maps string value to real floor",
+			input: "0",
+			enum:  floorMap,
+			want:  "G",
+		},
+		{
+			name:  "value not in enum falls back to raw string",
+			input: int32(9),
+			enum:  floorMap,
+			want:  "9",
+		},
+		{
+			name:  "nil enum returns raw string",
+			input: int32(5),
+			enum:  nil,
+			want:  "5",
+		},
+		{
+			name:      "unconvertible value returns error",
+			input:     true,
+			enum:      floorMap,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToEnumString(tt.input, tt.enum)
+			if (err != nil) != tt.wantError {
+				t.Errorf("ToEnumString() error = %v, wantError %v", err, tt.wantError)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ToEnumString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestToTraitEnum(t *testing.T) {
 	enumMap := map[string]string{
 		"0": "OPEN",

--- a/pkg/driver/opcua/transport.go
+++ b/pkg/driver/opcua/transport.go
@@ -3,7 +3,6 @@ package opcua
 import (
 	"context"
 	"encoding/json"
-	"strconv"
 
 	"github.com/gopcua/opcua/ua"
 	"go.uber.org/zap"
@@ -78,7 +77,7 @@ func (t *Transport) PullTransport(_ *transportpb.PullTransportRequest, server tr
 func (t *Transport) handleEvent(_ context.Context, node *ua.NodeID, value any) {
 	old := t.transport.Get().(*transportpb.Transport)
 	if t.cfg.ActualPosition != nil && nodeIdsAreEqual(t.cfg.ActualPosition.NodeId, node) {
-		floor, err := conv.ToString(value)
+		floor, err := conv.ToEnumString(value, t.cfg.ActualPosition.Enum)
 		if err != nil {
 			t.logger.Error("failed to convert ActualPosition event", zap.String("device", t.scName), zap.Error(err))
 			return
@@ -106,18 +105,18 @@ func (t *Transport) handleEvent(_ context.Context, node *ua.NodeID, value any) {
 	if t.cfg.NextDestinations != nil {
 		for i, dest := range t.cfg.NextDestinations {
 			if dest.Type == config.SingleFloor && nodeIdsAreEqual(dest.Source.NodeId, node) {
-				floor, err := conv.IntValue(value)
+				floor, err := conv.ToEnumString(value, dest.Source.Enum)
 				if err != nil {
 					t.logger.Error("failed to convert NextDestinations event", zap.String("device", t.scName), zap.Error(err))
 					return
 				}
 				if i >= len(old.NextDestinations) {
 					old.NextDestinations = append(old.NextDestinations, &transportpb.Transport_Location{
-						Floor: strconv.Itoa(floor),
+						Floor: floor,
 					})
 				} else {
 					old.NextDestinations[i] = &transportpb.Transport_Location{
-						Floor: strconv.Itoa(floor),
+						Floor: floor,
 					}
 				}
 			}

--- a/pkg/driver/opcua/transport_test.go
+++ b/pkg/driver/opcua/transport_test.go
@@ -84,6 +84,24 @@ func TestTransport_handleTransportEvent(t *testing.T) {
 			wantValue:  "3",
 		},
 		{
+			// Kone reports a raw position index that includes dummy floors; the enum maps it to the real floor.
+			name:       "actual position with enum mapping dummy floors",
+			config:     `{"kind":"smartcore.bos.Transport","actualPosition":{"nodeId":"ns=2;s=Position","enum":{"0":"G","1":"1","2":"2","4":"3"}}}`,
+			nodeId:     "ns=2;s=Position",
+			value:      int32(4),
+			checkField: "actualPosition",
+			wantValue:  "3",
+		},
+		{
+			// A value not present in the enum falls back to its raw string representation.
+			name:       "actual position with enum falls back to raw value",
+			config:     `{"kind":"smartcore.bos.Transport","actualPosition":{"nodeId":"ns=2;s=Position","enum":{"0":"G","1":"1"}}}`,
+			nodeId:     "ns=2;s=Position",
+			value:      int32(9),
+			checkField: "actualPosition",
+			wantValue:  "9",
+		},
+		{
 			name:       "load",
 			config:     `{"kind":"smartcore.bos.Transport","load":{"nodeId":"ns=2;s=Load"}}`,
 			nodeId:     "ns=2;s=Load",
@@ -122,6 +140,15 @@ func TestTransport_handleTransportEvent(t *testing.T) {
 			value:      int32(7),
 			checkField: "nextDestinations",
 			wantValue:  "7",
+		},
+		{
+			// Dummy-floor mapping applies to destinations the same way as the actual position.
+			name:       "next destinations - single floor with enum mapping dummy floors",
+			config:     `{"kind":"smartcore.bos.Transport","nextDestinations":[{"type":"SingleFloor","source":{"nodeId":"ns=2;s=Next","enum":{"0":"G","1":"1","2":"2","4":"3"}}}]}`,
+			nodeId:     "ns=2;s=Next",
+			value:      int32(4),
+			checkField: "nextDestinations",
+			wantValue:  "3",
 		},
 	}
 


### PR DESCRIPTION
[SCB-1188](https://vanti.youtrack.cloud/projects/SCB/issues/SCB-1188)

ActualPosition and NextDestinations (SingleFloor) now apply the configured ValueSource enum, so raw OPC UA position indices that include Kone dummy floors can be mapped onto real floor labels.

Add conv.ToEnumString which maps a value via the enum when present and falls back to the raw string representation otherwise, keeping existing enum-less configs unchanged.