### PR TITLE
driver/steinel: support multiple devices per driver instance

### DIFF
--- a/pkg/driver/steinel/hpd/client.go
+++ b/pkg/driver/steinel/hpd/client.go
@@ -1,12 +1,14 @@
 package hpd
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 type Client struct {
@@ -51,13 +53,14 @@ func getAllowedCiphers() []uint16 {
 
 // newInsecureClient creates a Client that connects over HTTPS but does not verify the server certificate.
 func newInsecureClient(host string, password string) *Client {
-	client := &Client{
+	return &Client{
 		BaseURL: url.URL{
 			Scheme: "https",
 			Host:   host,
 			Path:   "/rest",
 		},
 		Client: &http.Client{
+			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: true,
@@ -65,13 +68,8 @@ func newInsecureClient(host string, password string) *Client {
 				},
 			},
 		},
+		Password: password,
 	}
-	if len(password) > 0 {
-		client.Password = password
-	} else {
-		client.Password = "Steinel123"
-	}
-	return client
 }
 
 func (c *Client) newRequest(method string, endpoint string) *http.Request {
@@ -130,8 +128,8 @@ type SensorResponse struct {
 	IAQ                          int     `json:"IAQ,omitempty"`
 }
 
-func doGetRequest(conn *Client, target any, endpoint string) error {
-	req := conn.newRequest("GET", endpoint)
+func doGetRequest(ctx context.Context, conn *Client, target any, endpoint string) error {
+	req := conn.newRequest("GET", endpoint).WithContext(ctx)
 
 	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(":"+conn.Password)))
 

--- a/pkg/driver/steinel/hpd/config/root.go
+++ b/pkg/driver/steinel/hpd/config/root.go
@@ -12,20 +12,65 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/util/jsontypes"
 )
 
+// DefaultPollInterval is how often each device is polled for updates unless configured otherwise.
+const DefaultPollInterval = 60 * time.Second
+
 type Root struct {
 	driver.BaseConfig
 
-	// Smart core metadata associated with this device.
-	Metadata *metadatapb.Metadata `json:"metadata,omitempty"`
-
-	IpAddress    string `json:"ipAddress"`
-	Password     string `json:"password,omitempty"`
+	// PasswordFile is a shared default for all devices, can be overridden per device.
 	PasswordFile string `json:"passwordFile,omitempty"`
-	// PollInterval is the interval between polling the device for updates, defaults to 60 seconds
+	// PollInterval is the interval between polling each device for updates, defaults to 60 seconds.
+	// Can be overridden per device.
 	PollInterval *jsontypes.Duration `json:"pollInterval,omitempty,omitzero"`
 
-	// to support UDMI/MQTT automation
+	// Devices lists the HPD sensors managed by this driver.
+	Devices []Device `json:"devices,omitempty"`
+
+	// Legacy single-device config. When ipAddress is set the root describes one device
+	// announced using the driver name. Mutually exclusive with Devices.
+
+	// Metadata is the smart core metadata associated with the legacy single device.
+	// Deprecated: use Devices and set metadata per device instead.
+	Metadata *metadatapb.Metadata `json:"metadata,omitempty"`
+	// IpAddress is the address of the legacy single device.
+	// Deprecated: use Devices and set ipAddress per device instead.
+	IpAddress string `json:"ipAddress,omitempty"`
+	// Password is rejected when set, plaintext passwords in config are not supported.
+	// Deprecated: use PasswordFile.
+	Password string `json:"password,omitempty"`
+	// UDMITopicPrefix is the UDMI/MQTT topic prefix of the legacy single device.
+	// Deprecated: use Devices and set udmiTopicPrefix per device instead.
 	UDMITopicPrefix string `json:"udmiTopicPrefix,omitempty"`
+}
+
+type Device struct {
+	// Name is the smart core name the device is announced as.
+	Name string `json:"name"`
+	// Metadata is the smart core metadata associated with this device.
+	Metadata *metadatapb.Metadata `json:"metadata,omitempty"`
+
+	IpAddress string `json:"ipAddress"`
+	// Password is rejected when set, plaintext passwords in config are not supported.
+	// Deprecated: use PasswordFile.
+	Password string `json:"password,omitempty"`
+	// PasswordFile names a file the device password is read from, defaults to the root PasswordFile.
+	PasswordFile string `json:"passwordFile,omitempty"`
+	// PollInterval overrides the root pollInterval for this device.
+	PollInterval *jsontypes.Duration `json:"pollInterval,omitempty,omitzero"`
+
+	// UDMITopicPrefix supports the UDMI/MQTT automation.
+	// When empty the device is not announced with the UDMI trait.
+	// Must be unique between devices, otherwise their exports would share an MQTT topic.
+	UDMITopicPrefix string `json:"udmiTopicPrefix,omitempty"`
+
+	// password is the device password read from PasswordFile, see ResolvedPassword.
+	password string
+}
+
+// ResolvedPassword returns the device password read from PasswordFile during ParseConfig.
+func (d Device) ResolvedPassword() string {
+	return d.password
 }
 
 func ParseConfig(data []byte) (Root, error) {
@@ -36,21 +81,92 @@ func ParseConfig(data []byte) (Root, error) {
 		return Root{}, err
 	}
 
-	if root.IpAddress == "" {
-		return Root{}, fmt.Errorf("ipAddress is required")
+	if root.Password != "" {
+		return Root{}, fmt.Errorf("plaintext passwords in config are not supported, use passwordFile")
 	}
-
-	if root.Password == "" {
-		bs, err := os.ReadFile(root.PasswordFile)
-		if err != nil {
-			return Root{}, fmt.Errorf("failed to read password file: %w", err)
+	if root.IpAddress != "" {
+		if len(root.Devices) > 0 {
+			return Root{}, fmt.Errorf("ipAddress and devices are mutually exclusive")
 		}
-		root.Password = strings.TrimSpace(string(bs))
+		// legacy single-device config: the root describes one device named after the driver
+		root.Devices = []Device{{
+			Name:            root.Name,
+			Metadata:        root.Metadata,
+			IpAddress:       root.IpAddress,
+			UDMITopicPrefix: root.UDMITopicPrefix,
+		}}
+	} else {
+		if len(root.Devices) == 0 {
+			return Root{}, fmt.Errorf("one of ipAddress or devices is required")
+		}
+		if root.Metadata != nil || root.UDMITopicPrefix != "" {
+			// these don't cascade to devices, reject them rather than silently ignoring them
+			return Root{}, fmt.Errorf("metadata and udmiTopicPrefix are legacy single-device options, set them per device")
+		}
 	}
 
 	if root.PollInterval == nil || root.PollInterval.Duration == 0 {
-		root.PollInterval = &jsontypes.Duration{Duration: time.Second * 60}
+		root.PollInterval = &jsontypes.Duration{Duration: DefaultPollInterval}
+	}
+
+	seenNames := make(map[string]struct{}, len(root.Devices))
+	seenTopicPrefixes := make(map[string]struct{}, len(root.Devices))
+	passwords := make(map[string]string) // file path -> contents, so files shared between devices are read once
+	for i := range root.Devices {
+		device := &root.Devices[i]
+		if device.Name == "" {
+			return Root{}, fmt.Errorf("devices[%d]: name is required", i)
+		}
+		if _, ok := seenNames[device.Name]; ok {
+			return Root{}, fmt.Errorf("devices[%d]: duplicate name %q", i, device.Name)
+		}
+		seenNames[device.Name] = struct{}{}
+		if device.IpAddress == "" {
+			return Root{}, fmt.Errorf("devices[%d] %q: ipAddress is required", i, device.Name)
+		}
+		if device.Password != "" {
+			return Root{}, fmt.Errorf("devices[%d] %q: plaintext passwords in config are not supported, use passwordFile", i, device.Name)
+		}
+		if err := device.resolvePassword(root.PasswordFile, passwords); err != nil {
+			return Root{}, fmt.Errorf("devices[%d] %q: %w", i, device.Name, err)
+		}
+		if device.PollInterval == nil || device.PollInterval.Duration == 0 {
+			device.PollInterval = root.PollInterval
+		}
+		if device.UDMITopicPrefix != "" {
+			if _, ok := seenTopicPrefixes[device.UDMITopicPrefix]; ok {
+				return Root{}, fmt.Errorf("devices[%d] %q: duplicate udmiTopicPrefix %q, devices would share an MQTT topic", i, device.Name, device.UDMITopicPrefix)
+			}
+			seenTopicPrefixes[device.UDMITopicPrefix] = struct{}{}
+		}
 	}
 
 	return root, nil
+}
+
+// resolvePassword fills in d.password from d.PasswordFile, falling back to defaultFile.
+// passwords caches file contents by path so files shared between devices are read once.
+func (d *Device) resolvePassword(defaultFile string, passwords map[string]string) error {
+	file := d.PasswordFile
+	if file == "" {
+		file = defaultFile
+	}
+	if file == "" {
+		return fmt.Errorf("passwordFile is required")
+	}
+	if pass, ok := passwords[file]; ok {
+		d.password = pass
+		return nil
+	}
+	bs, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("failed to read password file: %w", err)
+	}
+	pass := strings.TrimSpace(string(bs))
+	if pass == "" {
+		return fmt.Errorf("password file %q is empty", file)
+	}
+	passwords[file] = pass
+	d.password = pass
+	return nil
 }

--- a/pkg/driver/steinel/hpd/config/root_test.go
+++ b/pkg/driver/steinel/hpd/config/root_test.go
@@ -1,0 +1,211 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseConfig_legacySingleDevice(t *testing.T) {
+	data := `{
+		"name": "steinel-hpd",
+		"type": "steinel-hpd",
+		"ipAddress": "10.0.0.1",
+		"passwordFile": ` + quote(writePasswordFile(t, "secret")) + `,
+		"udmiTopicPrefix": "topic/prefix",
+		"metadata": {"membership": {"subsystem": "sensors"}}
+	}`
+	root, err := ParseConfig([]byte(data))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if len(root.Devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(root.Devices))
+	}
+	dev := root.Devices[0]
+	if dev.Name != "steinel-hpd" {
+		t.Errorf("device name = %q, want %q", dev.Name, "steinel-hpd")
+	}
+	if dev.IpAddress != "10.0.0.1" {
+		t.Errorf("device ipAddress = %q, want %q", dev.IpAddress, "10.0.0.1")
+	}
+	if dev.ResolvedPassword() != "secret" {
+		t.Errorf("device password = %q, want %q", dev.ResolvedPassword(), "secret")
+	}
+	if dev.UDMITopicPrefix != "topic/prefix" {
+		t.Errorf("device udmiTopicPrefix = %q, want %q", dev.UDMITopicPrefix, "topic/prefix")
+	}
+	if dev.Metadata.GetMembership().GetSubsystem() != "sensors" {
+		t.Errorf("device metadata subsystem = %q, want %q", dev.Metadata.GetMembership().GetSubsystem(), "sensors")
+	}
+	if got, want := dev.PollInterval.Duration, DefaultPollInterval; got != want {
+		t.Errorf("device pollInterval = %v, want %v", got, want)
+	}
+}
+
+func TestParseConfig_multiDevice(t *testing.T) {
+	data := `{
+		"name": "steinel-hpd",
+		"type": "steinel-hpd",
+		"passwordFile": ` + quote(writePasswordFile(t, "shared")) + `,
+		"pollInterval": "30s",
+		"devices": [
+			{"name": "sensors/01", "ipAddress": "10.0.0.1", "udmiTopicPrefix": "site/01", "metadata": {"membership": {"subsystem": "sensors"}}},
+			{"name": "sensors/02", "ipAddress": "10.0.0.2", "passwordFile": ` + quote(writePasswordFile(t, "override")) + `, "pollInterval": "10s", "udmiTopicPrefix": "site/02"}
+		]
+	}`
+	root, err := ParseConfig([]byte(data))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if len(root.Devices) != 2 {
+		t.Fatalf("expected 2 devices, got %d", len(root.Devices))
+	}
+	d0, d1 := root.Devices[0], root.Devices[1]
+	if d0.ResolvedPassword() != "shared" {
+		t.Errorf("devices[0] password = %q, want shared default %q", d0.ResolvedPassword(), "shared")
+	}
+	if got, want := d0.PollInterval.Duration, 30*time.Second; got != want {
+		t.Errorf("devices[0] pollInterval = %v, want root default %v", got, want)
+	}
+	if d0.UDMITopicPrefix != "site/01" {
+		t.Errorf("devices[0] udmiTopicPrefix = %q, want %q", d0.UDMITopicPrefix, "site/01")
+	}
+	if d0.Metadata.GetMembership().GetSubsystem() != "sensors" {
+		t.Errorf("devices[0] metadata subsystem = %q, want %q", d0.Metadata.GetMembership().GetSubsystem(), "sensors")
+	}
+	if d1.ResolvedPassword() != "override" {
+		t.Errorf("devices[1] password = %q, want %q", d1.ResolvedPassword(), "override")
+	}
+	if got, want := d1.PollInterval.Duration, 10*time.Second; got != want {
+		t.Errorf("devices[1] pollInterval = %v, want %v", got, want)
+	}
+	if d1.UDMITopicPrefix != "site/02" {
+		t.Errorf("devices[1] udmiTopicPrefix = %q, want %q", d1.UDMITopicPrefix, "site/02")
+	}
+}
+
+func TestParseConfig_multiDeviceDefaults(t *testing.T) {
+	// no pollInterval or udmiTopicPrefix anywhere: devices poll at the default rate,
+	// and multiple devices without a udmi topic prefix are allowed
+	data := `{
+		"name": "steinel-hpd",
+		"passwordFile": ` + quote(writePasswordFile(t, "p")) + `,
+		"devices": [
+			{"name": "sensors/01", "ipAddress": "10.0.0.1"},
+			{"name": "sensors/02", "ipAddress": "10.0.0.2"}
+		]
+	}`
+	root, err := ParseConfig([]byte(data))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	for i, dev := range root.Devices {
+		if got, want := dev.PollInterval.Duration, DefaultPollInterval; got != want {
+			t.Errorf("devices[%d] pollInterval = %v, want %v", i, got, want)
+		}
+		if dev.UDMITopicPrefix != "" {
+			t.Errorf("devices[%d] udmiTopicPrefix = %q, want empty", i, dev.UDMITopicPrefix)
+		}
+	}
+}
+
+func TestParseConfig_errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		wantErr string
+	}{
+		{
+			name:    "no devices or ipAddress",
+			data:    `{"name": "steinel-hpd"}`,
+			wantErr: "one of ipAddress or devices is required",
+		},
+		{
+			name:    "both devices and ipAddress",
+			data:    `{"name": "x", "ipAddress": "10.0.0.1", "devices": [{"name": "a", "ipAddress": "10.0.0.2"}]}`,
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "device missing name",
+			data:    `{"name": "x", "devices": [{"ipAddress": "10.0.0.1"}]}`,
+			wantErr: "name is required",
+		},
+		{
+			name:    "device missing ipAddress",
+			data:    `{"name": "x", "devices": [{"name": "a"}]}`,
+			wantErr: "ipAddress is required",
+		},
+		{
+			name: "duplicate device names",
+			data: `{"name": "x", "passwordFile": ` + quote(writePasswordFile(t, "p")) + `,
+				"devices": [{"name": "a", "ipAddress": "10.0.0.1"}, {"name": "a", "ipAddress": "10.0.0.2"}]}`,
+			wantErr: "duplicate name",
+		},
+		{
+			name:    "no passwordFile",
+			data:    `{"name": "x", "devices": [{"name": "a", "ipAddress": "10.0.0.1"}]}`,
+			wantErr: "passwordFile is required",
+		},
+		{
+			name:    "root plaintext password",
+			data:    `{"name": "x", "ipAddress": "10.0.0.1", "password": "p"}`,
+			wantErr: "plaintext passwords in config are not supported",
+		},
+		{
+			// rejected even when a valid passwordFile is also configured
+			name: "device plaintext password",
+			data: `{"name": "x", "passwordFile": ` + quote(writePasswordFile(t, "p")) + `,
+				"devices": [{"name": "a", "ipAddress": "10.0.0.1", "password": "p"}]}`,
+			wantErr: "plaintext passwords in config are not supported",
+		},
+		{
+			name:    "empty password file",
+			data:    `{"name": "x", "passwordFile": ` + quote(writePasswordFile(t, "")) + `, "devices": [{"name": "a", "ipAddress": "10.0.0.1"}]}`,
+			wantErr: "is empty",
+		},
+		{
+			name: "root metadata with devices",
+			data: `{"name": "x", "metadata": {"membership": {"subsystem": "sensors"}},
+				"devices": [{"name": "a", "ipAddress": "10.0.0.1"}]}`,
+			wantErr: "legacy single-device options",
+		},
+		{
+			name:    "root udmiTopicPrefix with devices",
+			data:    `{"name": "x", "udmiTopicPrefix": "t", "devices": [{"name": "a", "ipAddress": "10.0.0.1"}]}`,
+			wantErr: "legacy single-device options",
+		},
+		{
+			name: "duplicate udmiTopicPrefix",
+			data: `{"name": "x", "passwordFile": ` + quote(writePasswordFile(t, "p")) + `,
+				"devices": [{"name": "a", "ipAddress": "10.0.0.1", "udmiTopicPrefix": "t"}, {"name": "b", "ipAddress": "10.0.0.2", "udmiTopicPrefix": "t"}]}`,
+			wantErr: "duplicate udmiTopicPrefix",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseConfig([]byte(tt.data))
+			if err == nil {
+				t.Fatalf("ParseConfig: expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("ParseConfig error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func writePasswordFile(t *testing.T, password string) string {
+	t.Helper()
+	file := filepath.Join(t.TempDir(), "password")
+	if err := os.WriteFile(file, []byte(password+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return file
+}
+
+func quote(s string) string {
+	return `"` + strings.ReplaceAll(s, `\`, `\\`) + `"`
+}

--- a/pkg/driver/steinel/hpd/driver.go
+++ b/pkg/driver/steinel/hpd/driver.go
@@ -2,9 +2,11 @@ package hpd
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
 
 	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/smart-core-os/sc-bos/pkg/driver"
 	"github.com/smart-core-os/sc-bos/pkg/driver/steinel/hpd/config"
@@ -46,64 +48,86 @@ type Driver struct {
 	health    *healthpb.Checks
 	logger    *zap.Logger
 
-	client *Client
-
-	airQualitySensor *AirQualitySensor
-	brightnessSensor *brightnessSensor
-	occupancy        *Occupancy
-	soundSensor      *soundSensor
-	temperature      *TemperatureSensor
-
-	udmiServiceServer *UdmiServiceServer
+	// devicesStopped waits until the devices set up by the previous applyConfig have
+	// stopped and released their health checks. nil before the first apply.
+	devicesStopped func()
 }
 
 func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
+	if d.devicesStopped != nil {
+		// MonoApply has cancelled the previous apply's context, but its devices release
+		// their health checks asynchronously as they stop. Wait for them so re-registering
+		// the checks below doesn't fail with ErrAlreadyExists.
+		d.devicesStopped()
+	}
 	announcer := d.announcer.Replace(ctx)
-	grp, ctx := errgroup.WithContext(ctx)
 
-	d.client = newInsecureClient(cfg.IpAddress, cfg.Password)
+	var wg sync.WaitGroup
+	d.devicesStopped = wg.Wait
 
-	d.airQualitySensor = newAirQualitySensor(d.client, d.logger.Named("AirQualityValue").With(zap.String("ipAddress", cfg.IpAddress)))
-	d.brightnessSensor = newBrightnessSensor(d.client, d.logger.Named("Brightness").With(zap.String("ipAddress", cfg.IpAddress)))
-	d.occupancy = newOccupancySensor(d.client, d.logger.Named("Occupancy").With(zap.String("ipAddress", cfg.IpAddress)))
-	d.soundSensor = newSoundSensor(d.client, d.logger.Named("soundSensor").With(zap.String("ipAddress", cfg.IpAddress)))
-	d.temperature = newTemperatureSensor(d.client, d.logger.Named("Temperature").With(zap.String("ipAddress", cfg.IpAddress)))
-	d.udmiServiceServer = newUdmiServiceServer(d.logger.Named("UdmiServiceServer"), d.airQualitySensor.AirQualityValue, d.occupancy.OccupancyValue, d.temperature.TemperatureValue, cfg.UDMITopicPrefix)
+	var errs []error
+	for _, devCfg := range cfg.Devices {
+		if err := d.applyDeviceConfig(ctx, announcer, &wg, devCfg); err != nil {
+			// one bad device shouldn't stop the others from running
+			d.logger.Error("failed to set up device", zap.String("device", devCfg.Name), zap.Error(err))
+			errs = append(errs, fmt.Errorf("%s: %w", devCfg.Name, err))
+		}
+	}
+	if len(errs) > 0 && len(errs) == len(cfg.Devices) {
+		// no device made it, surface that via the service status
+		return errors.Join(errs...)
+	}
+	return nil
+}
 
-	announcer.Announce(cfg.Name,
-		node.HasMetadata(cfg.Metadata),
-		node.HasServer(airqualitysensorpb.RegisterAirQualitySensorApiServer, airqualitysensorpb.AirQualitySensorApiServer(d.airQualitySensor)),
-		node.HasTrait(trait.AirQualitySensor),
-		node.HasServer(airtemperaturepb.RegisterAirTemperatureApiServer, airtemperaturepb.AirTemperatureApiServer(d.temperature)),
-		node.HasTrait(trait.AirTemperature),
-		node.HasServer(brightnesssensorpb.RegisterBrightnessSensorApiServer, brightnesssensorpb.BrightnessSensorApiServer(d.brightnessSensor)),
-		node.HasTrait(trait.BrightnessSensor),
-		node.HasServer(occupancysensorpb.RegisterOccupancySensorApiServer, occupancysensorpb.OccupancySensorApiServer(d.occupancy)),
-		node.HasTrait(trait.OccupancySensor),
-		node.HasServer(soundsensorpb.RegisterSoundSensorApiServer, soundsensorpb.SoundSensorApiServer(d.soundSensor)),
-		node.HasTrait(soundsensorpb.TraitName),
-		node.HasServer(udmipb.RegisterUdmiServiceServer, udmipb.UdmiServiceServer(d.udmiServiceServer)),
-		node.HasTrait(udmipb.TraitName),
-		node.HasDeviceType(metadatapb.Metadata_DEVICE),
-	)
+func (d *Driver) applyDeviceConfig(ctx context.Context, announcer node.Announcer, wg *sync.WaitGroup, cfg config.Device) error {
+	logger := d.logger.With(zap.String("device", cfg.Name), zap.String("ipAddress", cfg.IpAddress))
+	client := newInsecureClient(cfg.IpAddress, cfg.ResolvedPassword())
 
-	faultCheck, err := d.health.NewFaultCheck(cfg.Name, commsHealthCheck)
+	airQualitySensor := newAirQualitySensor(client, logger.Named("AirQualityValue"))
+	brightnessSensor := newBrightnessSensor(client, logger.Named("Brightness"))
+	occupancy := newOccupancySensor(client, logger.Named("Occupancy"))
+	soundSensor := newSoundSensor(client, logger.Named("soundSensor"))
+	temperature := newTemperatureSensor(client, logger.Named("Temperature"))
+
+	faultCheck, err := d.health.NewFaultCheck(cfg.Name, commsHealthCheck())
 	if err != nil {
-		d.logger.Error("failed to create health check", zap.String("device", cfg.Name), zap.Error(err))
-		return err
+		return fmt.Errorf("failed to create health check: %w", err)
 	}
 
-	poller := newPoller(d.client, cfg.PollInterval.Duration, d.logger.Named("SteinelPoller").With(zap.String("ipAddress", cfg.IpAddress)), faultCheck, d.airQualitySensor, d.occupancy, d.temperature)
+	features := []node.Feature{
+		node.HasMetadata(cfg.Metadata),
+		node.HasServer(airqualitysensorpb.RegisterAirQualitySensorApiServer, airqualitysensorpb.AirQualitySensorApiServer(airQualitySensor)),
+		node.HasTrait(trait.AirQualitySensor),
+		node.HasServer(airtemperaturepb.RegisterAirTemperatureApiServer, airtemperaturepb.AirTemperatureApiServer(temperature)),
+		node.HasTrait(trait.AirTemperature),
+		node.HasServer(brightnesssensorpb.RegisterBrightnessSensorApiServer, brightnesssensorpb.BrightnessSensorApiServer(brightnessSensor)),
+		node.HasTrait(trait.BrightnessSensor),
+		node.HasServer(occupancysensorpb.RegisterOccupancySensorApiServer, occupancysensorpb.OccupancySensorApiServer(occupancy)),
+		node.HasTrait(trait.OccupancySensor),
+		node.HasServer(soundsensorpb.RegisterSoundSensorApiServer, soundsensorpb.SoundSensorApiServer(soundSensor)),
+		node.HasTrait(soundsensorpb.TraitName),
+		node.HasDeviceType(metadatapb.Metadata_DEVICE),
+	}
+	if cfg.UDMITopicPrefix != "" {
+		// without a topic prefix devices would all export to the same MQTT topic, so no prefix means no UDMI
+		udmiServiceServer := newUdmiServiceServer(logger.Named("UdmiServiceServer"),
+			airQualitySensor.AirQualityValue, occupancy.OccupancyValue, temperature.TemperatureValue, cfg.UDMITopicPrefix)
+		features = append(features,
+			node.HasServer(udmipb.RegisterUdmiServiceServer, udmipb.UdmiServiceServer(udmiServiceServer)),
+			node.HasTrait(udmipb.TraitName),
+		)
+	}
+	announcer.Announce(cfg.Name, features...)
 
-	grp.Go(func() error {
-		poller.startPoll(ctx)
-		return nil
-	})
+	poller := newPoller(client, cfg.PollInterval.Or(config.DefaultPollInterval), logger.Named("SteinelPoller"), faultCheck, airQualitySensor, occupancy, temperature)
 
+	wg.Add(1)
 	go func() {
-		_ = grp.Wait() // won't error in current implementation
-		faultCheck.Dispose()
-		d.client.Client.CloseIdleConnections()
+		defer wg.Done()
+		defer client.Client.CloseIdleConnections()
+		defer faultCheck.Dispose()
+		poller.startPoll(ctx)
 	}()
 
 	return nil

--- a/pkg/driver/steinel/hpd/driver.go
+++ b/pkg/driver/steinel/hpd/driver.go
@@ -122,13 +122,11 @@ func (d *Driver) applyDeviceConfig(ctx context.Context, announcer node.Announcer
 
 	poller := newPoller(client, cfg.PollInterval.Or(config.DefaultPollInterval), logger.Named("SteinelPoller"), faultCheck, airQualitySensor, occupancy, temperature)
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer client.Client.CloseIdleConnections()
 		defer faultCheck.Dispose()
 		poller.startPoll(ctx)
-	}()
+	})
 
 	return nil
 }

--- a/pkg/driver/steinel/hpd/driver_test.go
+++ b/pkg/driver/steinel/hpd/driver_test.go
@@ -1,0 +1,80 @@
+package hpd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/smart-core-os/sc-bos/pkg/driver/steinel/hpd/config"
+	"github.com/smart-core-os/sc-bos/pkg/node"
+	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
+)
+
+// TestDriver_applyConfig_reapply checks that each device registers a health check under its own
+// un-compounded id, and that re-applying config — like service.MonoApply does — doesn't lose
+// devices to the asynchronous release of the previous apply's health checks.
+func TestDriver_applyConfig_reapply(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"Temperature": 20.2, "Humidity": 50}`))
+	}))
+	defer server.Close()
+	host := strings.TrimPrefix(server.URL, "https://")
+
+	passwordFile := filepath.Join(t.TempDir(), "password")
+	if err := os.WriteFile(passwordFile, []byte("secret\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	data := `{
+		"name": "steinel-hpd",
+		"passwordFile": "` + strings.ReplaceAll(passwordFile, `\`, `\\`) + `",
+		"devices": [
+			{"name": "sensors/01", "ipAddress": "` + host + `"},
+			{"name": "sensors/02", "ipAddress": "` + host + `"}
+		]
+	}`
+	cfg, err := config.ParseConfig([]byte(data))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+
+	const owner = "driver:steinel-hpd"
+	registry := healthpb.NewRegistry()
+	d := &Driver{
+		announcer: node.NewReplaceAnnouncer(node.New("test")),
+		health:    registry.ForOwner(owner),
+		logger:    zap.NewNop(),
+	}
+
+	checkID := healthpb.AbsID(owner, "commsCheck")
+	wantChecks := func(t *testing.T) {
+		t.Helper()
+		for _, name := range []string{"sensors/01", "sensors/02"} {
+			if got := registry.GetCheck(name, checkID); got == nil {
+				t.Errorf("GetCheck(%q, %q) = nil, want a registered check", name, checkID)
+			}
+		}
+	}
+
+	ctx1, stop1 := context.WithCancel(context.Background())
+	if err := d.applyConfig(ctx1, cfg); err != nil {
+		t.Fatalf("applyConfig: %v", err)
+	}
+	wantChecks(t)
+
+	// MonoApply cancels the previous context then immediately re-applies
+	ctx2, stop2 := context.WithCancel(context.Background())
+	stop1()
+	if err := d.applyConfig(ctx2, cfg); err != nil {
+		t.Fatalf("applyConfig (reapply): %v", err)
+	}
+	wantChecks(t)
+
+	stop2()
+	d.devicesStopped()
+}

--- a/pkg/driver/steinel/hpd/health.go
+++ b/pkg/driver/steinel/hpd/health.go
@@ -10,16 +10,19 @@ const (
 	Offline     = "Offline"
 )
 
-var (
-	// This health check monitors the device to check if it is online and communicating properly.
-	commsHealthCheck = &healthpb.HealthCheck{
+// commsHealthCheck returns a health check that monitors whether a device is online and communicating properly.
+// Each device needs its own instance, the health system takes ownership of (and mutates) the checks given to it.
+func commsHealthCheck() *healthpb.HealthCheck {
+	return &healthpb.HealthCheck{
 		Id:              "commsCheck",
 		DisplayName:     "Comms Check",
 		Description:     "Checks if the device is online and communicating properly",
 		OccupantImpact:  healthpb.HealthCheck_COMFORT,
 		EquipmentImpact: healthpb.HealthCheck_FUNCTION,
 	}
+}
 
+var (
 	noResponse = &healthpb.HealthCheck_Reliability{
 		State: healthpb.HealthCheck_Reliability_NO_RESPONSE,
 		LastError: &healthpb.HealthCheck_Error{

--- a/pkg/driver/steinel/hpd/poller.go
+++ b/pkg/driver/steinel/hpd/poller.go
@@ -50,7 +50,10 @@ func (p *poller) startPoll(ctx context.Context) {
 
 func (p *poller) process(ctx context.Context) {
 	response := SensorResponse{}
-	if err := doGetRequest(p.client, &response, "sensor"); err != nil {
+	if err := doGetRequest(ctx, p.client, &response, "sensor"); err != nil {
+		if ctx.Err() != nil {
+			return // we're stopping, not a device fault
+		}
 		h := noResponse
 		var unsupportedTypeErr *json.UnmarshalTypeError
 		if errors.Is(err, unsupportedTypeErr) {

--- a/pkg/driver/steinel/hpd/trait_airquality.go
+++ b/pkg/driver/steinel/hpd/trait_airquality.go
@@ -34,9 +34,9 @@ func newAirQualitySensor(client *Client, logger *zap.Logger) *AirQualitySensor {
 	}
 }
 
-func (a *AirQualitySensor) GetAirQuality(_ context.Context, _ *airqualitysensorpb.GetAirQualityRequest) (*airqualitysensorpb.AirQuality, error) {
+func (a *AirQualitySensor) GetAirQuality(ctx context.Context, _ *airqualitysensorpb.GetAirQualityRequest) (*airqualitysensorpb.AirQuality, error) {
 	response := SensorResponse{}
-	if err := doGetRequest(a.client, &response, "sensor"); err != nil {
+	if err := doGetRequest(ctx, a.client, &response, "sensor"); err != nil {
 		return nil, err
 	}
 	if err := a.GetUpdate(&response); err != nil {

--- a/pkg/driver/steinel/hpd/trait_brightness.go
+++ b/pkg/driver/steinel/hpd/trait_brightness.go
@@ -29,9 +29,9 @@ func newBrightnessSensor(client *Client, logger *zap.Logger) *brightnessSensor {
 	}
 }
 
-func (b *brightnessSensor) GetAmbientBrightness(context.Context, *brightnesssensorpb.GetAmbientBrightnessRequest) (*brightnesssensorpb.AmbientBrightness, error) {
+func (b *brightnessSensor) GetAmbientBrightness(ctx context.Context, _ *brightnesssensorpb.GetAmbientBrightnessRequest) (*brightnesssensorpb.AmbientBrightness, error) {
 	response := SensorResponse{}
-	if err := doGetRequest(b.client, &response, "sensor"); err != nil {
+	if err := doGetRequest(ctx, b.client, &response, "sensor"); err != nil {
 		return nil, err
 	}
 	if err := b.getUpdate(&response); err != nil {

--- a/pkg/driver/steinel/hpd/trait_occupancy.go
+++ b/pkg/driver/steinel/hpd/trait_occupancy.go
@@ -32,9 +32,9 @@ func newOccupancySensor(client *Client, logger *zap.Logger) *Occupancy {
 	}
 }
 
-func (o *Occupancy) GetOccupancy(_ context.Context, _ *occupancysensorpb.GetOccupancyRequest) (*occupancysensorpb.Occupancy, error) {
+func (o *Occupancy) GetOccupancy(ctx context.Context, _ *occupancysensorpb.GetOccupancyRequest) (*occupancysensorpb.Occupancy, error) {
 	response := SensorResponse{}
-	if err := doGetRequest(o.client, &response, "sensor"); err != nil {
+	if err := doGetRequest(ctx, o.client, &response, "sensor"); err != nil {
 		return nil, err
 	}
 	if err := o.GetUpdate(&response); err != nil {

--- a/pkg/driver/steinel/hpd/trait_soundsensor.go
+++ b/pkg/driver/steinel/hpd/trait_soundsensor.go
@@ -28,9 +28,9 @@ func newSoundSensor(client *Client, logger *zap.Logger) *soundSensor {
 	}
 }
 
-func (s *soundSensor) GetSoundLevel(context.Context, *soundsensorpb.GetSoundLevelRequest) (*soundsensorpb.SoundLevel, error) {
+func (s *soundSensor) GetSoundLevel(ctx context.Context, _ *soundsensorpb.GetSoundLevelRequest) (*soundsensorpb.SoundLevel, error) {
 	response := SensorResponse{}
-	if err := doGetRequest(s.client, &response, "sensor"); err != nil {
+	if err := doGetRequest(ctx, s.client, &response, "sensor"); err != nil {
 		return nil, err
 	}
 	if err := s.getUpdate(&response); err != nil {

--- a/pkg/driver/steinel/hpd/trait_temphumidity.go
+++ b/pkg/driver/steinel/hpd/trait_temphumidity.go
@@ -31,9 +31,9 @@ func newTemperatureSensor(client *Client, logger *zap.Logger) *TemperatureSensor
 	}
 }
 
-func (a *TemperatureSensor) GetAirTemperature(_ context.Context, _ *airtemperaturepb.GetAirTemperatureRequest) (*airtemperaturepb.AirTemperature, error) {
+func (a *TemperatureSensor) GetAirTemperature(ctx context.Context, _ *airtemperaturepb.GetAirTemperatureRequest) (*airtemperaturepb.AirTemperature, error) {
 	response := SensorResponse{}
-	if err := doGetRequest(a.client, &response, "sensor"); err != nil {
+	if err := doGetRequest(ctx, a.client, &response, "sensor"); err != nil {
 		return nil, err
 	}
 	if err := a.GetUpdate(&response); err != nil {


### PR DESCRIPTION
[SCB-1007](https://vanti.youtrack.cloud/issue/SCB-1007) 

## Summary

Converts the Steinel HPD driver from one device per driver instance to a `devices` list, so sites with many sensors per controller don't need a driver service per sensor.

- Each device gets its own client, poller and fault check, following the shelly/trv pattern. Root level `passwordFile` and `pollInterval` act as shared defaults with per-device overrides.
- The existing single-device config (root level `ipAddress`) is still supported and is normalised into a one-element devices list named after the driver.
- A device that fails to set up is logged and skipped rather than failing the whole driver, unless every device fails — then the service reports the error.
- Reconfiguring waits for the previous devices to stop and release their health checks before re-registering them, so devices don't vanish on a config reload. Sensor HTTP requests honour the context and have a timeout so that wait can't hang on an unresponsive sensor.
- Each device registers its own health check proto — `healthpb` mutates the check it's given, so a shared instance would compound check ids.

## Breaking config changes

- **Plaintext passwords are rejected** with `plaintext passwords in config are not supported, use passwordFile`. Passwords must come from a non-empty password file; the hardcoded vendor default fallback (`Steinel123`) is removed.
- Root `metadata`/`udmiTopicPrefix` alongside `devices` is an error rather than silently ignored (they don't cascade; set them per device).
- The **UDMI trait is only announced when a device has a `udmiTopicPrefix`**, and prefixes must be unique between devices — otherwise every device would export to the same MQTT topic (`events/pointset`). A legacy single-device config that relied on an empty prefix loses the UDMI trait and needs a prefix set.

## Testing

- `go test -race -count=1 ./pkg/driver/steinel/...` — includes a new re-apply regression test (`TestDriver_applyConfig_reapply`) covering health-check ids and config reload, plus expanded `ParseConfig` coverage (defaults, cascades, all error cases).
- `go build ./...`, `go vet`, `gofmt` clean.