### PR TITLE
drivers/helvarnet: normalise test times to UTC via timezone config

### DIFF
--- a/pkg/driver/helvarnet/README.md
+++ b/pkg/driver/helvarnet/README.md
@@ -28,3 +28,14 @@ sent i.e. if a query message is sent in ASCII form then the reply will also be i
 Comparing ASCII & raw binary, the binary format requires you to always send 40 bytes but the 
 ASCII can be less than 40 bytes (26 bytes for a standard scene recall message). 
 Also, it will be easier to log & debug ASCII so we will use ASCII. 
+
+### Device clocks and timezones
+
+Routers report times (e.g. emergency test completion times) as epoch seconds derived from their
+local wall-clock. If the routers' clocks are set to local time rather than UTC, the reported
+values are offset from the true epoch time (e.g. an hour ahead during BST).
+
+Set the `timezone` config option to the IANA timezone the routers' clocks follow
+(e.g. `"timezone": "Europe/London"`) and the driver will re-interpret reported times in that
+zone so the API exposes the correct UTC instant. When unset, reported times are taken as true
+epoch seconds (UTC).

--- a/pkg/driver/helvarnet/config/root.go
+++ b/pkg/driver/helvarnet/config/root.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/smart-core-os/sc-bos/pkg/driver"
@@ -55,6 +56,14 @@ type Root struct {
 	// ControllerHealthThreshold is the % of devices on a controller (IP address) that must be
 	// failing before the controller itself is marked unhealthy. Range [0, 100], default 50.
 	ControllerHealthThreshold int `json:"controllerHealthThreshold,omitempty"`
+	// Timezone is the IANA timezone name (e.g. "Europe/London") the routers' clocks are set to.
+	// Helvar routers report times, like emergency test completion times, as epoch seconds derived from
+	// their local wall-clock. When set, reported times are re-interpreted in this timezone so the API
+	// exposes the correct UTC instant. Defaults to UTC, i.e. reported times are taken as true epoch seconds.
+	Timezone string `json:"timezone,omitempty"`
+
+	// Location is the parsed Timezone, populated by ParseConfig.
+	Location *time.Location `json:"-"`
 }
 
 // Device represents a HelvarNet device, which can be a light, lighting group, or PIR sensor.
@@ -139,6 +148,15 @@ func ParseConfig(data []byte) (Root, error) {
 
 	if root.ControllerHealthThreshold == 0 {
 		root.ControllerHealthThreshold = 50
+	}
+
+	root.Location = time.UTC
+	if root.Timezone != "" {
+		loc, err := time.LoadLocation(root.Timezone)
+		if err != nil {
+			return Root{}, fmt.Errorf("invalid timezone %q: %w", root.Timezone, err)
+		}
+		root.Location = loc
 	}
 
 	for _, device := range root.EmergencyLights {

--- a/pkg/driver/helvarnet/driver.go
+++ b/pkg/driver/helvarnet/driver.go
@@ -139,7 +139,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 			d.clients[l.IpAddress] = newTcpClient(tcpAddr, d.logger, &cfg)
 		}
 
-		lum := newLight(d.clients[l.IpAddress], d.logger, l, d.database, false)
+		lum := newLight(d.clients[l.IpAddress], d.logger, l, d.database, false, cfg.Location)
 
 		faultCheck := createFaultCheck(l.Name)
 		ctrlHealth := getOrCreateControllerCheck(l.IpAddress)
@@ -189,7 +189,7 @@ func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
 			}
 			d.clients[em.IpAddress] = newTcpClient(tcpAddr, d.logger, &cfg)
 		}
