### PR TITLE
logpb,ui/ops: add per-service log view widget to service sidebars

### DIFF
--- a/pkg/app/services.go
+++ b/pkg/app/services.go
@@ -230,8 +230,15 @@ func logServiceRecordChange(logger *zap.Logger, oldVal, newVal *service.StateRec
 	}
 }
 
+// Log field keys attached to service lifecycle loggers.
+// Clients filter PullLogMessages on these keys; keep in sync with logFields in ui/ops/src/api/ui/log.js.
+const (
+	logFieldServiceID   = "service.id"
+	logFieldServiceKind = "service.kind"
+)
+
 func loggerWithServiceInfo(logger *zap.Logger, id, kind string) *zap.Logger {
-	return logger.With(zap.String("service.id", id), zap.String("service.kind", kind))
+	return logger.With(zap.String(logFieldServiceID, id), zap.String(logFieldServiceKind, kind))
 }
 
 func healthChecksForService(r *healthpb.Registry, id, kind string) *healthpb.Checks {

--- a/pkg/proto/logpb/log.pb.go
+++ b/pkg/proto/logpb/log.pb.go
@@ -345,7 +345,9 @@ type PullLogMessagesRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Number of buffered messages to replay before streaming live.
-	// Analogous to tail -n <count>. Default: 200. Max: 1000.
+	// Analogous to tail -n <count>. When min_level or field_filter are set, up
+	// to this many MATCHING messages are replayed, scanning older buffer
+	// entries as needed. Default: 200. Max: 1000.
 	InitialCount int32 `protobuf:"varint,2,opt,name=initial_count,json=initialCount,proto3" json:"initial_count,omitempty"`
 	// If true, skip the initial replay and stream from now onwards only.
 	UpdatesOnly bool `protobuf:"varint,3,opt,name=updates_only,json=updatesOnly,proto3" json:"updates_only,omitempty"`
@@ -353,8 +355,13 @@ type PullLogMessagesRequest struct {
 	MinLevel Level `protobuf:"varint,4,opt,name=min_level,json=minLevel,proto3,enum=smartcore.bos.log.v1.Level" json:"min_level,omitempty"`
 	// Optional: filter by logger name prefix.
 	// Reserved for future use; server may return UNIMPLEMENTED if used.
-	LoggerFilter  string                 `protobuf:"bytes,5,opt,name=logger_filter,json=loggerFilter,proto3" json:"logger_filter,omitempty"`
-	ReadMask      *fieldmaskpb.FieldMask `protobuf:"bytes,6,opt,name=read_mask,json=readMask,proto3" json:"read_mask,omitempty"`
+	LoggerFilter string                 `protobuf:"bytes,5,opt,name=logger_filter,json=loggerFilter,proto3" json:"logger_filter,omitempty"`
+	ReadMask     *fieldmaskpb.FieldMask `protobuf:"bytes,6,opt,name=read_mask,json=readMask,proto3" json:"read_mask,omitempty"`
+	// Optional: filter by structured field values. A message matches only when
+	// every entry here equals the corresponding entry in the message's fields
+	// map (exact match, AND semantics). An empty map matches all messages.
+	// Combined with min_level (both must pass).
+	FieldFilter   map[string]string `protobuf:"bytes,7,rep,name=field_filter,json=fieldFilter,proto3" json:"field_filter,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -427,6 +434,13 @@ func (x *PullLogMessagesRequest) GetLoggerFilter() string {
 func (x *PullLogMessagesRequest) GetReadMask() *fieldmaskpb.FieldMask {
 	if x != nil {
 		return x.ReadMask
+	}
+	return nil
+}
+
+func (x *PullLogMessagesRequest) GetFieldFilter() map[string]string {
+	if x != nil {
+		return x.FieldFilter
 	}
 	return nil
 }
@@ -964,7 +978,7 @@ type PullLogMessagesResponse_Change struct {
 
 func (x *PullLogMessagesResponse_Change) Reset() {
 	*x = PullLogMessagesResponse_Change{}
-	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[16]
+	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -976,7 +990,7 @@ func (x *PullLogMessagesResponse_Change) String() string {
 func (*PullLogMessagesResponse_Change) ProtoMessage() {}
 
 func (x *PullLogMessagesResponse_Change) ProtoReflect() protoreflect.Message {
-	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[16]
+	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1024,7 +1038,7 @@ type PullLogLevelResponse_Change struct {
 
 func (x *PullLogLevelResponse_Change) Reset() {
 	*x = PullLogLevelResponse_Change{}
-	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[17]
+	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1036,7 +1050,7 @@ func (x *PullLogLevelResponse_Change) String() string {
 func (*PullLogLevelResponse_Change) ProtoMessage() {}
 
 func (x *PullLogLevelResponse_Change) ProtoReflect() protoreflect.Message {
-	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[17]
+	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1084,7 +1098,7 @@ type PullLogMetadataResponse_Change struct {
 
 func (x *PullLogMetadataResponse_Change) Reset() {
 	*x = PullLogMetadataResponse_Change{}
-	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[18]
+	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1096,7 +1110,7 @@ func (x *PullLogMetadataResponse_Change) String() string {
 func (*PullLogMetadataResponse_Change) ProtoMessage() {}
 
 func (x *PullLogMetadataResponse_Change) ProtoReflect() protoreflect.Message {
-	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[18]
+	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1149,7 +1163,7 @@ type GetDownloadLogUrlResponse_LogFile struct {
 
 func (x *GetDownloadLogUrlResponse_LogFile) Reset() {
 	*x = GetDownloadLogUrlResponse_LogFile{}
-	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[19]
+	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1161,7 +1175,7 @@ func (x *GetDownloadLogUrlResponse_LogFile) String() string {
 func (*GetDownloadLogUrlResponse_LogFile) ProtoMessage() {}
 
 func (x *GetDownloadLogUrlResponse_LogFile) ProtoReflect() protoreflect.Message {
-	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[19]
+	mi := &file_smartcore_bos_log_v1_log_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1232,14 +1246,18 @@ const file_smartcore_bos_log_v1_log_proto_rawDesc = "" +
 	"\vLogMetadata\x12(\n" +
 	"\x10total_size_bytes\x18\x01 \x01(\x03R\x0etotalSizeBytes\x12\x1d\n" +
 	"\n" +
-	"file_count\x18\x02 \x01(\x05R\tfileCount\"\x8c\x02\n" +
+	"file_count\x18\x02 \x01(\x05R\tfileCount\"\xae\x03\n" +
 	"\x16PullLogMessagesRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12#\n" +
 	"\rinitial_count\x18\x02 \x01(\x05R\finitialCount\x12!\n" +
 	"\fupdates_only\x18\x03 \x01(\bR\vupdatesOnly\x128\n" +
 	"\tmin_level\x18\x04 \x01(\x0e2\x1b.smartcore.bos.log.v1.LevelR\bminLevel\x12#\n" +
 	"\rlogger_filter\x18\x05 \x01(\tR\floggerFilter\x127\n" +
-	"\tread_mask\x18\x06 \x01(\v2\x1a.google.protobuf.FieldMaskR\breadMask\"\x83\x02\n" +
+	"\tread_mask\x18\x06 \x01(\v2\x1a.google.protobuf.FieldMaskR\breadMask\x12`\n" +
+	"\ffield_filter\x18\a \x03(\v2=.smartcore.bos.log.v1.PullLogMessagesRequest.FieldFilterEntryR\vfieldFilter\x1a>\n" +
+	"\x10FieldFilterEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x83\x02\n" +
 	"\x17PullLogMessagesResponse\x12N\n" +
 	"\achanges\x18\x01 \x03(\v24.smartcore.bos.log.v1.PullLogMessagesResponse.ChangeR\achanges\x1a\x97\x01\n" +
 	"\x06Change\x12\x12\n" +
@@ -1322,7 +1340,7 @@ func file_smartcore_bos_log_v1_log_proto_rawDescGZIP() []byte {
 }
 
 var file_smartcore_bos_log_v1_log_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_smartcore_bos_log_v1_log_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_smartcore_bos_log_v1_log_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_smartcore_bos_log_v1_log_proto_goTypes = []any{
 	(Level)(0),                                // 0: smartcore.bos.log.v1.Level
 	(*SourceLocation)(nil),                    // 1: smartcore.bos.log.v1.SourceLocation
@@ -1341,58 +1359,60 @@ var file_smartcore_bos_log_v1_log_proto_goTypes = []any{
 	(*GetDownloadLogUrlRequest)(nil),          // 14: smartcore.bos.log.v1.GetDownloadLogUrlRequest
 	(*GetDownloadLogUrlResponse)(nil),         // 15: smartcore.bos.log.v1.GetDownloadLogUrlResponse
 	nil,                                       // 16: smartcore.bos.log.v1.LogMessage.FieldsEntry
-	(*PullLogMessagesResponse_Change)(nil),    // 17: smartcore.bos.log.v1.PullLogMessagesResponse.Change
-	(*PullLogLevelResponse_Change)(nil),       // 18: smartcore.bos.log.v1.PullLogLevelResponse.Change
-	(*PullLogMetadataResponse_Change)(nil),    // 19: smartcore.bos.log.v1.PullLogMetadataResponse.Change
-	(*GetDownloadLogUrlResponse_LogFile)(nil), // 20: smartcore.bos.log.v1.GetDownloadLogUrlResponse.LogFile
-	(*timestamppb.Timestamp)(nil),             // 21: google.protobuf.Timestamp
-	(*fieldmaskpb.FieldMask)(nil),             // 22: google.protobuf.FieldMask
-	(*durationpb.Duration)(nil),               // 23: google.protobuf.Duration
+	nil,                                       // 17: smartcore.bos.log.v1.PullLogMessagesRequest.FieldFilterEntry
+	(*PullLogMessagesResponse_Change)(nil),    // 18: smartcore.bos.log.v1.PullLogMessagesResponse.Change
+	(*PullLogLevelResponse_Change)(nil),       // 19: smartcore.bos.log.v1.PullLogLevelResponse.Change
+	(*PullLogMetadataResponse_Change)(nil),    // 20: smartcore.bos.log.v1.PullLogMetadataResponse.Change
+	(*GetDownloadLogUrlResponse_LogFile)(nil), // 21: smartcore.bos.log.v1.GetDownloadLogUrlResponse.LogFile
+	(*timestamppb.Timestamp)(nil),             // 22: google.protobuf.Timestamp
+	(*fieldmaskpb.FieldMask)(nil),             // 23: google.protobuf.FieldMask
+	(*durationpb.Duration)(nil),               // 24: google.protobuf.Duration
 }
 var file_smartcore_bos_log_v1_log_proto_depIdxs = []int32{
-	21, // 0: smartcore.bos.log.v1.LogMessage.timestamp:type_name -> google.protobuf.Timestamp
+	22, // 0: smartcore.bos.log.v1.LogMessage.timestamp:type_name -> google.protobuf.Timestamp
 	0,  // 1: smartcore.bos.log.v1.LogMessage.level:type_name -> smartcore.bos.log.v1.Level
 	16, // 2: smartcore.bos.log.v1.LogMessage.fields:type_name -> smartcore.bos.log.v1.LogMessage.FieldsEntry
 	1,  // 3: smartcore.bos.log.v1.LogMessage.source_location:type_name -> smartcore.bos.log.v1.SourceLocation
 	0,  // 4: smartcore.bos.log.v1.LogLevel.level:type_name -> smartcore.bos.log.v1.Level
 	0,  // 5: smartcore.bos.log.v1.PullLogMessagesRequest.min_level:type_name -> smartcore.bos.log.v1.Level
-	22, // 6: smartcore.bos.log.v1.PullLogMessagesRequest.read_mask:type_name -> google.protobuf.FieldMask
-	17, // 7: smartcore.bos.log.v1.PullLogMessagesResponse.changes:type_name -> smartcore.bos.log.v1.PullLogMessagesResponse.Change
-	22, // 8: smartcore.bos.log.v1.GetLogLevelRequest.read_mask:type_name -> google.protobuf.FieldMask
-	22, // 9: smartcore.bos.log.v1.PullLogLevelRequest.read_mask:type_name -> google.protobuf.FieldMask
-	18, // 10: smartcore.bos.log.v1.PullLogLevelResponse.changes:type_name -> smartcore.bos.log.v1.PullLogLevelResponse.Change
-	3,  // 11: smartcore.bos.log.v1.UpdateLogLevelRequest.log_level:type_name -> smartcore.bos.log.v1.LogLevel
-	22, // 12: smartcore.bos.log.v1.UpdateLogLevelRequest.update_mask:type_name -> google.protobuf.FieldMask
-	22, // 13: smartcore.bos.log.v1.GetLogMetadataRequest.read_mask:type_name -> google.protobuf.FieldMask
-	22, // 14: smartcore.bos.log.v1.PullLogMetadataRequest.read_mask:type_name -> google.protobuf.FieldMask
-	19, // 15: smartcore.bos.log.v1.PullLogMetadataResponse.changes:type_name -> smartcore.bos.log.v1.PullLogMetadataResponse.Change
-	23, // 16: smartcore.bos.log.v1.GetDownloadLogUrlRequest.url_ttl:type_name -> google.protobuf.Duration
-	20, // 17: smartcore.bos.log.v1.GetDownloadLogUrlResponse.files:type_name -> smartcore.bos.log.v1.GetDownloadLogUrlResponse.LogFile
-	21, // 18: smartcore.bos.log.v1.PullLogMessagesResponse.Change.change_time:type_name -> google.protobuf.Timestamp
-	2,  // 19: smartcore.bos.log.v1.PullLogMessagesResponse.Change.messages:type_name -> smartcore.bos.log.v1.LogMessage
-	21, // 20: smartcore.bos.log.v1.PullLogLevelResponse.Change.change_time:type_name -> google.protobuf.Timestamp
-	3,  // 21: smartcore.bos.log.v1.PullLogLevelResponse.Change.log_level:type_name -> smartcore.bos.log.v1.LogLevel
-	21, // 22: smartcore.bos.log.v1.PullLogMetadataResponse.Change.change_time:type_name -> google.protobuf.Timestamp
-	4,  // 23: smartcore.bos.log.v1.PullLogMetadataResponse.Change.log_metadata:type_name -> smartcore.bos.log.v1.LogMetadata
-	5,  // 24: smartcore.bos.log.v1.LogApi.PullLogMessages:input_type -> smartcore.bos.log.v1.PullLogMessagesRequest
-	7,  // 25: smartcore.bos.log.v1.LogApi.GetLogLevel:input_type -> smartcore.bos.log.v1.GetLogLevelRequest
-	8,  // 26: smartcore.bos.log.v1.LogApi.PullLogLevel:input_type -> smartcore.bos.log.v1.PullLogLevelRequest
-	10, // 27: smartcore.bos.log.v1.LogApi.UpdateLogLevel:input_type -> smartcore.bos.log.v1.UpdateLogLevelRequest
-	11, // 28: smartcore.bos.log.v1.LogApi.GetLogMetadata:input_type -> smartcore.bos.log.v1.GetLogMetadataRequest
-	12, // 29: smartcore.bos.log.v1.LogApi.PullLogMetadata:input_type -> smartcore.bos.log.v1.PullLogMetadataRequest
-	14, // 30: smartcore.bos.log.v1.LogApi.GetDownloadLogUrl:input_type -> smartcore.bos.log.v1.GetDownloadLogUrlRequest
-	6,  // 31: smartcore.bos.log.v1.LogApi.PullLogMessages:output_type -> smartcore.bos.log.v1.PullLogMessagesResponse
-	3,  // 32: smartcore.bos.log.v1.LogApi.GetLogLevel:output_type -> smartcore.bos.log.v1.LogLevel
-	9,  // 33: smartcore.bos.log.v1.LogApi.PullLogLevel:output_type -> smartcore.bos.log.v1.PullLogLevelResponse
-	3,  // 34: smartcore.bos.log.v1.LogApi.UpdateLogLevel:output_type -> smartcore.bos.log.v1.LogLevel
-	4,  // 35: smartcore.bos.log.v1.LogApi.GetLogMetadata:output_type -> smartcore.bos.log.v1.LogMetadata
-	13, // 36: smartcore.bos.log.v1.LogApi.PullLogMetadata:output_type -> smartcore.bos.log.v1.PullLogMetadataResponse
-	15, // 37: smartcore.bos.log.v1.LogApi.GetDownloadLogUrl:output_type -> smartcore.bos.log.v1.GetDownloadLogUrlResponse
-	31, // [31:38] is the sub-list for method output_type
-	24, // [24:31] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	23, // 6: smartcore.bos.log.v1.PullLogMessagesRequest.read_mask:type_name -> google.protobuf.FieldMask
+	17, // 7: smartcore.bos.log.v1.PullLogMessagesRequest.field_filter:type_name -> smartcore.bos.log.v1.PullLogMessagesRequest.FieldFilterEntry
+	18, // 8: smartcore.bos.log.v1.PullLogMessagesResponse.changes:type_name -> smartcore.bos.log.v1.PullLogMessagesResponse.Change
+	23, // 9: smartcore.bos.log.v1.GetLogLevelRequest.read_mask:type_name -> google.protobuf.FieldMask
+	23, // 10: smartcore.bos.log.v1.PullLogLevelRequest.read_mask:type_name -> google.protobuf.FieldMask
+	19, // 11: smartcore.bos.log.v1.PullLogLevelResponse.changes:type_name -> smartcore.bos.log.v1.PullLogLevelResponse.Change
+	3,  // 12: smartcore.bos.log.v1.UpdateLogLevelRequest.log_level:type_name -> smartcore.bos.log.v1.LogLevel
+	23, // 13: smartcore.bos.log.v1.UpdateLogLevelRequest.update_mask:type_name -> google.protobuf.FieldMask
+	23, // 14: smartcore.bos.log.v1.GetLogMetadataRequest.read_mask:type_name -> google.protobuf.FieldMask
+	23, // 15: smartcore.bos.log.v1.PullLogMetadataRequest.read_mask:type_name -> google.protobuf.FieldMask
+	20, // 16: smartcore.bos.log.v1.PullLogMetadataResponse.changes:type_name -> smartcore.bos.log.v1.PullLogMetadataResponse.Change
+	24, // 17: smartcore.bos.log.v1.GetDownloadLogUrlRequest.url_ttl:type_name -> google.protobuf.Duration
+	21, // 18: smartcore.bos.log.v1.GetDownloadLogUrlResponse.files:type_name -> smartcore.bos.log.v1.GetDownloadLogUrlResponse.LogFile
+	22, // 19: smartcore.bos.log.v1.PullLogMessagesResponse.Change.change_time:type_name -> google.protobuf.Timestamp
+	2,  // 20: smartcore.bos.log.v1.PullLogMessagesResponse.Change.messages:type_name -> smartcore.bos.log.v1.LogMessage
+	22, // 21: smartcore.bos.log.v1.PullLogLevelResponse.Change.change_time:type_name -> google.protobuf.Timestamp
+	3,  // 22: smartcore.bos.log.v1.PullLogLevelResponse.Change.log_level:type_name -> smartcore.bos.log.v1.LogLevel
+	22, // 23: smartcore.bos.log.v1.PullLogMetadataResponse.Change.change_time:type_name -> google.protobuf.Timestamp
+	4,  // 24: smartcore.bos.log.v1.PullLogMetadataResponse.Change.log_metadata:type_name -> smartcore.bos.log.v1.LogMetadata
+	5,  // 25: smartcore.bos.log.v1.LogApi.PullLogMessages:input_type -> smartcore.bos.log.v1.PullLogMessagesRequest
+	7,  // 26: smartcore.bos.log.v1.LogApi.GetLogLevel:input_type -> smartcore.bos.log.v1.GetLogLevelRequest
+	8,  // 27: smartcore.bos.log.v1.LogApi.PullLogLevel:input_type -> smartcore.bos.log.v1.PullLogLevelRequest
+	10, // 28: smartcore.bos.log.v1.LogApi.UpdateLogLevel:input_type -> smartcore.bos.log.v1.UpdateLogLevelRequest
+	11, // 29: smartcore.bos.log.v1.LogApi.GetLogMetadata:input_type -> smartcore.bos.log.v1.GetLogMetadataRequest
+	12, // 30: smartcore.bos.log.v1.LogApi.PullLogMetadata:input_type -> smartcore.bos.log.v1.PullLogMetadataRequest
+	14, // 31: smartcore.bos.log.v1.LogApi.GetDownloadLogUrl:input_type -> smartcore.bos.log.v1.GetDownloadLogUrlRequest
+	6,  // 32: smartcore.bos.log.v1.LogApi.PullLogMessages:output_type -> smartcore.bos.log.v1.PullLogMessagesResponse
+	3,  // 33: smartcore.bos.log.v1.LogApi.GetLogLevel:output_type -> smartcore.bos.log.v1.LogLevel
+	9,  // 34: smartcore.bos.log.v1.LogApi.PullLogLevel:output_type -> smartcore.bos.log.v1.PullLogLevelResponse
+	3,  // 35: smartcore.bos.log.v1.LogApi.UpdateLogLevel:output_type -> smartcore.bos.log.v1.LogLevel
+	4,  // 36: smartcore.bos.log.v1.LogApi.GetLogMetadata:output_type -> smartcore.bos.log.v1.LogMetadata
+	13, // 37: smartcore.bos.log.v1.LogApi.PullLogMetadata:output_type -> smartcore.bos.log.v1.PullLogMetadataResponse
+	15, // 38: smartcore.bos.log.v1.LogApi.GetDownloadLogUrl:output_type -> smartcore.bos.log.v1.GetDownloadLogUrlResponse
+	32, // [32:39] is the sub-list for method output_type
+	25, // [25:32] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_smartcore_bos_log_v1_log_proto_init() }
@@ -1406,7 +1426,7 @@ func file_smartcore_bos_log_v1_log_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_smartcore_bos_log_v1_log_proto_rawDesc), len(file_smartcore_bos_log_v1_log_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   20,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/proto/logpb/model.go
+++ b/pkg/proto/logpb/model.go
@@ -2,6 +2,7 @@ package logpb
 
 import (
 	"context"
+	"slices"
 	"sync"
 
 	"github.com/smart-core-os/sc-bos/pkg/resource"
@@ -91,17 +92,14 @@ func (m *Model) TailMatching(n int, match func(*LogMessage) bool) []*LogMessage 
 	cap := len(m.buf)
 	// Walk newest -> oldest collecting matches, then reverse into
 	// chronological order.
-	var rev []*LogMessage
-	for i := 0; i < m.bufSize && len(rev) < n; i++ {
+	var result []*LogMessage
+	for i := 0; i < m.bufSize && len(result) < n; i++ {
 		msg := m.buf[(m.bufHead-1-i+cap)%cap]
 		if match == nil || match(msg) {
-			rev = append(rev, msg)
+			result = append(result, msg)
 		}
 	}
-	result := make([]*LogMessage, len(rev))
-	for i, msg := range rev {
-		result[len(rev)-1-i] = msg
-	}
+	slices.Reverse(result)
 	return result
 }
 

--- a/pkg/proto/logpb/model.go
+++ b/pkg/proto/logpb/model.go
@@ -76,19 +76,31 @@ func (m *Model) AppendMessage(msg *LogMessage) {
 // TailMessages returns the most recent n messages in chronological order.
 // If n exceeds the number of buffered messages, all buffered messages are returned.
 func (m *Model) TailMessages(n int) []*LogMessage {
+	return m.TailMatching(n, nil)
+}
+
+// TailMatching returns up to the n most recent messages for which match
+// returns true, in chronological order, scanning back through the whole
+// buffer as needed. A nil match behaves like TailMessages(n).
+func (m *Model) TailMatching(n int, match func(*LogMessage) bool) []*LogMessage {
 	if n <= 0 {
 		return nil
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if n > m.bufSize {
-		n = m.bufSize
-	}
-	result := make([]*LogMessage, n)
 	cap := len(m.buf)
-	start := (m.bufHead - n + cap) % cap
-	for i := range n {
-		result[i] = m.buf[(start+i)%cap]
+	// Walk newest -> oldest collecting matches, then reverse into
+	// chronological order.
+	var rev []*LogMessage
+	for i := 0; i < m.bufSize && len(rev) < n; i++ {
+		msg := m.buf[(m.bufHead-1-i+cap)%cap]
+		if match == nil || match(msg) {
+			rev = append(rev, msg)
+		}
+	}
+	result := make([]*LogMessage, len(rev))
+	for i, msg := range rev {
+		result[len(rev)-1-i] = msg
 	}
 	return result
 }

--- a/pkg/proto/logpb/model_server.go
+++ b/pkg/proto/logpb/model_server.go
@@ -52,19 +52,18 @@ func (s *ModelServer) PullLogMessages(request *PullLogMessagesRequest, server Lo
 	ch, cancel := s.model.Subscribe()
 	defer cancel()
 
-	initial := s.model.TailMessages(n)
+	initial := s.model.TailMatching(n, func(m *LogMessage) bool {
+		return matchesMinLevel(m, request.MinLevel) && matchesFieldFilter(m, request.FieldFilter)
+	})
 	if len(initial) > 0 {
-		filtered := filterMessages(initial, request.MinLevel)
-		if len(filtered) > 0 {
-			if err := server.Send(&PullLogMessagesResponse{
-				Changes: []*PullLogMessagesResponse_Change{{
-					Name:       request.Name,
-					ChangeTime: timestamppb.Now(),
-					Messages:   filtered,
-				}},
-			}); err != nil {
-				return err
-			}
+		if err := server.Send(&PullLogMessagesResponse{
+			Changes: []*PullLogMessagesResponse_Change{{
+				Name:       request.Name,
+				ChangeTime: timestamppb.Now(),
+				Messages:   initial,
+			}},
+		}); err != nil {
+			return err
 		}
 	}
 
@@ -77,7 +76,7 @@ func (s *ModelServer) PullLogMessages(request *PullLogMessagesRequest, server Lo
 			if !ok {
 				return nil
 			}
-			filtered := filterMessages(batch, request.MinLevel)
+			filtered := filterMessages(batch, request.MinLevel, request.FieldFilter)
 			if len(filtered) == 0 {
 				continue
 			}
@@ -94,17 +93,34 @@ func (s *ModelServer) PullLogMessages(request *PullLogMessagesRequest, server Lo
 	}
 }
 
-func filterMessages(msgs []*LogMessage, minLevel Level) []*LogMessage {
-	if minLevel == Level_LEVEL_UNSPECIFIED {
+func filterMessages(msgs []*LogMessage, minLevel Level, fieldFilter map[string]string) []*LogMessage {
+	if minLevel == Level_LEVEL_UNSPECIFIED && len(fieldFilter) == 0 {
 		return msgs
 	}
 	out := msgs[:0:0] // reuse underlying array header but don't share
 	for _, m := range msgs {
-		if m.Level >= minLevel {
+		if matchesMinLevel(m, minLevel) && matchesFieldFilter(m, fieldFilter) {
 			out = append(out, m)
 		}
 	}
 	return out
+}
+
+// matchesMinLevel reports whether m's level is at least minLevel.
+// LEVEL_UNSPECIFIED matches everything.
+func matchesMinLevel(m *LogMessage, minLevel Level) bool {
+	return minLevel == Level_LEVEL_UNSPECIFIED || m.Level >= minLevel
+}
+
+// matchesFieldFilter reports whether m's fields contain every key/value pair
+// in filter (exact match). An empty/nil filter matches everything.
+func matchesFieldFilter(m *LogMessage, filter map[string]string) bool {
+	for k, v := range filter {
+		if got, ok := m.GetFields()[k]; !ok || got != v {
+			return false
+		}
+	}
+	return true
 }
 
 // GetLogLevel returns the current log level.

--- a/pkg/proto/logpb/model_server_test.go
+++ b/pkg/proto/logpb/model_server_test.go
@@ -1,0 +1,199 @@
+package logpb
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// fakeMessagesStream is a LogApi_PullLogMessagesServer that records sent responses.
+type fakeMessagesStream struct {
+	grpc.ServerStream
+	ctx context.Context
+
+	mu   sync.Mutex
+	sent []*PullLogMessagesResponse
+}
+
+func (f *fakeMessagesStream) Send(r *PullLogMessagesResponse) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sent = append(f.sent, r)
+	return nil
+}
+
+func (f *fakeMessagesStream) Context() context.Context { return f.ctx }
+
+// sentMessages returns the Message field of every LogMessage sent so far.
+func (f *fakeMessagesStream) sentMessages() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for _, res := range f.sent {
+		for _, c := range res.Changes {
+			out = append(out, messages(c.Messages)...)
+		}
+	}
+	return out
+}
+
+// fieldMsg builds a LogMessage with the given text, level and fields.
+func fieldMsg(text string, level Level, fields map[string]string) *LogMessage {
+	return &LogMessage{Message: text, Level: level, Fields: fields}
+}
+
+// pullReplay runs PullLogMessages with a cancelled-after-replay context and
+// returns the messages sent during the initial replay.
+func pullReplay(t *testing.T, model *Model, req *PullLogMessagesRequest) []string {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := &fakeMessagesStream{ctx: ctx}
+	srv := NewModelServer(model)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = srv.PullLogMessages(req, stream)
+	}()
+	// The replay happens synchronously before the live loop; give it a moment
+	// then cancel to unblock the live loop.
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("PullLogMessages did not return after context cancel")
+	}
+	return stream.sentMessages()
+}
+
+func TestPullLogMessages_fieldFilterMatch(t *testing.T) {
+	model := NewModel(8)
+	model.AppendMessage(fieldMsg("ours1", Level_LEVEL_INFO, map[string]string{"service.id": "a", "service.kind": "bacnet"}))
+	model.AppendMessage(fieldMsg("theirs", Level_LEVEL_INFO, map[string]string{"service.id": "b", "service.kind": "bacnet"}))
+	model.AppendMessage(fieldMsg("nofields", Level_LEVEL_INFO, nil))
+	model.AppendMessage(fieldMsg("ours2", Level_LEVEL_INFO, map[string]string{"service.id": "a", "service.kind": "bacnet"}))
+
+	got := pullReplay(t, model, &PullLogMessagesRequest{
+		FieldFilter: map[string]string{"service.id": "a", "service.kind": "bacnet"},
+	})
+	want := []string{"ours1", "ours2"}
+	if !sliceEq(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPullLogMessages_fieldFilterPartialMismatch(t *testing.T) {
+	model := NewModel(8)
+	model.AppendMessage(fieldMsg("a", Level_LEVEL_INFO, map[string]string{"service.id": "a", "service.kind": "bacnet"}))
+
+	// One key matches, the other doesn't — AND semantics means no match.
+	got := pullReplay(t, model, &PullLogMessagesRequest{
+		FieldFilter: map[string]string{"service.id": "a", "service.kind": "modbus"},
+	})
+	if len(got) != 0 {
+		t.Errorf("got %v, want no messages", got)
+	}
+}
+
+func TestPullLogMessages_emptyFilterReturnsAll(t *testing.T) {
+	model := NewModel(8)
+	model.AppendMessage(fieldMsg("a", Level_LEVEL_INFO, map[string]string{"k": "v"}))
+	model.AppendMessage(fieldMsg("b", Level_LEVEL_INFO, nil))
+
+	got := pullReplay(t, model, &PullLogMessagesRequest{})
+	want := []string{"a", "b"}
+	if !sliceEq(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPullLogMessages_fieldFilterAndMinLevel(t *testing.T) {
+	model := NewModel(8)
+	fields := map[string]string{"service.id": "a"}
+	model.AppendMessage(fieldMsg("debug", Level_LEVEL_DEBUG, fields))
+	model.AppendMessage(fieldMsg("info", Level_LEVEL_INFO, fields))
+	model.AppendMessage(fieldMsg("warn-other", Level_LEVEL_WARN, map[string]string{"service.id": "b"}))
+
+	got := pullReplay(t, model, &PullLogMessagesRequest{
+		MinLevel:    Level_LEVEL_INFO,
+		FieldFilter: map[string]string{"service.id": "a"},
+	})
+	want := []string{"info"}
+	if !sliceEq(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPullLogMessages_initialCountCountsMatching(t *testing.T) {
+	model := NewModel(16)
+	fields := map[string]string{"service.id": "a"}
+	// Interleave 5 matching with non-matching noise.
+	for _, s := range []string{"m1", "m2", "m3", "m4", "m5"} {
+		model.AppendMessage(fieldMsg(s, Level_LEVEL_INFO, fields))
+		model.AppendMessage(fieldMsg("noise", Level_LEVEL_INFO, nil))
+	}
+
+	got := pullReplay(t, model, &PullLogMessagesRequest{
+		InitialCount: 3,
+		FieldFilter:  map[string]string{"service.id": "a"},
+	})
+	// Up to initial_count MATCHING messages, newest first, chronological order.
+	want := []string{"m3", "m4", "m5"}
+	if !sliceEq(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPullLogMessages_livePathFiltered(t *testing.T) {
+	model := NewModel(8)
+	srv := NewModelServer(model)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := &fakeMessagesStream{ctx: ctx}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = srv.PullLogMessages(&PullLogMessagesRequest{
+			UpdatesOnly: true,
+			FieldFilter: map[string]string{"service.id": "a"},
+		}, stream)
+	}()
+
+	// Give the server a moment to subscribe before appending.
+	time.Sleep(10 * time.Millisecond)
+	model.AppendMessage(fieldMsg("ours", Level_LEVEL_INFO, map[string]string{"service.id": "a"}))
+	model.AppendMessage(fieldMsg("theirs", Level_LEVEL_INFO, map[string]string{"service.id": "b"}))
+
+	deadline := time.After(time.Second)
+	for {
+		got := stream.sentMessages()
+		if len(got) > 0 {
+			if !sliceEq(got, []string{"ours"}) {
+				t.Errorf("got %v, want [ours]", got)
+			}
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timeout waiting for live message")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("PullLogMessages did not return after cancel")
+	}
+
+	// "theirs" must never arrive, even after waiting.
+	if got := stream.sentMessages(); !sliceEq(got, []string{"ours"}) {
+		t.Errorf("after cancel: got %v, want [ours]", got)
+	}
+}

--- a/pkg/proto/logpb/model_test.go
+++ b/pkg/proto/logpb/model_test.go
@@ -103,6 +103,79 @@ func TestTailMessages_chronologicalOrder(t *testing.T) {
 	}
 }
 
+// ---- Ring buffer: tail with match -----------------------------------------------
+
+// matchMsg matches messages whose Message equals text.
+func matchMsg(text string) func(*LogMessage) bool {
+	return func(m *LogMessage) bool { return m.Message == text }
+}
+
+func TestTailMatching_nilMatchEqualsTail(t *testing.T) {
+	m := NewModel(4)
+	for _, s := range []string{"a", "b", "c", "d", "e"} {
+		m.AppendMessage(msg(s))
+	}
+
+	got := messages(m.TailMatching(3, nil))
+	want := messages(m.TailMessages(3))
+	if !sliceEq(got, want) {
+		t.Errorf("TailMatching(3, nil) = %v, want %v", got, want)
+	}
+}
+
+func TestTailMatching_skipsNonMatching(t *testing.T) {
+	m := NewModel(8)
+	// Interleave matching ("m") and non-matching ("x") entries.
+	for _, s := range []string{"m1", "x", "m2", "x", "m3", "x"} {
+		if s == "x" {
+			m.AppendMessage(msg("x"))
+		} else {
+			m.AppendMessage(&LogMessage{Message: s, Fields: map[string]string{"k": "v"}})
+		}
+	}
+
+	got := messages(m.TailMatching(2, func(lm *LogMessage) bool { return lm.GetFields()["k"] == "v" }))
+	want := []string{"m2", "m3"} // 2 newest matching, chronological order
+	if !sliceEq(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestTailMatching_fewerMatchesThanN(t *testing.T) {
+	m := NewModel(8)
+	for _, s := range []string{"x", "hit", "x", "x"} {
+		m.AppendMessage(msg(s))
+	}
+
+	got := messages(m.TailMatching(5, matchMsg("hit")))
+	want := []string{"hit"}
+	if !sliceEq(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestTailMatching_wrapAround(t *testing.T) {
+	m := NewModel(3)
+	// "hit1" is evicted by wrap-around; only "hit2" and "hit3" remain buffered.
+	for _, s := range []string{"hit1", "x", "hit2", "hit3", "x"} {
+		m.AppendMessage(msg(s))
+	}
+
+	got := messages(m.TailMatching(5, func(lm *LogMessage) bool { return lm.Message != "x" }))
+	want := []string{"hit2", "hit3"}
+	if !sliceEq(got, want) {
+		t.Errorf("wrap-around: got %v, want %v", got, want)
+	}
+}
+
+func TestTailMatching_zero(t *testing.T) {
+	m := NewModel(8)
+	m.AppendMessage(msg("a"))
+	if got := m.TailMatching(0, nil); got != nil {
+		t.Errorf("TailMatching(0): got %v, want nil", got)
+	}
+}
+
 // ---- Subscribe / cancel lifecycle -----------------------------------------------
 
 func TestSubscribe_receivesMessage(t *testing.T) {

--- a/proto/smartcore/bos/log/v1/log.proto
+++ b/proto/smartcore/bos/log/v1/log.proto
@@ -83,7 +83,9 @@ message LogMetadata {
 message PullLogMessagesRequest {
   string name = 1;
   // Number of buffered messages to replay before streaming live.
-  // Analogous to tail -n <count>. Default: 200. Max: 1000.
+  // Analogous to tail -n <count>. When min_level or field_filter are set, up
+  // to this many MATCHING messages are replayed, scanning older buffer
+  // entries as needed. Default: 200. Max: 1000.
   int32 initial_count = 2;
   // If true, skip the initial replay and stream from now onwards only.
   bool updates_only = 3;
@@ -93,6 +95,11 @@ message PullLogMessagesRequest {
   // Reserved for future use; server may return UNIMPLEMENTED if used.
   string logger_filter = 5;
   google.protobuf.FieldMask read_mask = 6;
+  // Optional: filter by structured field values. A message matches only when
+  // every entry here equals the corresponding entry in the message's fields
+  // map (exact match, AND semantics). An empty map matches all messages.
+  // Combined with min_level (both must pass).
+  map<string, string> field_filter = 7;
 }
 
 message PullLogMessagesResponse {

--- a/ui/ops/src/api/ui/log.js
+++ b/ui/ops/src/api/ui/log.js
@@ -14,12 +14,25 @@ import {
 const apiClient = (endpoint) => new LogApiPromiseClient(endpoint, null, clientOptions());
 
 /**
+ * Well-known log field keys the server attaches to service lifecycle loggers,
+ * for use with PullLogMessagesRequest.fieldFilter.
+ * Must match loggerWithServiceInfo in pkg/app/services.go.
+ */
+export const logFields = {
+  serviceId: 'service.id',
+  serviceKind: 'service.kind'
+};
+
+/**
  * Opens a server-streaming connection for log messages, with automatic retry.
  * Each incoming batch is delivered as resource.value (an array of LogMessage.AsObject).
  * The caller should accumulate batches; resource.value is the latest batch, not the full history.
  * Call closeResource(resource) to stop the stream.
  *
- * @param {Partial<PullLogMessagesRequest.AsObject>} request
+ * request.fieldFilter is a plain object of field key/value pairs; only messages whose
+ * fields contain ALL of those entries are returned (exact match, AND semantics).
+ *
+ * @param {Partial<PullLogMessagesRequest.AsObject> & {fieldFilter?: Record<string, string>}} request
  * @param {import('@/api/resource.js').ResourceValue} resource
  */
 export function pullLogMessages(request, resource) {
@@ -29,6 +42,14 @@ export function pullLogMessages(request, resource) {
     if (request?.name) req.setName(request.name);
     if (request?.initialCount) req.setInitialCount(request.initialCount);
     if (request?.updatesOnly) req.setUpdatesOnly(request.updatesOnly);
+    if (request?.minLevel != null) req.setMinLevel(request.minLevel);
+    if (request?.fieldFilter) {
+      const m = req.getFieldFilterMap();
+      for (const [k, v] of Object.entries(request.fieldFilter)) {
+        if (v == null) continue; // an unset value would serialise to "" and match nothing
+        m.set(k, v);
+      }
+    }
     const stream = api.pullLogMessages(req);
     stream.on('data', (msg) => {
       for (const change of msg.getChangesList()) {

--- a/ui/ops/src/components/download/download.js
+++ b/ui/ops/src/components/download/download.js
@@ -129,6 +129,22 @@ export async function triggerDownload(qual = 'devices', query, history = null, t
 }
 
 /**
+ * Triggers a browser download of in-memory text as a file.
+ *
+ * @param {string} text
+ * @param {string} filename
+ * @param {string} [mime]
+ */
+export function triggerTextDownload(text, filename, mime = 'text/plain') {
+  const url = URL.createObjectURL(new Blob([text], {type: mime}));
+  try {
+    triggerDownloadFromUrl(url, filename);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+/**
  * Triggers a browser download for the given URL and filename.
  *
  * @param {string} url

--- a/ui/ops/src/routes/system/components/ServicesSideBar.vue
+++ b/ui/ops/src/routes/system/components/ServicesSideBar.vue
@@ -6,6 +6,8 @@
     <status-card/>
     <v-divider/>
     <edit-config-card/>
+    <v-divider/>
+    <logs-card/>
   </side-bar>
 </template>
 
@@ -13,6 +15,7 @@
 import SideBar from '@/components/SideBar.vue';
 import {useSidebarServiceRouterLink} from '@/dynamic/route.js';
 import EditConfigCard from '@/routes/system/components/service-cards/EditConfigCard.vue';
+import LogsCard from '@/routes/system/components/service-cards/LogsCard.vue';
 import StatusCard from '@/routes/system/components/service-cards/StatusCard.vue';
 
 const {hasLink: canEdit, to: editLink} = useSidebarServiceRouterLink();

--- a/ui/ops/src/routes/system/components/log/LogSearchView.vue
+++ b/ui/ops/src/routes/system/components/log/LogSearchView.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="log-search-view">
+    <v-text-field
+        v-model="search"
+        class="flex-grow-0 mb-2"
+        clearable
+        density="compact"
+        hide-details
+        placeholder="Search logs…"
+        prepend-inner-icon="mdi-magnify"
+        @keydown.enter.exact.prevent="nextMatch"
+        @keydown.enter.shift.prevent="prevMatch">
+      <template #append-inner>
+        <span v-if="search" class="text-caption text-no-wrap text-neutral-lighten-4 mr-1">
+          {{ matchCount ? activeMatch + 1 : 0 }}/{{ matchCount }}
+        </span>
+        <v-btn
+            :disabled="!matchCount"
+            density="compact"
+            icon="mdi-chevron-up"
+            size="small"
+            title="Previous match (Shift+Enter)"
+            variant="text"
+            @click="prevMatch"/>
+        <v-btn
+            :disabled="!matchCount"
+            density="compact"
+            icon="mdi-chevron-down"
+            size="small"
+            title="Next match (Enter)"
+            variant="text"
+            @click="nextMatch"/>
+      </template>
+    </v-text-field>
+    <log-viewport
+        :messages="messages"
+        :search="debouncedSearch"
+        :active-match="activeMatch"
+        class="flex-grow-1"
+        @match-count="onMatchCount"/>
+  </div>
+</template>
+
+<script setup>
+import LogViewport from '@/routes/system/components/log/LogViewport.vue';
+import debounce from 'debounce';
+import {ref, watch} from 'vue';
+
+defineProps({
+  messages: {
+    type: Array,
+    default: () => []
+  }
+});
+
+// Ctrl+F style search: highlights matches in the viewport without filtering.
+// The viewport re-splits lines when the term changes, so debounce keystrokes.
+const search = ref('');
+const debouncedSearch = ref('');
+const applySearch = debounce(v => {
+  debouncedSearch.value = v || '';
+}, 200);
+const matchCount = ref(0);
+const activeMatch = ref(0);
+
+watch(search, applySearch);
+watch(debouncedSearch, () => {
+  activeMatch.value = 0;
+});
+
+/**
+ * @param {number} count
+ */
+function onMatchCount(count) {
+  matchCount.value = count;
+  if (activeMatch.value >= count) activeMatch.value = Math.max(0, count - 1);
+}
+
+/**
+ * Moves the active highlight to the next match, wrapping around.
+ */
+function nextMatch() {
+  if (matchCount.value) activeMatch.value = (activeMatch.value + 1) % matchCount.value;
+}
+
+/**
+ * Moves the active highlight to the previous match, wrapping around.
+ */
+function prevMatch() {
+  if (matchCount.value) activeMatch.value = (activeMatch.value - 1 + matchCount.value) % matchCount.value;
+}
+</script>
+
+<style scoped>
+.log-search-view {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/* allow the viewport to shrink within a height-capped container */
+.log-search-view > :deep(.log-viewport) {
+  min-height: 0;
+}
+</style>

--- a/ui/ops/src/routes/system/components/log/LogViewport.vue
+++ b/ui/ops/src/routes/system/components/log/LogViewport.vue
@@ -1,0 +1,176 @@
+<template>
+  <div ref="logEl" class="log-viewport">
+    <div
+        v-for="line in lines"
+        :key="line.msg._key"
+        class="log-line">
+      <span class="log-time">{{ line.time }}</span>
+      <span :class="['log-level', `text-${levelColor[line.msg.level] ?? 'white'}`]">{{ levelName[line.msg.level] ?? '?' }}</span>
+      <!-- eslint-disable-next-line max-len -->
+      <span class="log-logger"><template v-for="(p, i) in line.loggerParts" :key="i"><mark v-if="p.matchIndex != null" :class="{'log-match-active': p.matchIndex === activeMatch}">{{ p.text }}</mark><template v-else>{{ p.text }}</template></template>:</span>
+      <!-- eslint-disable-next-line max-len -->
+      <span class="log-msg"><template v-for="(p, i) in line.msgParts" :key="i"><mark v-if="p.matchIndex != null" :class="{'log-match-active': p.matchIndex === activeMatch}">{{ p.text }}</mark><template v-else>{{ p.text }}</template></template></span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import {formatFields, formatTime, levelColor, levelName, splitHighlight} from '@/routes/system/components/log/format.js';
+import {computed, nextTick, ref, watch} from 'vue';
+
+const props = defineProps({
+  messages: {
+    type: Array,
+    default: () => []
+  },
+  // Ctrl+F style search: highlights occurrences without filtering lines.
+  search: {
+    type: String,
+    default: ''
+  },
+  // Global index of the currently focused match; scrolled into view on change.
+  activeMatch: {
+    type: Number,
+    default: 0
+  }
+});
+
+const emit = defineEmits(['match-count']);
+
+const logEl = ref(null);
+
+// Per-message split and time formatting are cached by _key so appends and
+// buffer trims don't re-split every buffered line; the cache is rebuilt when
+// the search term changes. Cached match indices are line-local and offset to
+// global positions below.
+let splitCache = new Map();
+let splitCacheSearch = '';
+
+/**
+ * Returns parts with each matchIndex offset by base, reusing the original
+ * array when there's nothing to renumber.
+ *
+ * @param {Array<{text: string, matchIndex?: number}>} parts
+ * @param {number} base
+ * @return {Array<{text: string, matchIndex?: number}>}
+ */
+function offsetParts(parts, base) {
+  if (base === 0 || !parts.some(p => p.matchIndex != null)) return parts;
+  return parts.map(p => p.matchIndex != null ? {...p, matchIndex: p.matchIndex + base} : p);
+}
+
+// Each line's logger and message text split into plain/highlighted parts,
+// with match indices numbered globally across all lines for navigation.
+const linesAndCount = computed(() => {
+  if (props.search !== splitCacheSearch) {
+    splitCache = new Map();
+    splitCacheSearch = props.search;
+  }
+  const cache = splitCache;
+  let idx = 0;
+  const lines = props.messages.map(msg => {
+    let entry = cache.get(msg._key);
+    if (!entry) {
+      entry = {
+        time: formatTime(msg.timestamp),
+        logger: splitHighlight(msg.logger ?? '', props.search),
+        body: splitHighlight(`${msg.message ?? ''}${formatFields(msg.fieldsMap)}`, props.search)
+      };
+      cache.set(msg._key, entry);
+    }
+    const line = {
+      msg,
+      time: entry.time,
+      loggerParts: offsetParts(entry.logger.parts, idx),
+      msgParts: offsetParts(entry.body.parts, idx + entry.logger.count)
+    };
+    idx += entry.logger.count + entry.body.count;
+    return line;
+  });
+  // drop cache entries for messages evicted from the buffer
+  if (cache.size > props.messages.length + 1000) {
+    const live = new Set(props.messages.map(m => m._key));
+    for (const k of cache.keys()) {
+      if (!live.has(k)) cache.delete(k);
+    }
+  }
+  return {lines, count: idx};
+});
+const lines = computed(() => linesAndCount.value.lines);
+
+watch(() => linesAndCount.value.count, count => emit('match-count', count), {immediate: true});
+
+// Auto-scroll to the bottom when new messages arrive, unless the user has
+// scrolled up to read older entries. Watch the last message's _key rather
+// than the length so appends still trigger once the buffer is capped; _keys
+// only ever increase, so a filtered list changing shape (e.g. the Logs page
+// search) doesn't trigger a scroll, only genuinely new messages do.
+watch(() => props.messages[props.messages.length - 1]?._key, (newKey, oldKey) => {
+  if (newKey == null || (oldKey != null && newKey <= oldKey)) return; // not an append
+  if (props.search) return; // don't fight match navigation while searching
+  nextTick(() => {
+    const el = logEl.value;
+    if (!el) return;
+    if (el.scrollHeight - el.scrollTop - el.clientHeight < 100) {
+      el.scrollTop = el.scrollHeight;
+    }
+  });
+});
+
+// Bring the active match into view when it, or the search term, changes.
+watch([() => props.activeMatch, () => props.search], () => {
+  nextTick(() => {
+    logEl.value?.querySelector('.log-match-active')?.scrollIntoView({block: 'nearest'});
+  });
+});
+</script>
+
+<style scoped>
+.log-viewport {
+  overflow-y: auto;
+  background: #1e1e1e;
+  font-family: monospace;
+  font-size: 12px;
+  padding: 8px;
+  border-radius: 4px;
+}
+
+.log-line {
+  display: flex;
+  gap: 6px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.log-time {
+  color: #888;
+  flex-shrink: 0;
+}
+
+.log-level {
+  flex-shrink: 0;
+  width: 4ch;
+  font-weight: bold;
+}
+
+.log-logger {
+  color: #aaa;
+  flex-shrink: 0;
+}
+
+.log-msg {
+  color: #eee;
+}
+
+.log-line mark {
+  background: #806e00;
+  color: #fff;
+  border-radius: 2px;
+}
+
+.log-line mark.log-match-active {
+  background: #ff9632;
+  color: #000;
+}
+</style>

--- a/ui/ops/src/routes/system/components/log/format.js
+++ b/ui/ops/src/routes/system/components/log/format.js
@@ -1,0 +1,66 @@
+// Shared formatting helpers for rendering LogMessage.AsObject values,
+// used by the full Logs page and the per-service LogsCard.
+
+import {timestampToDate} from '@/api/convpb.js';
+
+export const levelColor = {1: 'grey', 2: 'blue', 3: 'amber', 4: 'red'};
+export const levelName = {1: 'DBG', 2: 'INF', 3: 'WRN', 4: 'ERR'};
+
+/**
+ * @param {{seconds: number, nanos?: number}|null|undefined} timestamp
+ * @return {string}
+ */
+export function formatTime(timestamp) {
+  const date = timestampToDate(timestamp);
+  if (!date) return '--:--.---';
+  return date.toLocaleTimeString(undefined, {fractionalSecondDigits: 3});
+}
+
+/**
+ * @param {Array<[string, *]>|undefined} fieldsMap
+ * @return {string}
+ */
+export function formatFields(fieldsMap) {
+  if (!fieldsMap?.length) return '';
+  return '\t' + JSON.stringify(Object.fromEntries(fieldsMap));
+}
+
+/**
+ * Splits text into parts, marking case-insensitive occurrences of query.
+ * Matching parts get a matchIndex, numbered globally from startIndex so
+ * occurrences can be navigated across multiple lines.
+ *
+ * @param {string} text
+ * @param {string} query
+ * @param {number} [startIndex]
+ * @return {{parts: Array<{text: string, matchIndex?: number}>, count: number}}
+ */
+export function splitHighlight(text, query, startIndex = 0) {
+  if (!query) return {parts: [{text}], count: 0};
+  const parts = [];
+  const lower = text.toLowerCase();
+  const q = query.toLowerCase();
+  let pos = 0;
+  let count = 0;
+  for (let i = lower.indexOf(q); i !== -1; i = lower.indexOf(q, pos)) {
+    if (i > pos) parts.push({text: text.slice(pos, i)});
+    parts.push({text: text.slice(i, i + q.length), matchIndex: startIndex + count});
+    count++;
+    pos = i + q.length;
+  }
+  if (pos < text.length) parts.push({text: text.slice(pos)});
+  return {parts, count};
+}
+
+/**
+ * Serialises messages to plain text, one line per message, for export.
+ *
+ * @param {Array<Object>} messages - LogMessage.AsObject values
+ * @return {string}
+ */
+export function messagesToText(messages) {
+  return messages.map(m => {
+    const time = timestampToDate(m.timestamp)?.toISOString() ?? '';
+    return `${time} ${levelName[m.level] ?? '?'} ${m.logger}: ${m.message}${formatFields(m.fieldsMap)}`;
+  }).join('\n') + '\n';
+}

--- a/ui/ops/src/routes/system/components/log/useLogBuffer.js
+++ b/ui/ops/src/routes/system/components/log/useLogBuffer.js
@@ -1,0 +1,35 @@
+import {ref, watch} from 'vue';
+
+/**
+ * Accumulates streamed log message batches into a capped buffer.
+ * Each message is given a unique, increasing _key for use as a render key.
+ *
+ * @param {import('@/api/resource.js').ResourceValue} resource - resource whose .value is the latest batch
+ * @param {{
+ *   max?: number,
+ *   onBatch?: (batch: Array<Object>) => void
+ * }} [opts] - max caps the buffer size; onBatch is called before each batch is appended
+ * @return {{messages: import('vue').Ref<Array<Object>>, clear: () => void}}
+ */
+export function useLogBuffer(resource, {max = 2000, onBatch} = {}) {
+  const messages = ref([]);
+  let _keyCounter = 0;
+
+  watch(() => resource.value, (batch) => {
+    if (!batch?.length) return;
+    onBatch?.(batch);
+    for (const m of batch) {
+      m._key = _keyCounter++;
+      messages.value.push(m);
+    }
+    if (messages.value.length > max) {
+      messages.value.splice(0, messages.value.length - max);
+    }
+  });
+
+  const clear = () => {
+    messages.value = [];
+  };
+
+  return {messages, clear};
+}

--- a/ui/ops/src/routes/system/components/pages/LogsPage.vue
+++ b/ui/ops/src/routes/system/components/pages/LogsPage.vue
@@ -59,21 +59,11 @@
           placeholder="Search logs…"
           prepend-inner-icon="mdi-magnify"
           style="max-width: 500px"/>
-      <v-btn class="ml-2" size="small" variant="tonal" @click="messages = []">Clear</v-btn>
+      <v-btn class="ml-2" size="small" variant="tonal" @click="clearMessages">Clear</v-btn>
       <v-chip v-if="streamError" class="ml-2" color="error" size="small">{{ streamError.message }}</v-chip>
     </v-row>
 
-    <div ref="logEl" class="log-viewport flex-grow-1 mx-4 mb-4">
-      <div
-          v-for="msg in filteredMessages"
-          :key="msg._key"
-          class="log-line">
-        <span class="log-time">{{ formatTime(msg.timestamp) }}</span>
-        <span :class="['log-level', `text-${levelColor[msg.level] ?? 'white'}`]">{{ levelName[msg.level] ?? '?' }}</span>
-        <span class="log-logger">{{ msg.logger }}:</span>
-        <span class="log-msg">{{ msg.message }}{{ formatFields(msg.fieldsMap) }}</span>
-      </div>
-    </div>
+    <log-viewport :messages="filteredMessages" class="flex-grow-1 mx-4 mb-4"/>
   </div>
 </template>
 
@@ -83,9 +73,12 @@ import {closeResource, newResourceValue} from '@/api/resource.js';
 import {getService} from '@/api/ui/services.js';
 import {triggerDownloadFromUrl} from '@/components/download/download.js';
 import useAuthSetup from '@/composables/useAuthSetup.js';
+import LogViewport from '@/routes/system/components/log/LogViewport.vue';
+import {levelName} from '@/routes/system/components/log/format.js';
+import {useLogBuffer} from '@/routes/system/components/log/useLogBuffer.js';
 import {useCohortStore} from '@/stores/cohort.js';
 import {storeToRefs} from 'pinia';
-import {computed, nextTick, onUnmounted, reactive, ref, watch} from 'vue';
+import {computed, onUnmounted, reactive, ref, watch} from 'vue';
 import {useRoute, useRouter} from 'vue-router';
 
 const route = useRoute();
@@ -112,19 +105,17 @@ const nodeNames = computed(() =>
 
 const selectedNode = ref(route.query.node ?? null);
 
-const messages = ref([]);
-const messageCount = ref(0); // incremented on each batch; watched for auto-scroll
 const search = ref('');
 const streamError = ref(null);
-const logEl = ref(null);
 const metadata = ref(null);
 const selectedLevel = ref(null);
 const levelError = ref(null);
 const downloadError = ref(null);
-let _keyCounter = 0;
 const messagesResource = reactive(newResourceValue());
 const levelResource = reactive(newResourceValue());
 const metadataResource = reactive(newResourceValue());
+
+const {messages, clear: clearMessages} = useLogBuffer(messagesResource, {max: 2000});
 
 const levelOptions = [
   {label: 'DEBUG', value: 1},
@@ -132,9 +123,6 @@ const levelOptions = [
   {label: 'WARN', value: 3},
   {label: 'ERROR', value: 4}
 ];
-
-const levelColor = {1: 'grey', 2: 'blue', 3: 'amber', 4: 'red'};
-const levelName = {1: 'DBG', 2: 'INF', 3: 'WRN', 4: 'ERR'};
 
 const filteredMessages = computed(() => {
   if (!search.value) return messages.value;
@@ -145,25 +133,6 @@ const filteredMessages = computed(() => {
       levelName[m.level]?.toLowerCase().includes(q)
   );
 });
-
-/**
- * @param {Array<[string, *]>} fieldsMap
- * @return {string}
- */
-function formatFields(fieldsMap) {
-  if (!fieldsMap?.length) return '';
-  return '\t' + JSON.stringify(Object.fromEntries(fieldsMap));
-}
-
-/**
- * @param {{seconds: number}|null} timestamp
- * @return {string}
- */
-function formatTime(timestamp) {
-  if (!timestamp) return '--:--.---';
-  const ms = (timestamp.seconds * 1000) + Math.floor((timestamp.nanos ?? 0) / 1e6);
-  return new Date(ms).toLocaleTimeString(undefined, {fractionalSecondDigits: 3});
-}
 
 /**
  * @param {number|null} bytes
@@ -182,7 +151,7 @@ function formatBytes(bytes) {
  */
 async function startStreams(name) {
   cancelStreams();
-  messages.value = [];
+  clearMessages();
   streamError.value = null;
   metadata.value = null;
   selectedLevel.value = null;
@@ -212,18 +181,6 @@ function cancelStreams() {
   closeResource(metadataResource);
 }
 
-// Append each incoming batch to the local message buffer.
-watch(() => messagesResource.value, (batch) => {
-  if (!batch?.length) return;
-  for (const m of batch) {
-    m._key = _keyCounter++;
-    messages.value.push(m);
-  }
-  if (messages.value.length > 2000) {
-    messages.value.splice(0, messages.value.length - 2000);
-  }
-  messageCount.value++;
-});
 watch(() => messagesResource.streamError, err => { streamError.value = err?.error ?? null; });
 
 watch(() => levelResource.value, lvl => { if (lvl != null) selectedLevel.value = lvl; });
@@ -238,16 +195,6 @@ watch(selectedNode, (name) => {
     cancelStreams();
   }
 }, {immediate: true});
-
-watch(messageCount, () => {
-  nextTick(() => {
-    if (!logEl.value) return;
-    const el = logEl.value;
-    if (el.scrollHeight - el.scrollTop - el.clientHeight < 100) {
-      el.scrollTop = el.scrollHeight;
-    }
-  });
-});
 
 /**
  * @param {string|null} name
@@ -309,42 +256,5 @@ onUnmounted(() => cancelStreams());
 .logs-page {
   height: 100%;
   overflow: hidden;
-}
-
-.log-viewport {
-  overflow-y: auto;
-  background: #1e1e1e;
-  font-family: monospace;
-  font-size: 12px;
-  padding: 8px;
-  border-radius: 4px;
-}
-
-.log-line {
-  display: flex;
-  gap: 6px;
-  line-height: 1.4;
-  white-space: pre-wrap;
-  word-break: break-all;
-}
-
-.log-time {
-  color: #888;
-  flex-shrink: 0;
-}
-
-.log-level {
-  flex-shrink: 0;
-  width: 4ch;
-  font-weight: bold;
-}
-
-.log-logger {
-  color: #aaa;
-  flex-shrink: 0;
-}
-
-.log-msg {
-  color: #eee;
 }
 </style>

--- a/ui/ops/src/routes/system/components/service-cards/EditConfigCard.vue
+++ b/ui/ops/src/routes/system/components/service-cards/EditConfigCard.vue
@@ -1,52 +1,72 @@
 <template>
   <v-card flat tile>
     <v-card-subtitle class="text-subtitle-2 text-title-caps-large text-neutral-lighten-3 py-4">Config</v-card-subtitle>
-    <v-card-text class="px-4 pt-0 json-form">
+    <v-card-text class="px-4 pt-0">
       <v-alert
           v-if="serviceError && !hasConfig"
           type="error"
           variant="tonal"
           class="mb-3 text-body-small"
           :text="serviceError"/>
-      <template v-else>
-        <div class="text-caption pb-1 text-neutral-lighten-6">Export</div>
-        <v-textarea
-            v-model="config"
-            auto-grow
-            class="text-body-code"
-            :disabled="blockSystemEdit"
-            :error-messages="jsonError"
-            variant="outlined"
-            hide-details="auto"
-            readonly/>
-        <v-btn
-            tile
-            variant="text"
-            icon="mdi-content-copy"
-            class="copy-btn"
-            :disabled="blockSystemEdit"
-            @click="copyConfig"/>
-      </template>
+      <!-- viewing config is read-only, so isn't gated on blockSystemEdit, only copying is -->
+      <v-btn
+          v-else
+          block
+          prepend-icon="mdi-code-json"
+          variant="tonal"
+          :disabled="!hasConfig"
+          @click="dialog = true">
+        View Config
+      </v-btn>
       <v-snackbar v-model="copyConfirm" timeout="2000" color="success" max-width="250" min-width="200">
         <span class="text-body-large align-baseline"><v-icon start>mdi-check-circle</v-icon>Config copied</span>
       </v-snackbar>
     </v-card-text>
+
+    <v-dialog v-model="dialog" max-width="800px" scrollable>
+      <v-card>
+        <v-card-title class="d-flex align-center">
+          {{ dialogTitle }}
+          <v-spacer/>
+          <v-btn icon="mdi-content-copy" variant="text" title="Copy config" :disabled="blockSystemEdit" @click="copyConfig"/>
+          <v-btn icon="mdi-close" variant="text" @click="dialog = false"/>
+        </v-card-title>
+        <v-card-text>
+          <v-textarea
+              v-model="config"
+              auto-grow
+              class="text-body-code"
+              :error-messages="jsonError"
+              variant="outlined"
+              hide-details="auto"
+              readonly/>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
   </v-card>
 </template>
 
 <script setup>
 import useAuthSetup from '@/composables/useAuthSetup';
 import {useSidebarStore} from '@/stores/sidebar';
-import {computed, ref} from 'vue';
+import {computed, ref, watch} from 'vue';
 
 const {blockSystemEdit} = useAuthSetup();
 
 const sidebar = useSidebarStore();
 
+const dialog = ref(false);
 const jsonError = ref('');
 
 const serviceError = computed(() => sidebar.data?.service?.error ?? '');
 const hasConfig = computed(() => Boolean(sidebar.data?.service?.configRaw));
+const serviceId = computed(() => sidebar.data?.service?.id);
+const dialogTitle = computed(() => serviceId.value ? `Config - ${serviceId.value}` : 'Config');
+
+// Close the dialog if the selected service changes while it's open.
+watch(serviceId, () => {
+  dialog.value = false;
+});
 
 const config = computed({
   get() {
@@ -71,19 +91,7 @@ const copyConfirm = ref(false);
  *
  */
 function copyConfig() {
-  navigator.clipboard.writeText(sidebar.data.service.configRaw);
+  navigator.clipboard.writeText(config.value);
   copyConfirm.value = true;
 }
 </script>
-
-<style scoped>
-.json-form {
-  position: relative;
-}
-
-.copy-btn {
-  position: absolute;
-  top: 28px;
-  right: 18px;
-}
-</style>

--- a/ui/ops/src/routes/system/components/service-cards/LogsCard.vue
+++ b/ui/ops/src/routes/system/components/service-cards/LogsCard.vue
@@ -1,48 +1,21 @@
 <template>
   <v-card flat tile>
-    <v-card-title class="text-subtitle-2 text-title-caps-large text-neutral-lighten-3 d-flex align-center">
-      Logs
-      <v-spacer/>
+    <v-card-subtitle class="text-subtitle-2 text-title-caps-large text-neutral-lighten-3 py-4">Logs</v-card-subtitle>
+    <v-card-text class="px-4 pt-0">
       <v-btn
-          :disabled="!messages.length"
-          icon="mdi-arrow-expand"
-          size="small"
-          title="Pop out logs"
-          variant="text"
-          @click="popout = true"/>
-      <v-btn
-          :disabled="!messages.length"
-          icon="mdi-download"
-          size="small"
-          title="Export logs"
-          variant="text"
-          @click="exportLogs"/>
-      <v-btn
-          :icon="expanded ? 'mdi-chevron-up' : 'mdi-chevron-down'"
-          size="small"
-          variant="text"
-          @click="expanded = !expanded"/>
-    </v-card-title>
-    <v-expand-transition>
-      <!-- v-if rather than v-show so a collapsed card doesn't keep re-rendering the stream -->
-      <v-card-text v-if="expanded" class="px-4 pt-0 pb-3">
-        <div v-if="unsupported" class="text-body-small text-neutral-lighten-4 py-2">
-          Logs are not available on this node.
-        </div>
-        <div v-else-if="streamError && !messages.length" class="text-body-small text-error py-2">
-          Error loading logs: {{ streamError }}
-        </div>
-        <div v-else-if="!messages.length" class="text-body-small text-neutral-lighten-4 py-2">
-          No recent logs for this service.
-        </div>
-        <log-search-view v-else :messages="messages" class="card-log-view"/>
-      </v-card-text>
-    </v-expand-transition>
+          block
+          prepend-icon="mdi-text-long"
+          variant="tonal"
+          :disabled="!canViewLogs"
+          @click="dialog = true">
+        View Logs
+      </v-btn>
+    </v-card-text>
 
-    <v-dialog v-model="popout" max-width="1200px">
+    <v-dialog v-model="dialog" max-width="1200px">
       <v-card>
         <v-card-title class="d-flex align-center">
-          {{ popoutTitle }}
+          {{ dialogTitle }}
           <v-spacer/>
           <v-btn
               :disabled="!messages.length"
@@ -50,10 +23,19 @@
               title="Export logs"
               variant="text"
               @click="exportLogs"/>
-          <v-btn icon="mdi-close" variant="text" @click="popout = false"/>
+          <v-btn icon="mdi-close" variant="text" @click="dialog = false"/>
         </v-card-title>
         <v-card-text class="pb-4">
-          <log-search-view :messages="messages" class="popout-log-view"/>
+          <div v-if="unsupported" class="text-body-small text-neutral-lighten-4 py-2">
+            Logs are not available on this node.
+          </div>
+          <div v-else-if="streamError && !messages.length" class="text-body-small text-error py-2">
+            Error loading logs: {{ streamError }}
+          </div>
+          <div v-else-if="!messages.length" class="text-body-small text-neutral-lighten-4 py-2">
+            No recent logs for this service.
+          </div>
+          <log-search-view v-else :messages="messages" class="log-view"/>
         </v-card-text>
       </v-card>
     </v-dialog>
@@ -68,6 +50,7 @@ import LogSearchView from '@/routes/system/components/log/LogSearchView.vue';
 import {messagesToText} from '@/routes/system/components/log/format.js';
 import {useLogBuffer} from '@/routes/system/components/log/useLogBuffer.js';
 import {useSidebarStore} from '@/stores/sidebar';
+import {StatusCode} from 'grpc-web';
 import {computed, onUnmounted, reactive, ref, watch} from 'vue';
 
 const sidebar = useSidebarStore();
@@ -76,8 +59,7 @@ const serviceId = computed(() => sidebar.data?.service?.id);
 const serviceType = computed(() => sidebar.data?.service?.type);
 const nodeName = computed(() => sidebar.data?.nodeName);
 
-const expanded = ref(true);
-const popout = ref(false);
+const dialog = ref(false);
 const unsupported = ref(false);
 const streamError = ref(null);
 const messagesResource = reactive(newResourceValue());
@@ -91,17 +73,14 @@ const {messages, clear: clearMessages} = useLogBuffer(messagesResource, {
   }
 });
 
-const popoutTitle = computed(() => serviceId.value ? `Logs - ${serviceId.value}` : 'Logs');
+const canViewLogs = computed(() => Boolean(nodeName.value && serviceId.value));
+const dialogTitle = computed(() => serviceId.value ? `Logs - ${serviceId.value}` : 'Logs');
 
 /**
- * (Re-)opens the log stream for the currently selected service.
+ * Opens the log stream for the currently selected service.
  */
 function startStream() {
-  closeResource(messagesResource);
-  clearMessages();
-  unsupported.value = false;
-  streamError.value = null;
-  popout.value = false;
+  stopStream();
   if (!nodeName.value || !serviceId.value) return;
   pullLogMessages({
     name: nodeName.value,
@@ -114,23 +93,41 @@ function startStream() {
   }, messagesResource);
 }
 
+/**
+ * Closes the log stream and resets the buffer and error state.
+ */
+function stopStream() {
+  closeResource(messagesResource);
+  clearMessages();
+  unsupported.value = false;
+  streamError.value = null;
+}
+
 // Nodes without the log system respond with UNIMPLEMENTED/NOT_FOUND; show a
 // quiet message rather than an error. Other errors are shown as errors - the
 // stream retries automatically and a successful batch clears them.
 watch(() => messagesResource.streamError, (err) => {
   if (!err) return;
   const code = err.error?.code;
-  if (code === 12 /* UNIMPLEMENTED */ || code === 5 /* NOT_FOUND */) {
+  if (code === StatusCode.UNIMPLEMENTED || code === StatusCode.NOT_FOUND) {
     unsupported.value = true;
   } else {
     streamError.value = err.error?.message ?? 'stream error';
   }
 });
 
+// Only stream while the dialog is open.
+watch(dialog, (open) => {
+  if (open) startStream();
+  else stopStream();
+});
+
 // The sidebar component instance is reused as the user selects different
-// services, so re-stream whenever the selection changes.
-watch([serviceId, serviceType, nodeName], startStream, {immediate: true});
-onUnmounted(() => closeResource(messagesResource));
+// services; close the dialog (stopping any stream) when the selection changes.
+watch([serviceId, serviceType, nodeName], () => {
+  dialog.value = false;
+});
+onUnmounted(stopStream);
 
 /**
  * Downloads the currently buffered messages as a text file.
@@ -141,11 +138,7 @@ function exportLogs() {
 </script>
 
 <style scoped>
-.card-log-view {
-  max-height: 440px;
-}
-
-.popout-log-view {
+.log-view {
   height: 70vh;
 }
 </style>

--- a/ui/ops/src/routes/system/components/service-cards/LogsCard.vue
+++ b/ui/ops/src/routes/system/components/service-cards/LogsCard.vue
@@ -1,0 +1,151 @@
+<template>
+  <v-card flat tile>
+    <v-card-title class="text-subtitle-2 text-title-caps-large text-neutral-lighten-3 d-flex align-center">
+      Logs
+      <v-spacer/>
+      <v-btn
+          :disabled="!messages.length"
+          icon="mdi-arrow-expand"
+          size="small"
+          title="Pop out logs"
+          variant="text"
+          @click="popout = true"/>
+      <v-btn
+          :disabled="!messages.length"
+          icon="mdi-download"
+          size="small"
+          title="Export logs"
+          variant="text"
+          @click="exportLogs"/>
+      <v-btn
+          :icon="expanded ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+          size="small"
+          variant="text"
+          @click="expanded = !expanded"/>
+    </v-card-title>
+    <v-expand-transition>
+      <!-- v-if rather than v-show so a collapsed card doesn't keep re-rendering the stream -->
+      <v-card-text v-if="expanded" class="px-4 pt-0 pb-3">
+        <div v-if="unsupported" class="text-body-small text-neutral-lighten-4 py-2">
+          Logs are not available on this node.
+        </div>
+        <div v-else-if="streamError && !messages.length" class="text-body-small text-error py-2">
+          Error loading logs: {{ streamError }}
+        </div>
+        <div v-else-if="!messages.length" class="text-body-small text-neutral-lighten-4 py-2">
+          No recent logs for this service.
+        </div>
+        <log-search-view v-else :messages="messages" class="card-log-view"/>
+      </v-card-text>
+    </v-expand-transition>
+
+    <v-dialog v-model="popout" max-width="1200px">
+      <v-card>
+        <v-card-title class="d-flex align-center">
+          {{ popoutTitle }}
+          <v-spacer/>
+          <v-btn
+              :disabled="!messages.length"
+              icon="mdi-download"
+              title="Export logs"
+              variant="text"
+              @click="exportLogs"/>
+          <v-btn icon="mdi-close" variant="text" @click="popout = false"/>
+        </v-card-title>
+        <v-card-text class="pb-4">
+          <log-search-view :messages="messages" class="popout-log-view"/>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
+  </v-card>
+</template>
+
+<script setup>
+import {closeResource, newResourceValue} from '@/api/resource.js';
+import {logFields, pullLogMessages} from '@/api/ui/log.js';
+import {triggerTextDownload} from '@/components/download/download.js';
+import LogSearchView from '@/routes/system/components/log/LogSearchView.vue';
+import {messagesToText} from '@/routes/system/components/log/format.js';
+import {useLogBuffer} from '@/routes/system/components/log/useLogBuffer.js';
+import {useSidebarStore} from '@/stores/sidebar';
+import {computed, onUnmounted, reactive, ref, watch} from 'vue';
+
+const sidebar = useSidebarStore();
+
+const serviceId = computed(() => sidebar.data?.service?.id);
+const serviceType = computed(() => sidebar.data?.service?.type);
+const nodeName = computed(() => sidebar.data?.nodeName);
+
+const expanded = ref(true);
+const popout = ref(false);
+const unsupported = ref(false);
+const streamError = ref(null);
+const messagesResource = reactive(newResourceValue());
+
+const {messages, clear: clearMessages} = useLogBuffer(messagesResource, {
+  max: 500,
+  onBatch: () => {
+    // a (re)tried stream has recovered
+    unsupported.value = false;
+    streamError.value = null;
+  }
+});
+
+const popoutTitle = computed(() => serviceId.value ? `Logs - ${serviceId.value}` : 'Logs');
+
+/**
+ * (Re-)opens the log stream for the currently selected service.
+ */
+function startStream() {
+  closeResource(messagesResource);
+  clearMessages();
+  unsupported.value = false;
+  streamError.value = null;
+  popout.value = false;
+  if (!nodeName.value || !serviceId.value) return;
+  pullLogMessages({
+    name: nodeName.value,
+    initialCount: 50,
+    fieldFilter: {
+      [logFields.serviceId]: serviceId.value,
+      // only constrain the kind when we know it, an absent value would match nothing
+      ...(serviceType.value && {[logFields.serviceKind]: serviceType.value})
+    }
+  }, messagesResource);
+}
+
+// Nodes without the log system respond with UNIMPLEMENTED/NOT_FOUND; show a
+// quiet message rather than an error. Other errors are shown as errors - the
+// stream retries automatically and a successful batch clears them.
+watch(() => messagesResource.streamError, (err) => {
+  if (!err) return;
+  const code = err.error?.code;
+  if (code === 12 /* UNIMPLEMENTED */ || code === 5 /* NOT_FOUND */) {
+    unsupported.value = true;
+  } else {
+    streamError.value = err.error?.message ?? 'stream error';
+  }
+});
+
+// The sidebar component instance is reused as the user selects different
+// services, so re-stream whenever the selection changes.
+watch([serviceId, serviceType, nodeName], startStream, {immediate: true});
+onUnmounted(() => closeResource(messagesResource));
+
+/**
+ * Downloads the currently buffered messages as a text file.
+ */
+function exportLogs() {
+  triggerTextDownload(messagesToText(messages.value), `${serviceId.value ?? 'service'}-logs.txt`);
+}
+</script>
+
+<style scoped>
+.card-log-view {
+  max-height: 440px;
+}
+
+.popout-log-view {
+  height: 70vh;
+}
+</style>

--- a/ui/ui-gen/proto/smartcore/bos/log/v1/log_pb.d.ts
+++ b/ui/ui-gen/proto/smartcore/bos/log/v1/log_pb.d.ts
@@ -138,6 +138,9 @@ export class PullLogMessagesRequest extends jspb.Message {
   hasReadMask(): boolean;
   clearReadMask(): PullLogMessagesRequest;
 
+  getFieldFilterMap(): jspb.Map<string, string>;
+  clearFieldFilterMap(): PullLogMessagesRequest;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PullLogMessagesRequest.AsObject;
   static toObject(includeInstance: boolean, msg: PullLogMessagesRequest): PullLogMessagesRequest.AsObject;
@@ -154,6 +157,7 @@ export namespace PullLogMessagesRequest {
     minLevel: Level;
     loggerFilter: string;
     readMask?: google_protobuf_field_mask_pb.FieldMask.AsObject;
+    fieldFilterMap: Array<[string, string]>;
   };
 }
 

--- a/ui/ui-gen/proto/smartcore/bos/log/v1/log_pb.js
+++ b/ui/ui-gen/proto/smartcore/bos/log/v1/log_pb.js
@@ -1318,7 +1318,8 @@ initialCount: jspb.Message.getFieldWithDefault(msg, 2, 0),
 updatesOnly: jspb.Message.getBooleanFieldWithDefault(msg, 3, false),
 minLevel: jspb.Message.getFieldWithDefault(msg, 4, 0),
 loggerFilter: jspb.Message.getFieldWithDefault(msg, 5, ""),
-readMask: (f = msg.getReadMask()) && google_protobuf_field_mask_pb.FieldMask.toObject(includeInstance, f)
+readMask: (f = msg.getReadMask()) && google_protobuf_field_mask_pb.FieldMask.toObject(includeInstance, f),
+fieldFilterMap: (f = msg.getFieldFilterMap()) ? f.toObject(includeInstance, undefined) : []
   };
 
   if (includeInstance) {
@@ -1379,6 +1380,12 @@ proto.smartcore.bos.log.v1.PullLogMessagesRequest.deserializeBinaryFromReader = 
       var value = new google_protobuf_field_mask_pb.FieldMask;
       reader.readMessage(value,google_protobuf_field_mask_pb.FieldMask.deserializeBinaryFromReader);
       msg.setReadMask(value);
+      break;
+    case 7:
+      var value = msg.getFieldFilterMap();
+      reader.readMessage(value, function(message, reader) {
+        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readStringRequireUtf8, jspb.BinaryReader.prototype.readStringRequireUtf8, null, "", "");
+         });
       break;
     default:
       reader.skipField();
@@ -1451,6 +1458,15 @@ proto.smartcore.bos.log.v1.PullLogMessagesRequest.serializeBinaryToWriter = func
       f,
       google_protobuf_field_mask_pb.FieldMask.serializeBinaryToWriter
     );
+  }
+  f = message.getFieldFilterMap(true);
+  if (f && f.getLength() > 0) {
+jspb.internal.public_for_gencode.serializeMapToBinary(
+    message.getFieldFilterMap(true),
+    7,
+    writer,
+    jspb.BinaryWriter.prototype.writeString,
+    jspb.BinaryWriter.prototype.writeString);
   }
 };
 
@@ -1579,6 +1595,29 @@ proto.smartcore.bos.log.v1.PullLogMessagesRequest.prototype.clearReadMask = func
  */
 proto.smartcore.bos.log.v1.PullLogMessagesRequest.prototype.hasReadMask = function() {
   return jspb.Message.getField(this, 6) != null;
+};
+
+
+/**
+ * map<string, string> field_filter = 7;
+ * @param {boolean=} opt_noLazyCreate Do not create the map if
+ * empty, instead returning `undefined`
+ * @return {!jspb.Map<string,string>}
+ */
+proto.smartcore.bos.log.v1.PullLogMessagesRequest.prototype.getFieldFilterMap = function(opt_noLazyCreate) {
+  return /** @type {!jspb.Map<string,string>} */ (
+      jspb.Message.getMapField(this, 7, opt_noLazyCreate,
+      null));
+};
+
+
+/**
+ * Clears values from the map. The map will be non-null.
+ * @return {!proto.smartcore.bos.log.v1.PullLogMessagesRequest} returns this
+ */
+proto.smartcore.bos.log.v1.PullLogMessagesRequest.prototype.clearFieldFilterMap = function() {
+  this.getFieldFilterMap().clear();
+  return this;
 };
 
 


### PR DESCRIPTION
[SCB-976](https://vanti.youtrack.cloud/projects/SCB/issues/SCB-976) Log view widget
## Summary 

Adds a live log view to the service sidebar in the ops UI, so logs for the selected driver/automation/zone/system can be read in place without leaving the page.

### LogApi: field_filter

- New `field_filter` on `PullLogMessagesRequest` — exact-match AND semantics over `LogMessage.fields`, applied to both the replay and live paths.
- Replay returns up to `initial_count` *matching* messages via the new `Model.TailMatching`, scanning older buffer entries as needed so quiet services aren't diluted by chatty neighbours.

### Ops UI: LogsCard

- New `LogsCard` in the shared service sidebar, filtering the node's log stream by the `service.id`/`service.kind` fields every service lifecycle logger carries (key names defined as constants on both the Go and JS sides).
- Ctrl+F style search: matches are highlighted in place (no filtering), Enter/Shift+Enter and chevrons cycle through them browser-style. Keystrokes are debounced and per-message formatting is cached so live appends don't re-split the whole buffer.
- Pop-out dialog showing the same live stream in a larger view, plus client-side text export of the buffered messages.
- Quiet "not available" fallback for nodes without the log system (UNIMPLEMENTED/NOT_FOUND); other stream errors are surfaced as errors.
- Log line rendering is extracted from `LogsPage` into shared `LogViewport`/`LogSearchView`/`format.js` components, with the capped message buffer shared via a `useLogBuffer` composable.

### Ops UI: service config dialog

- The always-visible inline config textarea in the service sidebar is replaced with a **View Config** button opening a read-only, copyable dialog — freeing sidebar space for the status and logs cards. Viewing stays available to users with system edit blocked; only the copy action is gated.

Server-side filtered download of full log history is deferred.

## Testing

<img width="2875" height="1555" alt="image" src="https://github.com/user-attachments/assets/a727d663-263b-47d4-bdbb-eac1e60d8cda" />


- `go test -short ./pkg/proto/logpb ./pkg/app` passes (excluding `TestServeHTTPS`/`TestServeGRPC`, which hang in the WSL dev environment on a clean tree too)
- `yarn lint:nofix` passes in `ui/ops`
- Exercised manually: card stream + filtering, search navigation, pop-out, export, config dialog