### PR TITLE
driver/bacnet: clear trait fault on clean poll

### DIFF
--- a/pkg/driver/bacnet/merge/trait.go
+++ b/pkg/driver/bacnet/merge/trait.go
@@ -11,7 +11,6 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/driver/bacnet/config"
 	"github.com/smart-core-os/sc-bos/pkg/driver/bacnet/known"
 	"github.com/smart-core-os/sc-bos/pkg/node"
-	"github.com/smart-core-os/sc-bos/pkg/task"
 	"github.com/smart-core-os/sc-bos/pkg/proto/accesspb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/meterpb"
@@ -20,6 +19,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/proto/temperaturepb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/transportpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/udmipb"
+	"github.com/smart-core-os/sc-bos/pkg/task"
 	"github.com/smart-core-os/sc-bos/pkg/trait"
 )
 
@@ -70,7 +70,7 @@ func IntoTrait(client *gobacnet.Client, devices known.Context, faultCheck *healt
 	return nil, ErrTraitNotSupported
 }
 
-func updateTraitFaultCheck(ctx context.Context, faultCheck *healthpb.FaultCheck, name string, trait trait.Name, errs []error) {
+func updateTraitFaultCheck(_ context.Context, faultCheck *healthpb.FaultCheck, name string, trait trait.Name, errs []error) {
 	if faultCheck == nil {
 		return
 	}
@@ -85,15 +85,12 @@ func updateTraitFaultCheck(ctx context.Context, faultCheck *healthpb.FaultCheck,
 		descriptions = append(descriptions, err.Error())
 
 	}
-	faultCheck.UpdateReliability(ctx, &healthpb.HealthCheck_Reliability{
-		State: healthpb.HealthCheck_Reliability_UNRELIABLE,
-		LastError: &healthpb.HealthCheck_Error{
-			SummaryText: fmt.Sprintf("%s[%s] has %d errors", name, trait.String(), len(errs)),
-			DetailsText: fmt.Sprintf("Trait %s errors: %s", trait, strings.Join(descriptions, "; ")),
-			Code: &healthpb.HealthCheck_Error_Code{
-				Code:   BacNetCommsError,
-				System: SystemName,
-			},
+	faultCheck.SetFault(&healthpb.HealthCheck_Error{
+		SummaryText: fmt.Sprintf("%s[%s] has %d errors", name, trait.String(), len(errs)),
+		DetailsText: fmt.Sprintf("Trait %s errors: %s", trait, strings.Join(descriptions, "; ")),
+		Code: &healthpb.HealthCheck_Error_Code{
+			Code:   BacNetCommsError,
+			System: SystemName,
 		},
 	})
 }


### PR DESCRIPTION
updateTraitFaultCheck wrote the failure into reliability.LastError via UpdateReliability, but LastError was never cleared and the success path's ClearFaults() didn't touch it, so trait faults latched after recovery.

Switch the failure path to SetFault so it pairs with the ClearFaults() already on the success path: ABNORMAL while failing, NORMAL on the next clean poll. Fixes the sticky fault for every trait routed through this helper (air_temperature, electric, meter, ...).