### PR TITLE
history/dataretention: raise health check on high storage utilisation

### DIFF
--- a/pkg/app/controller.go
+++ b/pkg/app/controller.go
@@ -685,7 +685,7 @@ func (c *Controller) Run(ctx context.Context) (err error) {
 	// we don't support changing metadata while running
 	c.Node.Announce(c.Node.Name(), node.HasMetadata(initialConfig.Metadata))
 
-	storeUndo := dataretention.Start(ctx, c.Node, c.SystemConfig.Name, c.Stores, c.SystemConfig.Stores, c.Logger)
+	storeUndo := dataretention.Start(ctx, c.Node, c.SystemConfig.Name, c.Stores, c.SystemConfig.Stores, c.CheckRegistry.ForOwner("stores"), c.Logger)
 	defer storeUndo()
 
 	group, ctx := errgroup.WithContext(ctx)

--- a/pkg/app/stores/stores.go
+++ b/pkg/app/stores/stores.go
@@ -24,6 +24,9 @@ var (
 // Config configures shared storage (dbs) for systems on this node.
 type Config struct {
 	Postgres *PostgresConfig `json:"postgres,omitempty"`
+	// StorageHealthHighPercent is the disk utilisation percentage (0-100) at or above which
+	// a store's storage HealthCheck reports HIGH. When zero, a default of 90 is used.
+	StorageHealthHighPercent float32 `json:"storageHealthHighPercent,omitempty"`
 	// Local directory for storing database files.
 	DataDir string      `json:"-"`
 	Logger  *zap.Logger `json:"-"`
@@ -31,6 +34,11 @@ type Config struct {
 
 type PostgresConfig struct {
 	pgxutil.ConnectConfig
+	// MaxSizeBytes is the maximum storage size, in bytes, the Postgres history store is
+	// allowed to use. Postgres does not report a disk capacity itself, so this must be set
+	// to enable the storage utilisation HealthCheck and the bytes.capacity DataRetention
+	// field for the Postgres store. When zero, no capacity is reported and no check is raised.
+	MaxSizeBytes uint64 `json:"maxSizeBytes,omitempty"`
 }
 
 const retryConnectDelay = 100 * time.Millisecond

--- a/pkg/history/dataretention/postgres.go
+++ b/pkg/history/dataretention/postgres.go
@@ -11,9 +11,10 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/history/pgxstore"
 	"github.com/smart-core-os/sc-bos/pkg/node"
 	"github.com/smart-core-os/sc-bos/pkg/proto/dataretentionpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
 )
 
-func announcePostgres(ctx context.Context, n *node.Node, name string, s *stores.Stores, logger *zap.Logger) node.Undo {
+func announcePostgres(ctx context.Context, n *node.Node, name string, s *stores.Stores, checks *healthpb.Checks, highPct float32, maxSizeBytes uint64, logger *zap.Logger) node.Undo {
 	model := dataretentionpb.NewModel()
 	server := dataretentionpb.NewModelServer(model, &postgresBackend{stores: s},
 		dataretentionpb.WithItemName("row"),
@@ -21,35 +22,20 @@ func announcePostgres(ctx context.Context, n *node.Node, name string, s *stores.
 
 	undo := n.Announce(name, node.HasTrait(dataretentionpb.TraitName, node.WithClients(dataretentionpb.WrapApi(server))))
 
-	go func() {
-		tick := time.NewTicker(30 * time.Second)
-		defer tick.Stop()
-		// poll once immediately so GetDataRetention returns a value without waiting 30s
-		updatePostgresModel(ctx, s, model, logger)
-		for {
-			if !model.HasSubscribers() {
-				select {
-				case <-ctx.Done():
-					return
-				case <-model.WaitForSubscriber():
-					updatePostgresModel(ctx, s, model, logger)
-					tick.Reset(30 * time.Second)
-				}
-				continue
-			}
-			select {
-			case <-ctx.Done():
-				return
-			case <-tick.C:
-				updatePostgresModel(ctx, s, model, logger)
-			}
-		}
-	}()
+	health := &storageHealth{checks: checks, name: name, highPct: highPct, logger: logger}
 
-	return undo
+	// Postgres only knows its capacity when a max size is configured. Without it there is
+	// no storage HealthCheck, so retain the subscriber-aware idling; with it, the check is
+	// an always-on consumer so we poll unconditionally. full is ignored: every figure the
+	// update queries is cheap (ApproxCount reads pg_stat, no scan) or needed by the check.
+	pollUndo := startPolling(ctx, model, maxSizeBytes > 0, health, func(ctx context.Context, _ bool) {
+		updatePostgresModel(ctx, s, model, health, maxSizeBytes, logger)
+	})
+
+	return node.UndoAll(undo, pollUndo)
 }
 
-func updatePostgresModel(ctx context.Context, s *stores.Stores, model *dataretentionpb.Model, logger *zap.Logger) {
+func updatePostgresModel(ctx context.Context, s *stores.Stores, model *dataretentionpb.Model, health *storageHealth, maxSizeBytes uint64, logger *zap.Logger) {
 	r, _, _, err := s.Postgres()
 	if err != nil {
 		logger.Warn("failed to get postgres store", zap.Error(err))
@@ -63,7 +49,13 @@ func updatePostgresModel(ctx context.Context, s *stores.Stores, model *datareten
 		logger.Warn("failed to query postgres history size", zap.Error(err))
 	} else {
 		used := uint64(sizeBytes)
-		retention.Bytes = &dataretentionpb.DataRetentionBytes{Used: &used}
+		bytesMsg := &dataretentionpb.DataRetentionBytes{Used: &used}
+		if maxSizeBytes > 0 {
+			capacity := maxSizeBytes
+			bytesMsg.Capacity = &capacity
+			health.update(ctx, float32(used)/float32(maxSizeBytes)*100)
+		}
+		retention.Bytes = bytesMsg
 	}
 
 	// ApproxCount reads n_live_tup from pg_stat_user_tables — O(1), no sequential scan.

--- a/pkg/history/dataretention/postgres_test.go
+++ b/pkg/history/dataretention/postgres_test.go
@@ -15,7 +15,7 @@ func TestUpdatePostgresModel_NotConfigured(t *testing.T) {
 	t.Cleanup(func() { _ = s.Close() })
 
 	model := dataretentionpb.NewModel()
-	updatePostgresModel(ctx, s, model, zap.NewNop())
+	updatePostgresModel(ctx, s, model, nil, 0, zap.NewNop())
 
 	got, err := model.GetDataRetention()
 	if err != nil {

--- a/pkg/history/dataretention/sqlite.go
+++ b/pkg/history/dataretention/sqlite.go
@@ -6,13 +6,15 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/smart-core-os/sc-bos/pkg/app/stores"
 	"github.com/smart-core-os/sc-bos/pkg/node"
 	"github.com/smart-core-os/sc-bos/pkg/proto/dataretentionpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
 )
 
-func announceSqlite(ctx context.Context, n *node.Node, name string, s *stores.Stores, dataDir string, logger *zap.Logger) node.Undo {
+func announceSqlite(ctx context.Context, n *node.Node, name string, s *stores.Stores, dataDir string, checks *healthpb.Checks, highPct float32, logger *zap.Logger) node.Undo {
 	model := dataretentionpb.NewModel()
 	server := dataretentionpb.NewModelServer(model, &sqliteBackend{stores: s},
 		dataretentionpb.WithItemName("row"),
@@ -20,67 +22,87 @@ func announceSqlite(ctx context.Context, n *node.Node, name string, s *stores.St
 
 	undo := n.Announce(name, node.HasTrait(dataretentionpb.TraitName, node.WithClients(dataretentionpb.WrapApi(server))))
 
-	go func() {
-		tick := time.NewTicker(30 * time.Second)
-		defer tick.Stop()
-		// poll once immediately so GetDataRetention returns a value without waiting 30s
-		updateSqliteModel(ctx, s, model, dataDir, logger)
-		for {
-			if !model.HasSubscribers() {
-				select {
-				case <-ctx.Done():
-					return
-				case <-model.WaitForSubscriber():
-					updateSqliteModel(ctx, s, model, dataDir, logger)
-					tick.Reset(30 * time.Second)
-				}
-				continue
-			}
-			select {
-			case <-ctx.Done():
-				return
-			case <-tick.C:
-				updateSqliteModel(ctx, s, model, dataDir, logger)
-			}
-		}
-	}()
+	health := &storageHealth{checks: checks, name: name, highPct: highPct, logger: logger}
 
-	return undo
+	// The SQLite store reports filesystem capacity (where available), so its storage
+	// HealthCheck is an always-on consumer: poll unconditionally rather than idling until
+	// a PullDataRetention subscriber connects.
+	pollUndo := startPolling(ctx, model, true, health, func(ctx context.Context, full bool) {
+		updateSqliteModel(ctx, s, model, dataDir, health, full, logger)
+	})
+
+	return node.UndoAll(undo, pollUndo)
 }
 
-func updateSqliteModel(ctx context.Context, s *stores.Stores, model *dataretentionpb.Model, dataDir string, logger *zap.Logger) {
+func updateSqliteModel(ctx context.Context, s *stores.Stores, model *dataretentionpb.Model, dataDir string, health *storageHealth, full bool, logger *zap.Logger) {
 	db, err := s.SqliteHistory(ctx)
 	if err != nil {
 		logger.Warn("failed to get sqlite history store", zap.Error(err))
+		// Disk fullness comes from the filesystem, not the store: report it even when the
+		// store query fails — a full disk may be why.
+		reportStorageHealth(ctx, health, dataDir, 0)
 		return
 	}
 
 	sizeBytes, err := db.Size(ctx)
 	if err != nil {
 		logger.Warn("failed to get sqlite history size", zap.Error(err))
+		reportStorageHealth(ctx, health, dataDir, 0)
 		return
 	}
-
-	count, err := db.TotalCount(ctx)
-	if err != nil {
-		logger.Warn("failed to get sqlite history count", zap.Error(err))
-		return
-	}
-
 	used := uint64(sizeBytes)
-	usedItems := uint64(count)
 
 	bytesMsg := &dataretentionpb.DataRetentionBytes{Used: &used}
-	if cap, otherUsed, available, ok := diskCapacity(dataDir, used); ok {
-		bytesMsg.Capacity = &cap
+	if capacity, otherUsed, available, ok := diskCapacity(dataDir, used); ok {
+		bytesMsg.Capacity = &capacity
 		bytesMsg.OtherUsed = &otherUsed
 		bytesMsg.Available = &available
+		if denom := used + otherUsed + available; denom > 0 {
+			health.update(ctx, float32(used+otherUsed)/float32(denom)*100)
+		}
+	}
+
+	// Counting rows is a full table scan in SQLite — too expensive to repeat on every
+	// poll when nobody is watching, so without full the last known count is kept.
+	items := lastItems(model)
+	if full {
+		if count, err := db.TotalCount(ctx); err != nil {
+			logger.Warn("failed to get sqlite history count", zap.Error(err))
+		} else {
+			usedItems := uint64(count)
+			items = &dataretentionpb.DataRetentionItems{Used: &usedItems}
+		}
 	}
 
 	_, _ = model.SetDataRetention(&dataretentionpb.DataRetention{
 		Bytes: bytesMsg,
-		Items: &dataretentionpb.DataRetentionItems{Used: &usedItems},
+		Items: items,
 	})
+}
+
+// reportStorageHealth reads disk stats for dataDir and reports df-style disk fullness —
+// (used+otherUsed)/(used+otherUsed+available), as a percentage — to the storage health check.
+// It is used on the store-failure paths (where the DB size is unknown, so dbUsedBytes is 0)
+// so a full disk still raises the check even when the store query fails; a full disk may be
+// the cause. The ratio is invariant to how disk usage splits between this store and other
+// data, so passing 0 for dbUsedBytes still yields the correct fullness.
+func reportStorageHealth(ctx context.Context, health *storageHealth, dataDir string, dbUsedBytes uint64) {
+	_, otherUsed, available, ok := diskCapacity(dataDir, dbUsedBytes)
+	if !ok {
+		return
+	}
+	if denom := dbUsedBytes + otherUsed + available; denom > 0 {
+		health.update(ctx, float32(dbUsedBytes+otherUsed)/float32(denom)*100)
+	}
+}
+
+// lastItems returns a copy of the items figures currently in the model, or nil if there are none.
+func lastItems(model *dataretentionpb.Model) *dataretentionpb.DataRetentionItems {
+	v, err := model.GetDataRetention()
+	if err != nil || v.GetItems() == nil {
+		return nil
+	}
+	return proto.Clone(v.GetItems()).(*dataretentionpb.DataRetentionItems)
 }
 
 // sqliteBackend implements dataretentionpb.Backend for the SQLite history store.

--- a/pkg/history/dataretention/sqlite_test.go
+++ b/pkg/history/dataretention/sqlite_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/app/stores"
 	"github.com/smart-core-os/sc-bos/pkg/history/sqlitestore"
 	"github.com/smart-core-os/sc-bos/pkg/proto/dataretentionpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
 )
 
 func TestUpdateSqliteModel(t *testing.T) {
@@ -29,7 +30,7 @@ func TestUpdateSqliteModel(t *testing.T) {
 	}
 
 	model := dataretentionpb.NewModel()
-	updateSqliteModel(ctx, s, model, tmpDir, zap.NewNop())
+	updateSqliteModel(ctx, s, model, tmpDir, nil, true, zap.NewNop())
 
 	got, err := model.GetDataRetention()
 	if err != nil {
@@ -41,6 +42,27 @@ func TestUpdateSqliteModel(t *testing.T) {
 	if got.Items == nil || got.Items.Used == nil || *got.Items.Used != 3 {
 		t.Errorf("expected items.used=3, got %v", got.Items)
 	}
+
+	// A non-full update must not re-count, but must keep the last known count.
+	if _, err := store.Append(ctx, []byte("payload")); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	updateSqliteModel(ctx, s, model, tmpDir, nil, false, zap.NewNop())
+	got, err = model.GetDataRetention()
+	if err != nil {
+		t.Fatalf("GetDataRetention: %v", err)
+	}
+	if got.Items == nil || got.Items.Used == nil || *got.Items.Used != 3 {
+		t.Errorf("expected items.used to stay at the last counted value 3, got %v", got.Items)
+	}
+	updateSqliteModel(ctx, s, model, tmpDir, nil, true, zap.NewNop())
+	got, err = model.GetDataRetention()
+	if err != nil {
+		t.Fatalf("GetDataRetention: %v", err)
+	}
+	if got.Items == nil || got.Items.Used == nil || *got.Items.Used != 4 {
+		t.Errorf("expected items.used=4 after a full update, got %v", got.Items)
+	}
 }
 
 func TestUpdateSqliteModel_DiskCapacity(t *testing.T) {
@@ -50,7 +72,7 @@ func TestUpdateSqliteModel_DiskCapacity(t *testing.T) {
 	t.Cleanup(func() { _ = s.Close() })
 
 	model := dataretentionpb.NewModel()
-	updateSqliteModel(ctx, s, model, tmpDir, zap.NewNop())
+	updateSqliteModel(ctx, s, model, tmpDir, nil, true, zap.NewNop())
 
 	got, err := model.GetDataRetention()
 	if err != nil {
@@ -68,6 +90,61 @@ func TestUpdateSqliteModel_DiskCapacity(t *testing.T) {
 	if got.Bytes.Available == nil {
 		t.Error("expected bytes.available to be populated from disk stats")
 	}
+}
+
+func TestStorageHealth_Update(t *testing.T) {
+	ctx := t.Context()
+
+	// capture the latest health check state as the registry observes updates
+	var latest *healthpb.HealthCheck
+	registry := healthpb.NewRegistry(
+		healthpb.WithOnCheckCreate(func(_ string, c *healthpb.HealthCheck) *healthpb.HealthCheck {
+			latest = c
+			return c
+		}),
+		healthpb.WithOnCheckUpdate(func(_ string, c *healthpb.HealthCheck) {
+			latest = c
+		}),
+	)
+	checks := registry.ForOwner("stores")
+
+	h := &storageHealth{checks: checks, name: "test/stores/history", highPct: 90, logger: zap.NewNop()}
+
+	// First update creates the check; utilisation below the threshold -> NORMAL.
+	h.update(ctx, 42.5)
+	if h.check == nil {
+		t.Fatal("expected storage health check to be created on first update")
+	}
+	if got := latest.GetNormality(); got != healthpb.HealthCheck_NORMAL {
+		t.Errorf("expected NORMAL at 42.5%% (threshold 90%%), got %v", got)
+	}
+	if got := latest.GetBounds().GetDisplayUnit(); got != "%" {
+		t.Errorf("expected display unit %q, got %q", "%", got)
+	}
+
+	// Utilisation above the threshold -> HIGH.
+	h.update(ctx, 95)
+	if got := latest.GetNormality(); got != healthpb.HealthCheck_HIGH {
+		t.Errorf("expected HIGH at 95%% (threshold 90%%), got %v", got)
+	}
+	if cv := latest.GetBounds().GetCurrentValue().GetFloatValue(); cv != 95 {
+		t.Errorf("expected current value 95, got %v", cv)
+	}
+
+	// Back below the threshold -> NORMAL again.
+	h.update(ctx, 10)
+	if got := latest.GetNormality(); got != healthpb.HealthCheck_NORMAL {
+		t.Errorf("expected NORMAL at 10%% (threshold 90%%), got %v", got)
+	}
+}
+
+func TestStorageHealth_Update_NilSafe(t *testing.T) {
+	ctx := t.Context()
+	// nil checks (no registry) and nil receiver must not panic.
+	(&storageHealth{logger: zap.NewNop()}).update(ctx, 50)
+	var h *storageHealth
+	h.update(ctx, 50)
+	h.dispose()
 }
 
 func TestSqliteBackend_Purge_All(t *testing.T) {

--- a/pkg/history/dataretention/start.go
+++ b/pkg/history/dataretention/start.go
@@ -10,10 +10,15 @@ import (
 
 	"github.com/smart-core-os/sc-bos/pkg/app/stores"
 	"github.com/smart-core-os/sc-bos/pkg/node"
+	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
 )
 
+// defaultStorageHealthHighPercent is the disk utilisation percentage above which the
+// storage HealthCheck reports HIGH, when none is configured.
+const defaultStorageHealthHighPercent float32 = 90
+
 // Start announces the DataRetention trait for each configured store and starts
-// subscriber-aware polling goroutines. Returns an undo func that removes all announcements.
+// polling goroutines. Returns an undo func that removes all announcements.
 //
 // Each backend is announced as an independent device:
 //   - {nodeName}/stores/history  – SQLite history store
@@ -21,18 +26,32 @@ import (
 //
 // These devices must not be aggregated (e.g. summing bytes.used is not meaningful
 // across heterogeneous backends).
-func Start(ctx context.Context, n *node.Node, nodeName string, s *stores.Stores, cfg *stores.Config, logger *zap.Logger) node.Undo {
+//
+// A storage utilisation HealthCheck is raised against a store device (using checks) once
+// the store's capacity is known. The check reports HIGH when disk utilisation reaches
+// highPct (see StorageHealthHighPercent). The SQLite store learns its capacity from the
+// filesystem; the Postgres store has no inherent capacity, so its check is only raised when
+// PostgresConfig.MaxSizeBytes is configured.
+func Start(ctx context.Context, n *node.Node, nodeName string, s *stores.Stores, cfg *stores.Config, checks *healthpb.Checks, logger *zap.Logger) node.Undo {
 	var undos []node.Undo
+	if cfg == nil {
+		return node.UndoAll(undos...)
+	}
 
-	if cfg != nil && cfg.DataDir != "" {
+	highPct := defaultStorageHealthHighPercent
+	if cfg.StorageHealthHighPercent > 0 {
+		highPct = cfg.StorageHealthHighPercent
+	}
+
+	if cfg.DataDir != "" {
 		name := path.Join(nodeName, "stores/history")
-		undo := announceSqlite(ctx, n, name, s, cfg.DataDir, logger.Named("stores.sqlite"))
+		undo := announceSqlite(ctx, n, name, s, cfg.DataDir, checks, highPct, logger.Named("stores.sqlite"))
 		undos = append(undos, undo)
 	}
 
-	if cfg != nil && cfg.Postgres != nil {
+	if cfg.Postgres != nil {
 		name := path.Join(nodeName, "stores/postgres")
-		undo := announcePostgres(ctx, n, name, s, logger.Named("stores.postgres"))
+		undo := announcePostgres(ctx, n, name, s, checks, highPct, cfg.Postgres.MaxSizeBytes, logger.Named("stores.postgres"))
 		undos = append(undos, undo)
 	}
 

--- a/pkg/history/dataretention/storagehealth.go
+++ b/pkg/history/dataretention/storagehealth.go
@@ -1,0 +1,131 @@
+package dataretention
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/smart-core-os/sc-bos/pkg/node"
+	"github.com/smart-core-os/sc-bos/pkg/proto/dataretentionpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
+)
+
+// storageHealth lazily maintains a BoundsCheck reporting disk utilisation for a store.
+// The check is created on the first update, so stores without capacity information
+// (e.g. SQLite on Windows, or Postgres with no configured max size) never call update
+// and so never announce a storage check.
+type storageHealth struct {
+	checks  *healthpb.Checks
+	name    string
+	highPct float32
+	logger  *zap.Logger
+
+	check *healthpb.BoundsCheck
+}
+
+// update reports the current disk utilisation (a percentage, 0-100) to the health check,
+// creating the check on first use.
+func (h *storageHealth) update(ctx context.Context, utilization float32) {
+	if h == nil || h.checks == nil {
+		return
+	}
+	if h.check == nil {
+		high := h.highPct
+		check, err := h.checks.NewBoundsCheck(h.name, &healthpb.HealthCheck{
+			Id:              "storage",
+			DisplayName:     "Storage Utilisation",
+			Description:     "Reports HIGH when disk utilisation approaches capacity.",
+			EquipmentImpact: healthpb.HealthCheck_FUNCTION,
+			Check: &healthpb.HealthCheck_Bounds_{
+				Bounds: &healthpb.HealthCheck_Bounds{
+					Expected: &healthpb.HealthCheck_Bounds_NormalRange{
+						NormalRange: &healthpb.HealthCheck_ValueRange{High: healthpb.FloatValue(float64(high))},
+					},
+					DisplayUnit: "%",
+				},
+			},
+		})
+		if err != nil {
+			h.logger.Warn("failed to create storage health check", zap.Error(err))
+			return
+		}
+		h.check = check
+	}
+	h.check.UpdateValue(ctx, healthpb.FloatValue(float64(utilization)))
+}
+
+func (h *storageHealth) dispose() {
+	if h != nil && h.check != nil {
+		h.check.Dispose()
+	}
+}
+
+// startPolling runs pollLoop in a background goroutine and returns an Undo that stops the
+// loop, waits for it to exit, then disposes the health check.
+//
+// Disposing only after the goroutine has returned is what makes this safe: storageHealth's
+// check (a healthpb.BoundsCheck) is not safe for concurrent use, so an in-flight update must
+// never overlap dispose. The Undo cancels the loop's context (aborting any in-flight update)
+// and blocks on the done channel before calling dispose.
+func startPolling(ctx context.Context, model *dataretentionpb.Model, alwaysPoll bool, health *storageHealth, update func(ctx context.Context, full bool)) node.Undo {
+	ctx, stop := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pollLoop(ctx, model, alwaysPoll, update)
+	}()
+	return func() {
+		stop()
+		<-done
+		health.dispose()
+	}
+}
+
+// pollLoop drives update at a fixed interval until ctx is done, calling it once
+// immediately so GetDataRetention returns a value without waiting for the first tick.
+//
+// update's full argument tells it whether to refresh expensive figures (e.g. SQLite row
+// counts, which are a full table scan) alongside the cheap ones. full is true at startup,
+// whenever a PullDataRetention subscriber connects, and on every poll while at least one
+// subscriber is connected; unsubscribed polls pass false so updates that nobody is
+// watching stay cheap.
+//
+// When alwaysPoll is false the loop idles (no polling) until a subscriber connects,
+// avoiding work when nobody is watching. When alwaysPoll is true the loop polls
+// unconditionally — used when a storage HealthCheck is an always-on consumer of the
+// polled data.
+func pollLoop(ctx context.Context, model *dataretentionpb.Model, alwaysPoll bool, update func(ctx context.Context, full bool)) {
+	tick := time.NewTicker(30 * time.Second)
+	defer tick.Stop()
+	update(ctx, true)
+	for {
+		switch {
+		case model.HasSubscribers():
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+				update(ctx, true)
+			}
+		case alwaysPoll:
+			select {
+			case <-ctx.Done():
+				return
+			case <-model.WaitForSubscriber():
+				update(ctx, true)
+				tick.Reset(30 * time.Second)
+			case <-tick.C:
+				update(ctx, false)
+			}
+		default:
+			select {
+			case <-ctx.Done():
+				return
+			case <-model.WaitForSubscriber():
+				update(ctx, true)
+				tick.Reset(30 * time.Second)
+			}
+		}
+	}
+}

--- a/pkg/history/dataretention/storagehealth.go
+++ b/pkg/history/dataretention/storagehealth.go
@@ -11,6 +11,9 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
 )
 
+// tickInterval is how often pollLoop refreshes disk utilisation figures.
+const tickInterval = 30 * time.Second
+
 // storageHealth lazily maintains a BoundsCheck reporting disk utilisation for a store.
 // The check is created on the first update, so stores without capacity information
 // (e.g. SQLite on Windows, or Postgres with no configured max size) never call update
@@ -96,7 +99,7 @@ func startPolling(ctx context.Context, model *dataretentionpb.Model, alwaysPoll 
 // unconditionally — used when a storage HealthCheck is an always-on consumer of the
 // polled data.
 func pollLoop(ctx context.Context, model *dataretentionpb.Model, alwaysPoll bool, update func(ctx context.Context, full bool)) {
-	tick := time.NewTicker(30 * time.Second)
+	tick := time.NewTicker(tickInterval)
 	defer tick.Stop()
 	update(ctx, true)
 	for {
@@ -114,7 +117,7 @@ func pollLoop(ctx context.Context, model *dataretentionpb.Model, alwaysPoll bool
 				return
 			case <-model.WaitForSubscriber():
 				update(ctx, true)
-				tick.Reset(30 * time.Second)
+				tick.Reset(tickInterval)
 			case <-tick.C:
 				update(ctx, false)
 			}
@@ -124,7 +127,7 @@ func pollLoop(ctx context.Context, model *dataretentionpb.Model, alwaysPoll bool
 				return
 			case <-model.WaitForSubscriber():
 				update(ctx, true)
-				tick.Reset(30 * time.Second)
+				tick.Reset(tickInterval)
 			}
 		}
 	}

--- a/pkg/history/dataretention/storagehealth_test.go
+++ b/pkg/history/dataretention/storagehealth_test.go
@@ -1,0 +1,160 @@
+package dataretention
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/smart-core-os/sc-bos/pkg/proto/dataretentionpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
+)
+
+// TestPollLoop_FullOnlyWhenWatched verifies the full/cheap update schedule of an
+// alwaysPoll loop: full at startup, cheap on ticks while nobody subscribes, full
+// immediately when a subscriber connects and on ticks while they stay connected.
+func TestPollLoop_FullOnlyWhenWatched(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var mu sync.Mutex
+		var fulls []bool
+		wantFulls := func(want ...bool) {
+			t.Helper()
+			mu.Lock()
+			defer mu.Unlock()
+			if !slices.Equal(fulls, want) {
+				t.Errorf("update full args = %v, want %v", fulls, want)
+			}
+		}
+
+		model := dataretentionpb.NewModel()
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			pollLoop(ctx, model, true, func(_ context.Context, full bool) {
+				mu.Lock()
+				fulls = append(fulls, full)
+				mu.Unlock()
+			})
+		}()
+
+		// Startup update is full; unsubscribed ticks are cheap.
+		synctest.Wait()
+		wantFulls(true)
+		time.Sleep(30 * time.Second)
+		synctest.Wait()
+		time.Sleep(30 * time.Second)
+		synctest.Wait()
+		wantFulls(true, false, false)
+
+		// A subscriber connecting triggers an immediate full update, and ticks stay
+		// full while they remain connected.
+		subCtx, unsubscribe := context.WithCancel(ctx)
+		model.PullDataRetention(subCtx)
+		synctest.Wait()
+		wantFulls(true, false, false, true)
+		time.Sleep(30 * time.Second)
+		synctest.Wait()
+		wantFulls(true, false, false, true, true)
+
+		// After the subscriber disconnects, ticks return to cheap. The first tick after
+		// disconnect may still be full (the loop only rechecks subscribers per iteration).
+		unsubscribe()
+		synctest.Wait()
+		time.Sleep(30 * time.Second) // may be full or cheap, ignored
+		synctest.Wait()
+		mu.Lock()
+		fulls = nil
+		mu.Unlock()
+		time.Sleep(30 * time.Second)
+		synctest.Wait()
+		wantFulls(false)
+
+		cancel()
+		<-done
+	})
+}
+
+// TestStartPolling_DisposeWaitsForInFlightUpdate verifies that the Undo returned by
+// startPolling does not dispose the health check until the poll goroutine has fully
+// exited. storageHealth's check is not safe for concurrent use, so an in-flight update
+// must never overlap dispose.
+func TestStartPolling_DisposeWaitsForInFlightUpdate(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var mu sync.Mutex
+		disposed := false
+		updateAfterDispose := false
+
+		registry := healthpb.NewRegistry(
+			healthpb.WithOnCheckDelete(func(_, _ string) {
+				mu.Lock()
+				disposed = true
+				mu.Unlock()
+			}),
+		)
+		health := &storageHealth{
+			checks:  registry.ForOwner("stores"),
+			name:    "n/stores/history",
+			highPct: 90,
+			logger:  zap.NewNop(),
+		}
+
+		inUpdate := make(chan struct{}) // closed once the update is in flight
+		release := make(chan struct{})  // closes to let the in-flight update return
+		var once sync.Once
+
+		model := dataretentionpb.NewModel()
+		undo := startPolling(t.Context(), model, true, health, func(ctx context.Context, _ bool) {
+			mu.Lock()
+			if disposed {
+				updateAfterDispose = true
+			}
+			mu.Unlock()
+			health.update(ctx, 50) // creates the check on the first call
+			once.Do(func() {
+				close(inUpdate)
+				<-release
+			})
+		})
+
+		// The immediate update runs in the poll goroutine and parks on release.
+		<-inUpdate
+		synctest.Wait()
+
+		// undo cancels the loop, then must block until the in-flight update returns.
+		undoDone := make(chan struct{})
+		go func() {
+			undo()
+			close(undoDone)
+		}()
+		synctest.Wait() // undo has called stop() and is now blocked waiting for the goroutine
+
+		mu.Lock()
+		if disposed {
+			t.Error("check disposed while an update was still in flight")
+		}
+		mu.Unlock()
+		select {
+		case <-undoDone:
+			t.Fatal("undo returned before the in-flight update completed")
+		default:
+		}
+
+		// Let the in-flight update finish; undo should now exit and dispose the check.
+		close(release)
+		<-undoDone
+
+		mu.Lock()
+		defer mu.Unlock()
+		if !disposed {
+			t.Error("check was not disposed after undo returned")
+		}
+		if updateAfterDispose {
+			t.Error("update ran after the check was disposed")
+		}
+	})
+}


### PR DESCRIPTION
[SCB-1113](https://vanti.youtrack.cloud/projects/SCB/issues/SCB-1113) 

Link the DataRetention trait to the Health system so that store devices report a storage utilisation HealthCheck (normality HIGH) when disk usage approaches capacity.

The check is produced at the source, inside the existing poll loop. For SQLite the utilisation is the actual fullness of the filesystem containing the store (matching df's Use%, counting all files on the disk), since running out of space breaks the store regardless of who consumed it; the trait still reports the DB's own bytes.used against the disk's bytes.capacity. Postgres has no inherent capacity, so its check is only raised when the new PostgresConfig.MaxSizeBytes is configured, with utilisation measured against that quota. The high threshold is configurable via stores.Config.StorageHealthHighPercent (default 90%).

The health check makes the SQLite poll always-on, but counting rows is a full table scan, too expensive to repeat forever when nobody is watching. Polls therefore only refresh the row count at startup, when a PullDataRetention subscriber connects, and while one stays connected; unsubscribed polls just refresh the cheap size and disk fullness figures, keeping the last known count.