-		emergencyLight := newLight(d.clients[em.IpAddress], d.logger, em, d.database, true)
+		emergencyLight := newLight(d.clients[em.IpAddress], d.logger, em, d.database, true, cfg.Location)
 		err := emergencyLight.loadTestResults()
 		if err != nil {
 			d.logger.Error("loadTestResults error", zap.Error(err))

--- a/pkg/driver/helvarnet/light.go
+++ b/pkg/driver/helvarnet/light.go
@@ -53,15 +53,18 @@ type Light struct {
 	database      *bolthold.Store
 	testResultSet *resource.Value // *emergencylightpb.TestResultSet
 	isEm          bool
+	// location is the timezone the device's clock is set to, used to correct device-reported times to UTC
+	location *time.Location
 }
 
-func newLight(client *tcpClient, l *zap.Logger, conf *config.Device, db *bolthold.Store, em bool) *Light {
+func newLight(client *tcpClient, l *zap.Logger, conf *config.Device, db *bolthold.Store, em bool, loc *time.Location) *Light {
 	return &Light{
 		brightness: resource.NewValue(resource.WithInitialValue(&lightpb.Brightness{}), resource.WithNoDuplicates()),
 		client:     client,
 		conf:       conf,
 		database:   db,
 		isEm:       em,
+		location:   loc,
 		logger:     l,
 		testResultSet: resource.NewValue(resource.WithInitialValue(&emergencylightpb.TestResultSet{
 			DurationTest: &emergencylightpb.EmergencyTestResult{},
@@ -453,7 +456,10 @@ func (l *Light) getDurationTestResult(ctx context.Context) (*EmergencyState, err
 }
 
 // parseGetCompletionTimeResponse parses the response from the device for the completion time of a function/duration test.
-func parseGetCompletionTimeResponse(r string) (*time.Time, error) {
+//
+// The device reports epoch seconds derived from its local wall-clock, so when loc is set the reported
+// time is re-interpreted in that timezone to recover the correct UTC instant.
+func parseGetCompletionTimeResponse(r string, loc *time.Location) (*time.Time, error) {
 	// example response ?V:1,C:170,@10.106.4.40=1754495355#
 	// the time is seconds in the Linux epoch
 	split := strings.Split(r, "=")
@@ -473,6 +479,12 @@ func parseGetCompletionTimeResponse(r string) (*time.Time, error) {
 	if t.IsZero() {
 		return nil, fmt.Errorf("function test completion time is zero")
 	}
+	if loc != nil {
+		// the epoch seconds encode the device's local wall-clock, take that wall-clock and
+		// place it in the device's timezone to get the true instant
+		wall := t.UTC()
+		t = time.Date(wall.Year(), wall.Month(), wall.Day(), wall.Hour(), wall.Minute(), wall.Second(), 0, loc)
+	}
 	return &t, nil
 }
 
@@ -487,7 +499,7 @@ func (l *Light) getFunctionTestCompletionTime(ctx context.Context) (*time.Time, 
 		return nil, err
 	}
 
-	return parseGetCompletionTimeResponse(r)
+	return parseGetCompletionTimeResponse(r, l.location)
 }
 
 // getDurationTestCompletionTime queries the device for the finish time of the last duration test.
@@ -501,7 +513,7 @@ func (l *Light) getDurationTestCompletionTime(ctx context.Context) (*time.Time, 
 		return nil, err
 	}
 
-	return parseGetCompletionTimeResponse(r)
+	return parseGetCompletionTimeResponse(r, l.location)
 }
 
 func (l *Light) StartFunctionTest(ctx context.Context, _ *emergencylightpb.StartEmergencyTestRequest) (*emergencylightpb.StartEmergencyTestResponse, error) {

--- a/pkg/driver/helvarnet/light_test.go
+++ b/pkg/driver/helvarnet/light_test.go
@@ -1,0 +1,85 @@
+package helvarnet
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_parseGetCompletionTimeResponse(t *testing.T) {
+	london, err := time.LoadLocation("Europe/London")
+	if err != nil {
+		t.Fatalf("failed to load Europe/London: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		r       string
+		loc     *time.Location
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name: "no timezone, epoch taken as-is",
+			r:    "?V:1,C:170,@10.106.4.40=1754495355#",
+			loc:  nil,
+			want: time.Unix(1754495355, 0),
+		},
+		{
+			name: "UTC timezone, epoch taken as-is",
+			r:    "?V:1,C:170,@10.106.4.40=1754495355#",
+			loc:  time.UTC,
+			want: time.Unix(1754495355, 0),
+		},
+		{
+			// device clock is set to BST (UTC+1), reported wall-clock is 2025-08-06 15:49:15,
+			// the true instant is an hour earlier than the raw epoch suggests
+			name: "Europe/London during BST shifts back an hour",
+			r:    "?V:1,C:170,@10.106.4.40=1754495355#",
+			loc:  london,
+			want: time.Unix(1754495355, 0).Add(-time.Hour),
+		},
+		{
+			// during GMT Europe/London matches UTC, no shift
+			name: "Europe/London during GMT is unchanged",
+			r:    "?V:1,C:170,@10.106.4.40=1736500000#",
+			loc:  london,
+			want: time.Unix(1736500000, 0),
+		},
+		{
+			name:    "zero time means test never run",
+			r:       "?V:1,C:170,@10.106.4.40=0#",
+			loc:     nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid response",
+			r:       "?V:1,C:170,@10.106.4.40",
+			loc:     nil,
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric time",
+			r:       "?V:1,C:170,@10.106.4.40=abc#",
+			loc:     nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGetCompletionTimeResponse(tt.r, tt.loc)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseGetCompletionTimeResponse(%q) expected error, got %v", tt.r, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseGetCompletionTimeResponse(%q) unexpected error: %v", tt.r, err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("parseGetCompletionTimeResponse(%q) = %v, want %v", tt.r, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[SCB-1232](https://vanti.youtrack.cloud/issue/SCB-1232)
Helvar routers report emergency test completion times as epoch seconds
derived from their local wall-clock, so when router clocks are set to
local time (e.g. BST) the reported instant is offset from true UTC.

Add a timezone config option naming the IANA zone the router clocks
follow; reported times are re-interpreted in that zone to recover the
correct UTC instant. Defaults to UTC (no correction), and the shift is
DST-aware so it stays correct year-round.