### PR TITLE
driver/sim: add coupled simulated building driver

### DIFF
--- a/.run/BOS [23557,8443] (sim-building).run.xml
+++ b/.run/BOS [23557,8443] (sim-building).run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="BOS [23557,8443] (sim-building)" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="sc-bos" />
+    <working_directory value="$PROJECT_DIR$" />
+    <parameters value="--policy-mode check --data .data/sim-building --appconf example/config/sim-building/app.conf.json --sysconf example/config/sim-building/system.conf.json" />
+    <kind value="PACKAGE" />
+    <package value="github.com/smart-core-os/sc-bos/cmd/bos" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Ops UI (sim-building).run.xml
+++ b/.run/Ops UI (sim-building).run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Ops UI (sim-building)" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/ui/ops/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="dev" />
+    </scripts>
+    <arguments value="--mode=sim-building" />
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/example/config/sim-building/app.conf.json
+++ b/example/config/sim-building/app.conf.json
@@ -1,0 +1,127 @@
+{
+  "name": "sim-building",
+  "metadata": {
+    "appearance": {
+      "title": "Simulated Building"
+    }
+  },
+  "drivers": [
+    {
+      "name": "sim/demo/driver",
+      "type": "sim",
+      "namePrefix": "sim/demo",
+      "timeMultiplier": 288,
+      "tickInterval": "5s",
+      "baseLoadW": 5000,
+      "workingHours": {"start": 8, "end": 18, "days": ["Mon", "Tue", "Wed", "Thu", "Fri"]},
+      "healthCheck": {"faultProbability": 0.05},
+      "floors": [
+        {
+          "name": "ground",
+          "title": "Ground Floor",
+          "maxOccupancy": 60,
+          "rooms": [
+            {
+              "name": "open-plan",
+              "title": "Open Plan",
+              "archetypes": [
+                {"type": "lighting", "count": 6},
+                {"type": "fcu", "count": 2, "setPointC": 21},
+                {"type": "pir"},
+                {"type": "brightness"},
+                {"type": "airquality"}
+              ]
+            },
+            {
+              "name": "meeting-1",
+              "title": "Meeting Room 1",
+              "maxOccupancy": 8,
+              "archetypes": [
+                {"type": "lighting", "count": 2},
+                {"type": "fcu", "setPointC": 21},
+                {"type": "pir"}
+              ]
+            }
+          ]
+        },
+        {
+          "name": "first",
+          "title": "First Floor",
+          "maxOccupancy": 40,
+          "rooms": [
+            {
+              "name": "open-plan",
+              "title": "Open Plan",
+              "archetypes": [
+                {"type": "lighting", "count": 4},
+                {"type": "fcu", "count": 2, "setPointC": 22},
+                {"type": "pir"},
+                {"type": "brightness"}
+              ]
+            },
+            {
+              "name": "meeting-1",
+              "title": "Meeting Room 1",
+              "maxOccupancy": 6,
+              "archetypes": [
+                {"type": "lighting", "count": 2},
+                {"type": "pir"}
+              ]
+            }
+          ]
+        }
+      ],
+      "buildingDevices": [
+        {"type": "meter", "title": "Main Incomer"},
+        {"type": "electric", "title": "Main Incomer"}
+      ]
+    }
+  ],
+  "zones": [
+    {
+      "name": "sim/demo/zones/ground",
+      "type": "area",
+      "metadata": {"appearance": {"title": "Ground Floor"}, "membership": {"subsystem": "zones"}},
+      "lights": [
+        "sim/demo/ground/open-plan/lighting-01", "sim/demo/ground/open-plan/lighting-02",
+        "sim/demo/ground/open-plan/lighting-03", "sim/demo/ground/open-plan/lighting-04",
+        "sim/demo/ground/open-plan/lighting-05", "sim/demo/ground/open-plan/lighting-06",
+        "sim/demo/ground/meeting-1/lighting-01", "sim/demo/ground/meeting-1/lighting-02"
+      ],
+      "thermostats": [
+        "sim/demo/ground/open-plan/fcu-01", "sim/demo/ground/open-plan/fcu-02",
+        "sim/demo/ground/meeting-1/fcu-01"
+      ],
+      "occupancySensors": [
+        "sim/demo/ground/open-plan/pir-01", "sim/demo/ground/meeting-1/pir-01"
+      ],
+      "airQualitySensors": ["sim/demo/ground/open-plan/airquality-01"]
+    },
+    {
+      "name": "sim/demo/zones/first",
+      "type": "area",
+      "metadata": {"appearance": {"title": "First Floor"}, "membership": {"subsystem": "zones"}},
+      "lights": [
+        "sim/demo/first/open-plan/lighting-01", "sim/demo/first/open-plan/lighting-02",
+        "sim/demo/first/open-plan/lighting-03", "sim/demo/first/open-plan/lighting-04",
+        "sim/demo/first/meeting-1/lighting-01", "sim/demo/first/meeting-1/lighting-02"
+      ],
+      "thermostats": [
+        "sim/demo/first/open-plan/fcu-01", "sim/demo/first/open-plan/fcu-02"
+      ],
+      "occupancySensors": [
+        "sim/demo/first/open-plan/pir-01", "sim/demo/first/meeting-1/pir-01"
+      ]
+    },
+    {
+      "name": "sim/demo/zones/building",
+      "type": "area",
+      "metadata": {"appearance": {"title": "Whole Building"}, "membership": {"subsystem": "zones"}},
+      "lights": ["sim/demo/zones/ground", "sim/demo/zones/first"],
+      "thermostats": ["sim/demo/zones/ground", "sim/demo/zones/first"],
+      "occupancySensors": ["sim/demo/zones/ground", "sim/demo/zones/first"],
+      "meters": ["sim/demo/building/meter-01"],
+      "electrics": ["sim/demo/building/electric-01"]
+    }
+  ]
+}

--- a/example/config/sim-building/app.conf.json
+++ b/example/config/sim-building/app.conf.json
@@ -56,7 +56,8 @@
                 {"type": "lighting", "count": 4},
                 {"type": "fcu", "count": 2, "setPointC": 22},
                 {"type": "pir"},
-                {"type": "brightness"}
+                {"type": "brightness"},
+                {"type": "airquality"}
               ]
             },
             {
@@ -111,7 +112,8 @@
       ],
       "occupancySensors": [
         "sim/demo/first/open-plan/pir-01", "sim/demo/first/meeting-1/pir-01"
-      ]
+      ],
+      "airQualitySensors": ["sim/demo/first/open-plan/airquality-01"]
     },
     {
       "name": "sim/demo/zones/building",
@@ -120,8 +122,89 @@
       "lights": ["sim/demo/zones/ground", "sim/demo/zones/first"],
       "thermostats": ["sim/demo/zones/ground", "sim/demo/zones/first"],
       "occupancySensors": ["sim/demo/zones/ground", "sim/demo/zones/first"],
+      "airQualitySensors": ["sim/demo/zones/ground", "sim/demo/zones/first"],
       "meters": ["sim/demo/building/meter-01"],
       "electrics": ["sim/demo/building/electric-01"]
+    }
+  ],
+  "automation": [
+    {
+      "name": "sim/demo/automation/electric-history/building",
+      "type": "history",
+      "source": {"name": "sim/demo/zones/building", "trait": "smartcore.traits.Electric"},
+      "storage": {"type": "postgres"}
+    },
+    {
+      "name": "sim/demo/automation/electric-history/main-incomer",
+      "type": "history",
+      "source": {"name": "sim/demo/building/electric-01", "trait": "smartcore.traits.Electric"},
+      "storage": {"type": "postgres"}
+    },
+    {
+      "name": "sim/demo/automation/meter-history/building",
+      "type": "history",
+      "source": {"name": "sim/demo/zones/building", "trait": "smartcore.bos.Meter"},
+      "storage": {"type": "postgres"}
+    },
+    {
+      "name": "sim/demo/automation/meter-history/main-incomer",
+      "type": "history",
+      "source": {"name": "sim/demo/building/meter-01", "trait": "smartcore.bos.Meter"},
+      "storage": {"type": "postgres"}
+    },
+    {
+      "name": "sim/demo/automation/occupancy-history/building",
+      "type": "history",
+      "source": {"name": "sim/demo/zones/building", "trait": "smartcore.traits.OccupancySensor"},
+      "storage": {"type": "postgres"}
+    },
+    {
+      "name": "sim/demo/automation/occupancy-history/ground",
+      "type": "history",
+      "source": {"name": "sim/demo/zones/ground", "trait": "smartcore.traits.OccupancySensor"},
+      "storage": {"type": "postgres"}
+    },
+    {
+      "name": "sim/demo/automation/occupancy-history/first",
+      "type": "history",
+      "source": {"name": "sim/demo/zones/first", "trait": "smartcore.traits.OccupancySensor"},
+      "storage": {"type": "postgres"}
+    },
+    {
+      "name": "sim/demo/automation/air-temperature-history/building",
+      "type": "history",
+      "source": {"name": "sim/demo/zones/building", "trait": "smartcore.traits.AirTemperature"},
+      "storage": {"type": "postgres"}
+    },
+    {
+      "name": "sim/demo/automation/air-temperature-history/ground",
+      "type": "history",
+      "source": {"name": "sim/demo/zones/ground", "trait": "smartcore.traits.AirTemperature"},
+      "storage": {"type": "postgres"}
+    },
+    {
+      "name": "sim/demo/automation/air-temperature-history/first",
+      "type": "history",
+      "source": {"name": "sim/demo/zones/first", "trait": "smartcore.traits.AirTemperature"},
+      "storage": {"type": "postgres"}
+    },
+    {
+      "name": "sim/demo/automation/air-quality-history/building",
+      "type": "history",
+      "source": {"name": "sim/demo/zones/building", "trait": "smartcore.traits.AirQualitySensor"},
+      "storage": {"type": "postgres"}
+    },
+    {
+      "name": "sim/demo/automation/air-quality-history/ground",
+      "type": "history",
+      "source": {"name": "sim/demo/zones/ground", "trait": "smartcore.traits.AirQualitySensor"},
+      "storage": {"type": "postgres"}
+    },
+    {
+      "name": "sim/demo/automation/air-quality-history/first",
+      "type": "history",
+      "source": {"name": "sim/demo/zones/first", "trait": "smartcore.traits.AirQualitySensor"},
+      "storage": {"type": "postgres"}
     }
   ]
 }

--- a/example/config/sim-building/system.conf.json
+++ b/example/config/sim-building/system.conf.json
@@ -6,5 +6,11 @@
   },
   "staticHosting": [
     {"path": "/__/sim-building/", "filePath": "./example/config/sim-building"}
-  ]
+  ],
+  "stores": {
+    "postgres": {
+      "uri": "postgres://postgres@localhost:5432/smart_core",
+      "passwordFile": "./.data/secrets/postgres-password"
+    }
+  }
 }

--- a/example/config/sim-building/system.conf.json
+++ b/example/config/sim-building/system.conf.json
@@ -1,0 +1,10 @@
+{
+  "listenHTTPS": ":8443",
+  "cors": {
+    "debugMode": true,
+    "corsOrigins": ["*"]
+  },
+  "staticHosting": [
+    {"path": "/__/sim-building/", "filePath": "./example/config/sim-building"}
+  ]
+}

--- a/example/config/sim-building/ui-config.json
+++ b/example/config/sim-building/ui-config.json
@@ -55,6 +55,14 @@
                 "source": "sim/demo/zones/building",
                 "metric": "score"
               }
+            },
+            {
+              "component": "builtin:health/HealthCheckTable",
+              "props": {
+                "conditions": [
+                  {"field": "name", "stringEqual": "sim/demo/driver"}
+                ]
+              }
             }
           ],
           "after": [

--- a/example/config/sim-building/ui-config.json
+++ b/example/config/sim-building/ui-config.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "auth": {
+      "third-party": false,
+      "users": false
+    },
+    "devices": true,
+    "ops": false,
+    "automations": true,
+    "system": true
+  },
+  "config": {
+    "home": "/devices",
+    "auth": {"disabled": true},
+    "theme": {
+      "appBranding": {"brandName": "Simulated Building"}
+    }
+  }
+}

--- a/example/config/sim-building/ui-config.json
+++ b/example/config/sim-building/ui-config.json
@@ -4,16 +4,237 @@
       "third-party": false,
       "users": false
     },
+    "device": true,
     "devices": true,
-    "ops": false,
+    "ops": true,
     "automations": true,
     "system": true
   },
   "config": {
-    "home": "/devices",
+    "home": "/ops",
     "auth": {"disabled": true},
     "theme": {
       "appBranding": {"brandName": "Simulated Building"}
+    },
+    "ops": {
+      "airQuality": false,
+      "emergencyLighting": false,
+      "security": false,
+      "pages": [
+        {
+          "title": "Building Overview",
+          "icon": "mdi-domain",
+          "layout": "builtin:LayoutMainSide",
+          "path": "building",
+          "main": [
+            {
+              "component": "builtin:power-history/PowerHistoryCard",
+              "props": {
+                "demand": "sim/demo/zones/building",
+                "occupancy": "sim/demo/zones/building"
+              }
+            },
+            {
+              "component": "builtin:occupancy/PeopleCountHistoryCard",
+              "props": {
+                "totalOccupancyName": "sim/demo/zones/building"
+              }
+            },
+            {
+              "component": "builtin:environmental/AirTemperatureHistoryCard",
+              "props": {
+                "title": "Average Air Temperature",
+                "source": "sim/demo/zones/building",
+                "metric": "ambientTemperature"
+              }
+            },
+            {
+              "component": "builtin:environmental/AirQualityHistoryCard",
+              "props": {
+                "title": "Air Quality",
+                "source": "sim/demo/zones/building",
+                "metric": "score"
+              }
+            }
+          ],
+          "after": [
+            {
+              "component": "builtin:occupancy/OccupancyCard",
+              "props": {
+                "source": "sim/demo/zones/building"
+              }
+            },
+            {
+              "component": "builtin:environmental/EnvironmentalCard",
+              "props": {
+                "title": "Building Environment",
+                "internal": "sim/demo/zones/building"
+              }
+            }
+          ],
+          "children": [
+            {
+              "title": "Ground Floor",
+              "shortTitle": "GF",
+              "icon": "mdi-layers-triple-outline",
+              "layout": "builtin:LayoutMainSide",
+              "main": [
+                {
+                  "component": "builtin:devices/DeviceTable",
+                  "props": {
+                    "forceQuery": {"metadata.location.floor": "Ground Floor"}
+                  }
+                },
+                {
+                  "component": "builtin:environmental/AirTemperatureHistoryCard",
+                  "props": {
+                    "title": "Air Temperature",
+                    "source": "sim/demo/zones/ground",
+                    "metric": "ambientTemperature"
+                  }
+                },
+                {
+                  "component": "builtin:environmental/AirQualityHistoryCard",
+                  "props": {
+                    "title": "Air Quality",
+                    "source": "sim/demo/zones/ground",
+                    "metric": "score"
+                  }
+                }
+              ],
+              "after": [
+                {
+                  "component": "builtin:occupancy/PresenceCard",
+                  "props": {
+                    "source": "sim/demo/zones/ground"
+                  }
+                },
+                {
+                  "component": "builtin:environmental/EnvironmentalCard",
+                  "props": {
+                    "title": "Floor Environment",
+                    "internal": "sim/demo/zones/ground"
+                  }
+                }
+              ]
+            },
+            {
+              "title": "First Floor",
+              "shortTitle": "L1",
+              "icon": "mdi-layers-triple-outline",
+              "layout": "builtin:LayoutMainSide",
+              "main": [
+                {
+                  "component": "builtin:devices/DeviceTable",
+                  "props": {
+                    "forceQuery": {"metadata.location.floor": "First Floor"}
+                  }
+                },
+                {
+                  "component": "builtin:environmental/AirTemperatureHistoryCard",
+                  "props": {
+                    "title": "Air Temperature",
+                    "source": "sim/demo/zones/first",
+                    "metric": "ambientTemperature"
+                  }
+                },
+                {
+                  "component": "builtin:environmental/AirQualityHistoryCard",
+                  "props": {
+                    "title": "Air Quality",
+                    "source": "sim/demo/zones/first",
+                    "metric": "score"
+                  }
+                }
+              ],
+              "after": [
+                {
+                  "component": "builtin:occupancy/PresenceCard",
+                  "props": {
+                    "source": "sim/demo/zones/first"
+                  }
+                },
+                {
+                  "component": "builtin:environmental/EnvironmentalCard",
+                  "props": {
+                    "title": "Floor Environment",
+                    "internal": "sim/demo/zones/first"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Energy",
+          "icon": "mdi-flash",
+          "path": "energy",
+          "layout": "builtin:LayoutMainSide",
+          "mainWidgetMinHeight": 0,
+          "sideWidth": 420,
+          "main": [
+            {
+              "component": "builtin:meter/MeterHistoryCard",
+              "props": {
+                "title": "Electricity Usage",
+                "totalConsumptionName": "sim/demo/zones/building"
+              }
+            },
+            {
+              "component": "builtin:energy/DemandHistoryCard",
+              "props": {
+                "title": "Average Power Demand",
+                "metric": "realPower",
+                "demandNames": ["sim/demo/building/electric-01"],
+                "minChartHeight": "300px"
+              }
+            },
+            {
+              "component": "builtin:power-history/PowerHistoryCard",
+              "props": {
+                "demand": "sim/demo/zones/building",
+                "occupancy": "sim/demo/zones/building"
+              }
+            }
+          ],
+          "after": [
+            {
+              "component": "builtin:container/FlexRow",
+              "props": {
+                "itemMinWidth": "14em",
+                "title": "Total Today",
+                "items": [
+                  {
+                    "component": "builtin:meter/ConsumptionCard",
+                    "props": {
+                      "name": "sim/demo/zones/building",
+                      "period": "day",
+                      "title": "Consumed"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "component": "builtin:container/FlexRow",
+              "props": {
+                "itemMinWidth": "14em",
+                "title": "Total Month",
+                "items": [
+                  {
+                    "component": "builtin:meter/ConsumptionCard",
+                    "props": {
+                      "name": "sim/demo/zones/building",
+                      "period": "month",
+                      "title": "Consumed"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/pkg/driver/alldrivers/factory.go
+++ b/pkg/driver/alldrivers/factory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/driver/proxy"
 	seWiserKnx "github.com/smart-core-os/sc-bos/pkg/driver/se/wiser-knx"
 	shellyTrv "github.com/smart-core-os/sc-bos/pkg/driver/shelly/trv"
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim"
 	steinelHpd "github.com/smart-core-os/sc-bos/pkg/driver/steinel/hpd"
 	"github.com/smart-core-os/sc-bos/pkg/driver/xovis"
 )
@@ -30,6 +31,7 @@ func Factories() map[string]driver.Factory {
 		pestsense.DriverName:  pestsense.Factory,
 		proxy.DriverName:      proxy.Factory,
 		seWiserKnx.DriverName: seWiserKnx.Factory,
+		sim.DriverName:        sim.Factory,
 		shellyTrv.DriverName:  shellyTrv.Factory,
 		steinelHpd.DriverName: steinelHpd.Factory,
 		xovis.DriverName:      xovis.Factory,

--- a/pkg/driver/mock/scale/time.go
+++ b/pkg/driver/mock/scale/time.go
@@ -1,73 +1,21 @@
 package scale
 
 import (
-	"time"
+	"github.com/smart-core-os/sc-bos/pkg/util/timescale"
 )
 
-// TimeFunc returns a scale factor based on a time.
-// The scale return value will be in the range [0,1].
-// If t is before the period represented by this scale func, tense will be -1, 0 when during, and 1 when t is after.
-// A tense of 0 should be returned if the func applies to the entire timeline.
-type TimeFunc func(t time.Time) (scale float64, tense int)
-
-// Time scales based on time.Time values.
-// The first entry that returns a non-positive tense return value will have its value returned.
-type Time []TimeFunc
-
-// Now returns a scale factor between [0, 1] for the current time.
-func (s Time) Now() float64 {
-	return s.At(time.Now())
-}
-
-// At returns a scale factor between [0, 1] for the given time.
-func (s Time) At(t time.Time) float64 {
-	var v float64
-	for _, timeFunc := range s {
-		var cmp int
-		v, cmp = timeFunc(t)
-		if cmp <= 0 {
-			return v
-		}
-	}
-	return v
-}
+// Time and TimeFunc alias the shared timescale types so existing callers keep
+// working; the day-curve mechanism now lives in pkg/util/timescale.
+type (
+	Time     = timescale.Time
+	TimeFunc = timescale.TimeFunc
+)
 
 // NineToFive is a Time scaler that reports higher values during working days/hours.
 var NineToFive = Time{
-	weekendRamp(0.1, 1),            // no work at weekends, must be first
-	linearRampHour(8, 10, 0.1, 1),  // start of day
-	linearRampHour(12, 13, 1, 0.5), // start of lunch
-	linearRampHour(13, 14, 0.5, 1), // end of lunch
-	linearRampHour(16, 18, 1, 0.1), // end of day
-}
-
-func weekendRamp(min, max float64) TimeFunc {
-	return func(t time.Time) (float64, int) {
-		if isWeekend(t) {
-			return min, 0
-		}
-		return max, 1 // after the weekend means we'll check the next TimeFunc
-	}
-}
-
-func linearRampHour(from, to, min, max float64) TimeFunc {
-	return func(t time.Time) (float64, int) {
-		hour := float64(t.Hour()) + float64(t.Minute())/60.0
-		if hour < from {
-			return min, -1
-		}
-		if hour > to {
-			return max, 1
-		}
-		return mapRange(hour, from, to, min, max), 0
-	}
-}
-
-func isWeekend(t time.Time) bool {
-	return t.Weekday() == time.Saturday || t.Weekday() == time.Sunday
-}
-
-// mapRange maps a value from one range to another
-func mapRange[T float32 | float64](value, fromLow, fromHigh, toLow, toHigh T) T {
-	return (value-fromLow)/(fromHigh-fromLow)*(toHigh-toLow) + toLow
+	timescale.WorkdayRamp(0.1, 1, nil),       // no work at weekends, must be first
+	timescale.LinearRampHour(8, 10, 0.1, 1),  // start of day
+	timescale.LinearRampHour(12, 13, 1, 0.5), // start of lunch
+	timescale.LinearRampHour(13, 14, 0.5, 1), // end of lunch
+	timescale.LinearRampHour(16, 18, 1, 0.1), // end of day
 }

--- a/pkg/driver/sim/README.md
+++ b/pkg/driver/sim/README.md
@@ -1,0 +1,94 @@
+# sim driver
+
+The `sim` driver simulates a whole building with **physically-coupled** behaviour. Where the
+[`mock`](../mock) driver gives every trait its own independent random automation, `sim` runs a
+single engine in which the pieces influence each other the way a real building does:
+
+- **People** arrive, move between rooms and leave over the working day. Their presence drives
+  occupancy sensors, motion/PIR sensors and enter/leave counts.
+- **Lights** come on in occupied rooms during working hours and dim when there's more daylight.
+- **FCUs** (fan coil units) ramp their fans with occupancy; room temperature rises with the
+  number of people and is pulled back toward the setpoint by the fan.
+- **Energy** is *derived*: the building's electrical demand is the base load plus the actual
+  lighting and FCU loads, and the meter accumulates that demand over time. CO₂ rises with how
+  full a room is.
+
+## Configuration
+
+The driver is configured at the building level rather than as a device list. You describe
+floors, the rooms on each floor, and the device *archetypes* in each room; the driver expands
+each archetype into concrete devices named `<namePrefix>/<floor>/<room>/<type>-NN`.
+
+```jsonc
+{
+  "type": "sim",
+  "namePrefix": "sim/demo",
+  "timeMultiplier": 288,           // optional: 1 = real time, 288 = a day every 5 minutes
+  "tickInterval": "5s",            // optional: wall-clock simulation cadence (default 5s)
+  "baseLoadW": 5000,               // optional: always-on building load (default 5000W)
+  "workingHours": {"start": 8, "end": 18, "days": ["Mon","Tue","Wed","Thu","Fri"]},
+  "healthCheck": {"faultProbability": 0.05}, // optional driver-level connectivity sim
+  "floors": [
+    {
+      "name": "ground", "title": "Ground Floor", "maxOccupancy": 60,
+      "rooms": [
+        {
+          "name": "open-plan", "title": "Open Plan",
+          "archetypes": [
+            {"type": "lighting", "count": 6},
+            {"type": "fcu", "count": 2, "setPointC": 21},
+            {"type": "pir"},
+            {"type": "brightness"},
+            {"type": "airquality"}
+          ]
+        }
+      ]
+    }
+  ],
+  "buildingDevices": [             // devices reporting whole-building aggregates
+    {"type": "meter"},
+    {"type": "electric"}
+  ]
+}
+```
+
+A room's `maxOccupancy` defaults to an even share of its floor's `maxOccupancy`.
+
+### Archetypes
+
+| `type`       | Traits                                  | Coupling |
+|--------------|-----------------------------------------|----------|
+| `lighting`   | Light, Status                           | level follows occupancy + working hours, dimmed by daylight; contributes lighting watts |
+| `fcu`        | AirTemperature, FanSpeed, OnOff, Status | fan ramps with occupancy; temperature responds to occupant heat vs. fan cooling; contributes FCU watts |
+| `pir` / `occupancy` | OccupancySensor                  | people count / state from room occupants |
+| `motion`     | MotionSensor                            | detected while the room is occupied |
+| `brightness` | BrightnessSensor                        | daylight through windows + electric light contribution |
+| `airquality` | AirQualitySensor                        | CO₂ rises with occupancy |
+| `enterleave` | EnterLeaveSensor                        | enter/leave totals as occupancy changes (whole-building when in `buildingDevices`) |
+| `meter`      | Meter                                   | accumulating kWh from whole-building demand |
+| `electric`   | Electric                                | instantaneous demand derived from lighting + FCU + base load |
+
+`ratedPowerW` overrides a lighting/fcu device's full-load power (defaults: 60W per light, 400W
+per FCU). `setPointC` sets an FCU's target temperature (default 21°C).
+
+## Time acceleration
+
+By default the simulation runs in real time, so values look right for the current time of day.
+Set `timeMultiplier` above 1 to compress time — e.g. `288` runs a full 24-hour cycle every five
+wall-clock minutes, which is useful for demos. State changes are clamped per tick so they stay
+stable under large time steps.
+
+## Example
+
+A self-contained two-floor example lives at
+[`example/config/sim-building/app.conf.json`](../../../example/config/sim-building/app.conf.json),
+including zones so the data aggregates in the ops UI.
+
+## Notes
+
+- The simulation is the single source of truth; there is no per-device force/control API as in
+  the mock driver (the engine would overwrite forced values on the next tick).
+- The random source is seeded (config `seed`, default fixed) so runs are reproducible. The
+  optional `healthCheck` fault simulation is intentionally not seeded — fault timing varies
+  from run to run.
+- The optional `metadata` block is announced on the driver's own `name` as a device.

--- a/pkg/driver/sim/README.md
+++ b/pkg/driver/sim/README.md
@@ -56,6 +56,11 @@ A room's `maxOccupancy` defaults to an even share of its floor's `maxOccupancy`.
 
 ### Archetypes
 
+An archetype is a named device *type* defined as a set of SmartCore traits (some,
+like `fcu`, are composites of several), together with the simulation coupling that
+drives them. The trait set is the archetype's authoritative capability list — the
+table below mirrors what each `type` declares in the driver's archetype registry.
+
 | `type`       | Traits                                  | Coupling |
 |--------------|-----------------------------------------|----------|
 | `lighting`   | Light, Status                           | level follows occupancy + working hours, dimmed by daylight; contributes lighting watts |

--- a/pkg/driver/sim/README.md
+++ b/pkg/driver/sim/README.md
@@ -80,9 +80,15 @@ stable under large time steps.
 
 ## Example
 
-A self-contained two-floor example lives at
+A two-floor example lives at
 [`example/config/sim-building/app.conf.json`](../../../example/config/sim-building/app.conf.json),
-including zones so the data aggregates in the ops UI.
+including zones so the data aggregates in the ops UI. It also configures `history` automations
+and an ops dashboard (`ui-config.json`) so the simulated data is visible as power, occupancy,
+air-temperature and air-quality charts. With `timeMultiplier: 288` a simulated day passes in
+roughly five wall-clock minutes, so the history charts fill quickly.
+
+History is stored in Postgres (matching the other example configs), so the example needs the
+dev database running (`podman compose up -d`) — see the project README for details.
 
 ## Notes
 

--- a/pkg/driver/sim/README.md
+++ b/pkg/driver/sim/README.md
@@ -89,7 +89,9 @@ A two-floor example lives at
 [`example/config/sim-building/app.conf.json`](../../../example/config/sim-building/app.conf.json),
 including zones so the data aggregates in the ops UI. It also configures `history` automations
 and an ops dashboard (`ui-config.json`) so the simulated data is visible as power, occupancy,
-air-temperature and air-quality charts. With `timeMultiplier: 288` a simulated day passes in
+air-temperature and air-quality charts, plus a health-check table on the overview page that
+surfaces the driver's `healthCheck` connectivity status (`sim/demo/driver`) and flips to a fault
+when the simulation injects one. With `timeMultiplier: 288` a simulated day passes in
 roughly five wall-clock minutes, so the history charts fill quickly.
 
 History is stored in Postgres (matching the other example configs), so the example needs the

--- a/pkg/driver/sim/README.md
+++ b/pkg/driver/sim/README.md
@@ -63,8 +63,8 @@ table below mirrors what each `type` declares in the driver's archetype registry
 
 | `type`       | Traits                                  | Coupling |
 |--------------|-----------------------------------------|----------|
-| `lighting`   | Light, Status                           | level follows occupancy + working hours, dimmed by daylight; contributes lighting watts |
-| `fcu`        | AirTemperature, FanSpeed, OnOff, Status | fan ramps with occupancy; temperature responds to occupant heat vs. fan cooling; contributes FCU watts |
+| `lighting`   | Light                                   | level follows occupancy + working hours, dimmed by daylight; contributes lighting watts |
+| `fcu`        | AirTemperature, FanSpeed, OnOff         | fan ramps with occupancy; temperature responds to occupant heat vs. fan cooling; contributes FCU watts |
 | `pir` / `occupancy` | OccupancySensor                  | people count / state from room occupants |
 | `motion`     | MotionSensor                            | detected while the room is occupied |
 | `brightness` | BrightnessSensor                        | daylight through windows + electric light contribution |

--- a/pkg/driver/sim/README.md
+++ b/pkg/driver/sim/README.md
@@ -90,10 +90,26 @@ roughly five wall-clock minutes, so the history charts fill quickly.
 History is stored in Postgres (matching the other example configs), so the example needs the
 dev database running (`podman compose up -d`) — see the project README for details.
 
+## Forcing values
+
+Lighting, FCU and occupancy devices expose the `MockDeviceApi` (`smartcore.bos.mock.v1`), the same
+service the mock driver uses, so you can drive the simulation live:
+
+- `ForceTraitValue` sets a room input — occupancy (people count), air-temperature set point,
+  lighting level or fan speed. Unlike the mock driver, the forced value becomes a **simulation
+  input**: the engine keeps running and the rest of the building responds to it (forcing a room's
+  occupancy still drives its lighting, FCU load, CO2, metered energy and so on).
+- `SetDeviceAutomation` toggles whether the engine drives that input: `active=false` freezes it at
+  its current value, `active=true` releases it back to the simulation.
+
+Derived outputs (electrical demand, metering, brightness, air quality, motion, enter/leave) follow
+from those inputs and cannot be forced directly — `ForceTraitValue` rejects them and points at the
+input that drives them.
+
 ## Notes
 
-- The simulation is the single source of truth; there is no per-device force/control API as in
-  the mock driver (the engine would overwrite forced values on the next tick).
+- The simulation owns all device state and recomputes it every tick; forced values are inputs to
+  that model (see above) rather than overwrites of a device's output.
 - The random source is seeded (config `seed`, default fixed) so runs are reproducible. The
   optional `healthCheck` fault simulation is intentionally not seeded — fault timing varies
   from run to run.

--- a/pkg/driver/sim/archetype.go
+++ b/pkg/driver/sim/archetype.go
@@ -157,226 +157,298 @@ func expandArchetype(prefix string, b *Building, fc config.Floor, rc config.Room
 	return devices, nil
 }
 
+// archetypeDesc is the single descriptor for a device archetype: its display
+// defaults, the subsystem its devices report under, its scoping rules, and the
+// constructor for its trait servers and updaters. The registry below replaces the
+// per-concern switch statements (build, room-scoping, occupancy-driven, display
+// name) with one table, so adding an archetype is a single entry.
+type archetypeDesc struct {
+	Type            string
+	DisplayName     string
+	Subsystem       string
+	RoomScoped      bool // reads per-room state, so cannot be a building-level device
+	OccupancyDriven bool // readings come entirely from room occupancy
+	Build           buildFunc
+}
+
+// buildFunc constructs the trait servers (as node Features) and the per-tick
+// updaters for one device of an archetype. room is nil for building-level devices.
+type buildFunc func(a config.Archetype, room *Room) (features []node.Feature, updaters []Updater)
+
+var archetypeList = []archetypeDesc{
+	{Type: ArchetypeLighting, DisplayName: "Light", Subsystem: "lighting", RoomScoped: true, Build: buildLighting},
+	{Type: ArchetypeFCU, DisplayName: "Fan Coil Unit", Subsystem: "hvac", RoomScoped: true, Build: buildFCU},
+	{Type: ArchetypePIR, DisplayName: "Occupancy Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildOccupancy},
+	{Type: ArchetypeOccupancy, DisplayName: "Occupancy Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildOccupancy},
+	{Type: ArchetypeMotion, DisplayName: "Motion Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildMotion},
+	{Type: ArchetypeBrightness, DisplayName: "Brightness Sensor", Subsystem: "sensors", RoomScoped: true, Build: buildBrightness},
+	{Type: ArchetypeAirQuality, DisplayName: "Air Quality Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildAirQuality},
+	{Type: ArchetypeEnterLeave, DisplayName: "Access Reader", Subsystem: "acs", OccupancyDriven: true, Build: buildEnterLeave},
+	{Type: ArchetypeMeter, DisplayName: "Meter", Subsystem: "metering", Build: buildMeter},
+	{Type: ArchetypeElectric, DisplayName: "Electricity Meter", Subsystem: "metering", Build: buildElectric},
+}
+
+// archetypes indexes archetypeList by Type, panicking on a duplicate so a
+// copy-paste slip in the list fails loudly at startup rather than silently
+// shadowing an earlier entry.
+var archetypes = func() map[string]archetypeDesc {
+	m := make(map[string]archetypeDesc, len(archetypeList))
+	for _, d := range archetypeList {
+		if _, dup := m[d.Type]; dup {
+			panic(fmt.Sprintf("sim: duplicate archetype type %q", d.Type))
+		}
+		m[d.Type] = d
+	}
+	return m
+}()
+
 // buildArchetype constructs the trait servers and updaters for a single device of
 // the given archetype. room is nil for building-level aggregates.
 func buildArchetype(a config.Archetype, room *Room) (features []node.Feature, updaters []Updater, subsystem string, err error) {
+	desc, ok := archetypes[a.Type]
+	if !ok {
+		return nil, nil, "", fmt.Errorf("unknown archetype type %q", a.Type)
+	}
 	// Room-scoped archetypes read per-room state; rejecting them here (rather than
 	// letting their updater dereference a nil room on the engine goroutine) keeps a
 	// misconfigured buildingDevices entry a config error instead of a panic.
-	if room == nil && roomScoped(a.Type) {
+	if room == nil && desc.RoomScoped {
 		return nil, nil, "", fmt.Errorf("archetype %q is room-scoped and cannot be used as a building-level device", a.Type)
 	}
-	switch a.Type {
-	case ArchetypeLighting:
-		model := lightpb.NewModel(
-			lightpb.WithPreset(0, &lightpb.LightPreset{Name: "off", Title: "Off"}),
-			lightpb.WithPreset(40, &lightpb.LightPreset{Name: "low", Title: "Low"}),
-			lightpb.WithPreset(60, &lightpb.LightPreset{Name: "med", Title: "Normal"}),
-			lightpb.WithPreset(80, &lightpb.LightPreset{Name: "high", Title: "High"}),
-			lightpb.WithPreset(100, &lightpb.LightPreset{Name: "full", Title: "Full"}),
-		)
-		server := lightpb.NewModelServer(model)
-		features = []node.Feature{
-			node.HasServer(lightpb.RegisterLightApiServer, lightpb.LightApiServer(server)),
-			node.HasServer(lightpb.RegisterLightInfoServer, lightpb.LightInfoServer(server)),
-			node.HasTrait(trait.Light),
-		}
-		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
-			_, _ = model.UpdateBrightness(&lightpb.Brightness{LevelPercent: float32(room.LightLevel)},
-				resource.WithUpdatePaths("level_percent"))
-		})}
-		features = append(features, statusFeatures()...)
-		return features, updaters, "lighting", nil
+	features, updaters = desc.Build(a, room)
+	return features, updaters, desc.Subsystem, nil
+}
 
-	case ArchetypeFCU:
-		atModel := airtemperaturepb.NewModel()
-		fanModel := fanspeedpb.NewModel(fanspeedpb.WithPresets(fanPresets...))
-		onModel := onoffpb.NewModel(resource.WithInitialValue(&onoffpb.OnOff{State: onoffpb.OnOff_OFF}))
-		features = []node.Feature{
-			node.HasServer(airtemperaturepb.RegisterAirTemperatureApiServer, airtemperaturepb.AirTemperatureApiServer(airtemperaturepb.NewModelServer(atModel))),
-			node.HasTrait(trait.AirTemperature),
-			node.HasServer(fanspeedpb.RegisterFanSpeedApiServer, fanspeedpb.FanSpeedApiServer(fanspeedpb.NewModelServer(fanModel))),
-			node.HasTrait(trait.FanSpeed),
-			node.HasServer(onoffpb.RegisterOnOffApiServer, onoffpb.OnOffApiServer(onoffpb.NewModelServer(onModel))),
-			node.HasTrait(trait.OnOff),
-		}
-		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
-			_, _ = atModel.UpdateAirTemperature(&airtemperaturepb.AirTemperature{
-				AmbientTemperature: &typespb.Temperature{ValueCelsius: room.TempC},
-				TemperatureGoal: &airtemperaturepb.AirTemperature_TemperatureSetPoint{
-					TemperatureSetPoint: &typespb.Temperature{ValueCelsius: room.SetPointC},
-				},
-			})
-			_, _ = fanModel.UpdateFanSpeed(&fanspeedpb.FanSpeed{Percentage: float32(room.FanPct)})
-			state := onoffpb.OnOff_OFF
-			if room.FanPct > 1 {
-				state = onoffpb.OnOff_ON
-			}
-			_, _ = onModel.UpdateOnOff(&onoffpb.OnOff{State: state})
-		})}
-		features = append(features, statusFeatures()...)
-		return features, updaters, "hvac", nil
+// The trait models below are created with resource.WithNoDuplicates so an updater
+// that re-publishes an unchanged value each tick produces no Pull emission. This
+// keeps steady rooms (overnight, weekends, empty meeting rooms) from churning the
+// history automations; values that genuinely change each tick (demand, lux,
+// temperature) still emit on every change.
 
-	case ArchetypePIR, ArchetypeOccupancy:
-		model := occupancysensorpb.NewModel()
-		features = []node.Feature{
-			node.HasServer(occupancysensorpb.RegisterOccupancySensorApiServer, occupancysensorpb.OccupancySensorApiServer(occupancysensorpb.NewModelServer(model))),
-			node.HasTrait(trait.OccupancySensor),
-		}
-		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
-			occ := &occupancysensorpb.Occupancy{PeopleCount: int32(room.Occupants)}
-			if room.Occupants == 0 {
-				occ.State = occupancysensorpb.Occupancy_UNOCCUPIED
-			} else {
-				occ.State = occupancysensorpb.Occupancy_OCCUPIED
-			}
-			_, _ = model.SetOccupancy(occ, resource.WithUpdatePaths("state", "people_count"))
-		})}
-		return features, updaters, "sensors", nil
-
-	case ArchetypeMotion:
-		model := motionsensorpb.NewModel()
-		features = []node.Feature{
-			node.HasServer(motionsensorpb.RegisterMotionSensorApiServer, motionsensorpb.MotionSensorApiServer(motionsensorpb.NewModelServer(model))),
-			node.HasTrait(trait.MotionSensor),
-		}
-		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
-			state := motionsensorpb.MotionDetection_NOT_DETECTED
-			if room.Occupants > 0 {
-				state = motionsensorpb.MotionDetection_DETECTED
-			}
-			_, _ = model.SetMotionDetection(&motionsensorpb.MotionDetection{State: state, StateChangeTime: timestamppb.New(now)})
-		})}
-		return features, updaters, "sensors", nil
-
-	case ArchetypeBrightness:
-		model := brightnesssensorpb.NewModel()
-		features = []node.Feature{
-			node.HasServer(brightnesssensorpb.RegisterBrightnessSensorApiServer, brightnesssensorpb.BrightnessSensorApiServer(brightnesssensorpb.NewModelServer(model))),
-			node.HasTrait(trait.BrightnessSensor),
-		}
-		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
-			// Lux = daylight through the windows + the room's own electric lighting.
-			// b.day is the daylight factor Tick already computed for this instant.
-			lux := b.day*800 + room.LightLevel/100*400
-			_, _ = model.UpdateAmbientBrightness(&brightnesssensorpb.AmbientBrightness{BrightnessLux: float32(lux)},
-				resource.WithUpdatePaths("brightness_lux"))
-		})}
-		return features, updaters, "sensors", nil
-
-	case ArchetypeAirQuality:
-		model := airqualitysensorpb.NewModel()
-		features = []node.Feature{
-			node.HasServer(airqualitysensorpb.RegisterAirQualitySensorApiServer, airqualitysensorpb.AirQualitySensorApiServer(airqualitysensorpb.NewModelServer(model))),
-			node.HasTrait(trait.AirQualitySensor),
-		}
-		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
-			co2 := float32(room.CO2ppm)
-			comfort := airqualitysensorpb.AirQuality_COMFORTABLE
-			if co2 > 1000 {
-				comfort = airqualitysensorpb.AirQuality_UNCOMFORTABLE
-			}
-			// Score 100 at baseline, falling as CO2 rises.
-			score := float32(min(max(100-(room.CO2ppm-420)/12, 0), 100))
-			_, _ = model.UpdateAirQuality(&airqualitysensorpb.AirQuality{
-				CarbonDioxideLevel: &co2,
-				Comfort:            comfort,
-				Score:              &score,
-			})
-		})}
-		return features, updaters, "sensors", nil
-
-	case ArchetypeEnterLeave:
-		model := enterleavesensorpb.NewModel()
-		features = []node.Feature{
-			node.HasServer(enterleavesensorpb.RegisterEnterLeaveSensorApiServer, enterleavesensorpb.EnterLeaveSensorApiServer(enterleavesensorpb.NewModelServer(model))),
-			node.HasTrait(trait.EnterLeaveSensor),
-		}
-		// Building-level enter/leave aggregates all rooms; room-level tracks just its room.
-		var lastEnter, lastLeave int64
-		primed := false
-		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
-			enter, leave := enterLeaveTotals(b, room)
-			if primed && enter == lastEnter && leave == lastLeave {
-				return
-			}
-			emit := func(dir enterleavesensorpb.EnterLeaveEvent_Direction) {
-				// Totals truncate to int32 for the proto fields; sim-scale
-				// totals stay far below the limit.
-				e32, l32 := int32(enter), int32(leave)
-				_ = model.CreateEnterLeaveEvent(&enterleavesensorpb.EnterLeaveEvent{
-					Direction:  dir,
-					EnterTotal: &e32,
-					LeaveTotal: &l32,
-				})
-			}
-			switch {
-			case !primed:
-				// Baseline event so the sensor reports totals before any movement.
-				emit(enterleavesensorpb.EnterLeaveEvent_DIRECTION_UNSPECIFIED)
-			default:
-				// One event per direction that changed this tick, so simultaneous
-				// enters and leaves (e.g. across rooms at building level) are both seen.
-				if enter != lastEnter {
-					emit(enterleavesensorpb.EnterLeaveEvent_ENTER)
-				}
-				if leave != lastLeave {
-					emit(enterleavesensorpb.EnterLeaveEvent_LEAVE)
-				}
-			}
-			primed = true
-			lastEnter, lastLeave = enter, leave
-		})}
-		return features, updaters, "acs", nil
-
-	case ArchetypeMeter:
-		model := meterpb.NewModel()
-		info := &meterpb.InfoServer{MeterReading: &meterpb.MeterReadingSupport{
-			ResourceSupport: &typespb.ResourceSupport{Readable: true, Observable: true},
-			UsageUnit:       "kWh",
-		}}
-		features = []node.Feature{
-			node.HasServer(meterpb.RegisterMeterApiServer, meterpb.MeterApiServer(meterpb.NewModelServer(model))),
-			node.HasServer(meterpb.RegisterMeterInfoServer, meterpb.MeterInfoServer(info)),
-			node.HasTrait(meterpb.TraitName),
-		}
-		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
-			_, _ = model.UpdateMeterReading(&meterpb.MeterReading{
-				Usage:     float32(b.MeterKWh),
-				StartTime: timestamppb.New(b.meterFrom),
-				EndTime:   timestamppb.New(now),
-			})
-		})}
-		return features, updaters, "metering", nil
-
-	case ArchetypeElectric:
-		model := electricpb.NewModel()
-		features = []node.Feature{
-			node.HasServer(electricpb.RegisterElectricApiServer, electricpb.ElectricApiServer(electricpb.NewModelServer(model))),
-			node.HasTrait(trait.Electric),
-		}
-		const voltage, pf float32 = 240, 0.95
-		// Constant for every tick, so box/compute them once per device rather than
-		// on the hot path. reactiveFactor = sin(acos(pf)) = sqrt(1 - pf²).
-		voltagePtr, pfPtr := ptr(voltage), ptr(pf)
-		reactiveFactor := float32(math.Sqrt(float64(1 - pf*pf)))
-		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
-			real := float32(b.DemandW)
-			apparent := real / pf
-			current := apparent / voltage
-			reactive := apparent * reactiveFactor
-			_, _ = model.UpdateDemand(&electricpb.ElectricDemand{
-				Current:       current,
-				Voltage:       voltagePtr,
-				PowerFactor:   pfPtr,
-				RealPower:     ptr(real),
-				ApparentPower: ptr(apparent),
-				ReactivePower: ptr(reactive),
-			})
-		})}
-		return features, updaters, "metering", nil
+func buildLighting(_ config.Archetype, room *Room) (features []node.Feature, updaters []Updater) {
+	model := lightpb.NewModel(
+		lightpb.WithPreset(0, &lightpb.LightPreset{Name: "off", Title: "Off"}),
+		lightpb.WithPreset(40, &lightpb.LightPreset{Name: "low", Title: "Low"}),
+		lightpb.WithPreset(60, &lightpb.LightPreset{Name: "med", Title: "Normal"}),
+		lightpb.WithPreset(80, &lightpb.LightPreset{Name: "high", Title: "High"}),
+		lightpb.WithPreset(100, &lightpb.LightPreset{Name: "full", Title: "Full"}),
+		resource.WithNoDuplicates(),
+	)
+	server := lightpb.NewModelServer(model)
+	features = []node.Feature{
+		node.HasServer(lightpb.RegisterLightApiServer, lightpb.LightApiServer(server)),
+		node.HasServer(lightpb.RegisterLightInfoServer, lightpb.LightInfoServer(server)),
+		node.HasTrait(trait.Light),
 	}
-	return nil, nil, "", fmt.Errorf("unknown archetype type %q", a.Type)
+	features = append(features, statusFeatures()...)
+	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+		_, _ = model.UpdateBrightness(&lightpb.Brightness{LevelPercent: float32(room.LightLevel)},
+			resource.WithUpdatePaths("level_percent"))
+	})}
+	return features, updaters
+}
+
+func buildFCU(_ config.Archetype, room *Room) (features []node.Feature, updaters []Updater) {
+	atModel := airtemperaturepb.NewModel(resource.WithNoDuplicates())
+	fanModel := fanspeedpb.NewModel(fanspeedpb.WithPresets(fanPresets...), resource.WithNoDuplicates())
+	onModel := onoffpb.NewModel(resource.WithInitialValue(&onoffpb.OnOff{State: onoffpb.OnOff_OFF}), resource.WithNoDuplicates())
+	features = []node.Feature{
+		node.HasServer(airtemperaturepb.RegisterAirTemperatureApiServer, airtemperaturepb.AirTemperatureApiServer(airtemperaturepb.NewModelServer(atModel))),
+		node.HasTrait(trait.AirTemperature),
+		node.HasServer(fanspeedpb.RegisterFanSpeedApiServer, fanspeedpb.FanSpeedApiServer(fanspeedpb.NewModelServer(fanModel))),
+		node.HasTrait(trait.FanSpeed),
+		node.HasServer(onoffpb.RegisterOnOffApiServer, onoffpb.OnOffApiServer(onoffpb.NewModelServer(onModel))),
+		node.HasTrait(trait.OnOff),
+	}
+	features = append(features, statusFeatures()...)
+	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+		_, _ = atModel.UpdateAirTemperature(&airtemperaturepb.AirTemperature{
+			AmbientTemperature: &typespb.Temperature{ValueCelsius: room.TempC},
+			TemperatureGoal: &airtemperaturepb.AirTemperature_TemperatureSetPoint{
+				TemperatureSetPoint: &typespb.Temperature{ValueCelsius: room.SetPointC},
+			},
+		})
+		_, _ = fanModel.UpdateFanSpeed(&fanspeedpb.FanSpeed{Percentage: float32(room.FanPct)})
+		state := onoffpb.OnOff_OFF
+		if room.FanPct > 1 {
+			state = onoffpb.OnOff_ON
+		}
+		_, _ = onModel.UpdateOnOff(&onoffpb.OnOff{State: state})
+	})}
+	return features, updaters
+}
+
+func buildOccupancy(_ config.Archetype, room *Room) (features []node.Feature, updaters []Updater) {
+	model := occupancysensorpb.NewModel(resource.WithNoDuplicates())
+	features = []node.Feature{
+		node.HasServer(occupancysensorpb.RegisterOccupancySensorApiServer, occupancysensorpb.OccupancySensorApiServer(occupancysensorpb.NewModelServer(model))),
+		node.HasTrait(trait.OccupancySensor),
+	}
+	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+		occ := &occupancysensorpb.Occupancy{PeopleCount: int32(room.Occupants)}
+		if room.Occupants == 0 {
+			occ.State = occupancysensorpb.Occupancy_UNOCCUPIED
+		} else {
+			occ.State = occupancysensorpb.Occupancy_OCCUPIED
+		}
+		_, _ = model.SetOccupancy(occ, resource.WithUpdatePaths("state", "people_count"))
+	})}
+	return features, updaters
+}
+
+func buildMotion(_ config.Archetype, room *Room) (features []node.Feature, updaters []Updater) {
+	model := motionsensorpb.NewModel(resource.WithNoDuplicates())
+	features = []node.Feature{
+		node.HasServer(motionsensorpb.RegisterMotionSensorApiServer, motionsensorpb.MotionSensorApiServer(motionsensorpb.NewModelServer(model))),
+		node.HasTrait(trait.MotionSensor),
+	}
+	// Emit only on a transition. StateChangeTime would otherwise be re-stamped every
+	// tick, making each message distinct and defeating the model's deduplication.
+	lastState := motionsensorpb.MotionDetection_STATE_UNSPECIFIED
+	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+		state := motionsensorpb.MotionDetection_NOT_DETECTED
+		if room.Occupants > 0 {
+			state = motionsensorpb.MotionDetection_DETECTED
+		}
+		if state == lastState {
+			return
+		}
+		lastState = state
+		_, _ = model.SetMotionDetection(&motionsensorpb.MotionDetection{State: state, StateChangeTime: timestamppb.New(now)})
+	})}
+	return features, updaters
+}
+
+func buildBrightness(_ config.Archetype, room *Room) (features []node.Feature, updaters []Updater) {
+	model := brightnesssensorpb.NewModel(resource.WithNoDuplicates())
+	features = []node.Feature{
+		node.HasServer(brightnesssensorpb.RegisterBrightnessSensorApiServer, brightnesssensorpb.BrightnessSensorApiServer(brightnesssensorpb.NewModelServer(model))),
+		node.HasTrait(trait.BrightnessSensor),
+	}
+	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+		// Lux = daylight through the windows + the room's own electric lighting.
+		// b.day is the daylight factor Tick already computed for this instant.
+		lux := b.day*800 + room.LightLevel/100*400
+		_, _ = model.UpdateAmbientBrightness(&brightnesssensorpb.AmbientBrightness{BrightnessLux: float32(lux)},
+			resource.WithUpdatePaths("brightness_lux"))
+	})}
+	return features, updaters
+}
+
+func buildAirQuality(_ config.Archetype, room *Room) (features []node.Feature, updaters []Updater) {
+	model := airqualitysensorpb.NewModel(resource.WithNoDuplicates())
+	features = []node.Feature{
+		node.HasServer(airqualitysensorpb.RegisterAirQualitySensorApiServer, airqualitysensorpb.AirQualitySensorApiServer(airqualitysensorpb.NewModelServer(model))),
+		node.HasTrait(trait.AirQualitySensor),
+	}
+	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+		co2 := float32(room.CO2ppm)
+		comfort := airqualitysensorpb.AirQuality_COMFORTABLE
+		if co2 > 1000 {
+			comfort = airqualitysensorpb.AirQuality_UNCOMFORTABLE
+		}
+		// Score 100 at baseline, falling as CO2 rises.
+		score := float32(min(max(100-(room.CO2ppm-420)/12, 0), 100))
+		_, _ = model.UpdateAirQuality(&airqualitysensorpb.AirQuality{
+			CarbonDioxideLevel: &co2,
+			Comfort:            comfort,
+			Score:              &score,
+		})
+	})}
+	return features, updaters
+}
+
+func buildEnterLeave(_ config.Archetype, room *Room) (features []node.Feature, updaters []Updater) {
+	model := enterleavesensorpb.NewModel()
+	features = []node.Feature{
+		node.HasServer(enterleavesensorpb.RegisterEnterLeaveSensorApiServer, enterleavesensorpb.EnterLeaveSensorApiServer(enterleavesensorpb.NewModelServer(model))),
+		node.HasTrait(trait.EnterLeaveSensor),
+	}
+	// Building-level enter/leave aggregates all rooms; room-level tracks just its room.
+	var lastEnter, lastLeave int64
+	primed := false
+	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+		enter, leave := enterLeaveTotals(b, room)
+		if primed && enter == lastEnter && leave == lastLeave {
+			return
+		}
+		emit := func(dir enterleavesensorpb.EnterLeaveEvent_Direction) {
+			// Totals truncate to int32 for the proto fields; sim-scale
+			// totals stay far below the limit.
+			e32, l32 := int32(enter), int32(leave)
+			_ = model.CreateEnterLeaveEvent(&enterleavesensorpb.EnterLeaveEvent{
+				Direction:  dir,
+				EnterTotal: &e32,
+				LeaveTotal: &l32,
+			})
+		}
+		switch {
+		case !primed:
+			// Baseline event so the sensor reports totals before any movement.
+			emit(enterleavesensorpb.EnterLeaveEvent_DIRECTION_UNSPECIFIED)
+		default:
+			// One event per direction that changed this tick, so simultaneous
+			// enters and leaves (e.g. across rooms at building level) are both seen.
+			if enter != lastEnter {
+				emit(enterleavesensorpb.EnterLeaveEvent_ENTER)
+			}
+			if leave != lastLeave {
+				emit(enterleavesensorpb.EnterLeaveEvent_LEAVE)
+			}
+		}
+		primed = true
+		lastEnter, lastLeave = enter, leave
+	})}
+	return features, updaters
+}
+
+func buildMeter(_ config.Archetype, _ *Room) (features []node.Feature, updaters []Updater) {
+	model := meterpb.NewModel(resource.WithNoDuplicates())
+	info := &meterpb.InfoServer{MeterReading: &meterpb.MeterReadingSupport{
+		ResourceSupport: &typespb.ResourceSupport{Readable: true, Observable: true},
+		UsageUnit:       "kWh",
+	}}
+	features = []node.Feature{
+		node.HasServer(meterpb.RegisterMeterApiServer, meterpb.MeterApiServer(meterpb.NewModelServer(model))),
+		node.HasServer(meterpb.RegisterMeterInfoServer, meterpb.MeterInfoServer(info)),
+		node.HasTrait(meterpb.TraitName),
+	}
+	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+		_, _ = model.UpdateMeterReading(&meterpb.MeterReading{
+			Usage:     float32(b.MeterKWh),
+			StartTime: timestamppb.New(b.meterFrom),
+			EndTime:   timestamppb.New(now),
+		})
+	})}
+	return features, updaters
+}
+
+func buildElectric(_ config.Archetype, _ *Room) (features []node.Feature, updaters []Updater) {
+	model := electricpb.NewModel(resource.WithNoDuplicates())
+	features = []node.Feature{
+		node.HasServer(electricpb.RegisterElectricApiServer, electricpb.ElectricApiServer(electricpb.NewModelServer(model))),
+		node.HasTrait(trait.Electric),
+	}
+	const voltage, pf float32 = 240, 0.95
+	// Constant for every tick, so box/compute them once per device rather than
+	// on the hot path. reactiveFactor = sin(acos(pf)) = sqrt(1 - pf²).
+	voltagePtr, pfPtr := ptr(voltage), ptr(pf)
+	reactiveFactor := float32(math.Sqrt(float64(1 - pf*pf)))
+	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+		real := float32(b.DemandW)
+		apparent := real / pf
+		current := apparent / voltage
+		reactive := apparent * reactiveFactor
+		_, _ = model.UpdateDemand(&electricpb.ElectricDemand{
+			Current:       current,
+			Voltage:       voltagePtr,
+			PowerFactor:   pfPtr,
+			RealPower:     ptr(real),
+			ApparentPower: ptr(apparent),
+			ReactivePower: ptr(reactive),
+		})
+	})}
+	return features, updaters
 }
 
 var fanPresets = []fanspeedpb.Preset{
@@ -444,26 +516,11 @@ func deviceTitle(a config.Archetype, n int) string {
 	return fmt.Sprintf("%s %d", base, n)
 }
 
+// displayName is the human-readable default for an archetype type, used when a
+// device sets no explicit title.
 func displayName(typ string) string {
-	switch typ {
-	case ArchetypeLighting:
-		return "Light"
-	case ArchetypeFCU:
-		return "Fan Coil Unit"
-	case ArchetypePIR, ArchetypeOccupancy:
-		return "Occupancy Sensor"
-	case ArchetypeMotion:
-		return "Motion Sensor"
-	case ArchetypeBrightness:
-		return "Brightness Sensor"
-	case ArchetypeAirQuality:
-		return "Air Quality Sensor"
-	case ArchetypeMeter:
-		return "Meter"
-	case ArchetypeElectric:
-		return "Electricity Meter"
-	case ArchetypeEnterLeave:
-		return "Access Reader"
+	if d, ok := archetypes[typ]; ok {
+		return d.DisplayName
 	}
 	return typ
 }
@@ -479,12 +536,7 @@ func count(a config.Archetype) int {
 // per-room state. These cannot be configured as building-level devices (where
 // room is nil); only meter, electric and enterleave aggregate at the building.
 func roomScoped(typ string) bool {
-	switch typ {
-	case ArchetypeLighting, ArchetypeFCU, ArchetypePIR, ArchetypeOccupancy,
-		ArchetypeMotion, ArchetypeBrightness, ArchetypeAirQuality:
-		return true
-	}
-	return false
+	return archetypes[typ].RoomScoped
 }
 
 func ratedPower(a config.Archetype, def float64) float64 {
@@ -499,12 +551,7 @@ func ratedPower(a config.Archetype, def float64) float64 {
 // resolves to zero. Lighting, brightness and fcu are excluded: they still produce
 // sensible time-of-day output in an unoccupied room (e.g. corridor lighting).
 func occupancyDriven(typ string) bool {
-	switch typ {
-	case ArchetypePIR, ArchetypeOccupancy, ArchetypeMotion,
-		ArchetypeAirQuality, ArchetypeEnterLeave:
-		return true
-	}
-	return false
+	return archetypes[typ].OccupancyDriven
 }
 
 // zeroOccupancyRooms returns the floor/room paths of rooms that contain

--- a/pkg/driver/sim/archetype.go
+++ b/pkg/driver/sim/archetype.go
@@ -1,0 +1,558 @@
+package sim
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim/config"
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim/scale"
+	"github.com/smart-core-os/sc-bos/pkg/node"
+	"github.com/smart-core-os/sc-bos/pkg/proto/airqualitysensorpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/airtemperaturepb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/brightnesssensorpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/electricpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/enterleavesensorpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/fanspeedpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/lightpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/meterpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/motionsensorpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/occupancysensorpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/onoffpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/statuspb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/typespb"
+	"github.com/smart-core-os/sc-bos/pkg/resource"
+	"github.com/smart-core-os/sc-bos/pkg/trait"
+)
+
+// Supported archetype types.
+const (
+	ArchetypeLighting   = "lighting"
+	ArchetypeFCU        = "fcu"
+	ArchetypePIR        = "pir"
+	ArchetypeOccupancy  = "occupancy"
+	ArchetypeMotion     = "motion"
+	ArchetypeBrightness = "brightness"
+	ArchetypeAirQuality = "airquality"
+	ArchetypeMeter      = "meter"
+	ArchetypeElectric   = "electric"
+	ArchetypeEnterLeave = "enterleave"
+)
+
+// Per-device defaults at full load, in watts.
+const (
+	defaultLightingW = 60  // a ceiling LED panel
+	defaultFcuW      = 400 // a fan coil unit at full fan
+	defaultSetPointC = 21
+)
+
+// Device is an announce-ready expanded device.
+type Device struct {
+	Name     string
+	Metadata *metadatapb.Metadata
+	Features []node.Feature
+}
+
+// Expand turns the building config into a coupled simulation engine plus the list
+// of devices to announce. Device updaters are registered on the returned Building.
+// start is the simulated time at which the building begins.
+func Expand(cfg config.Root, scaler scale.Time, start time.Time) (*Building, []Device, error) {
+	// Build the floor/room state first; both the engine and the per-device updaters
+	// need the room pointers. Each room is kept alongside its config so the
+	// expansion pass below can use the pointer directly instead of re-indexing the
+	// config positionally (which would silently mismatch if rooms were reordered).
+	type roomBuild struct {
+		fc   config.Floor
+		rc   config.Room
+		room *Room
+	}
+	floors := make([]*Floor, 0, len(cfg.Floors))
+	var built []roomBuild
+	for _, fc := range cfg.Floors {
+		floor := &Floor{Name: fc.Name}
+		roomMax := sharedOccupancy(fc)
+		for _, rc := range fc.Rooms {
+			room := &Room{
+				Name:         rc.Name,
+				MaxOccupancy: roomMax(rc),
+				SetPointC:    defaultSetPointC,
+			}
+			for _, a := range rc.Archetypes {
+				switch a.Type {
+				case ArchetypeLighting:
+					room.ratedLightingW += float64(count(a)) * ratedPower(a, defaultLightingW)
+				case ArchetypeFCU:
+					room.ratedFcuW += float64(count(a)) * ratedPower(a, defaultFcuW)
+					if a.SetPointC > 0 {
+						room.SetPointC = a.SetPointC
+					}
+				}
+			}
+			floor.Rooms = append(floor.Rooms, room)
+			built = append(built, roomBuild{fc: fc, rc: rc, room: room})
+		}
+		floors = append(floors, floor)
+	}
+
+	b := NewBuilding(start, scaler, cfg.BaseLoadW, cfg.Seed, floors)
+
+	// Device numbering is keyed by location+type rather than per archetype entry,
+	// so a room listing the same type twice (e.g. to mix titles or rated powers)
+	// continues lighting-01, -02, -03 instead of generating colliding names.
+	counters := make(map[string]int)
+	var devices []Device
+	for _, rb := range built {
+		for _, a := range rb.rc.Archetypes {
+			ds, err := expandArchetype(cfg.NamePrefix, b, rb.fc, rb.rc, rb.room, a, counters)
+			if err != nil {
+				return nil, nil, err
+			}
+			devices = append(devices, ds...)
+		}
+	}
+	// Building-level devices (meter, electric) read whole-building aggregates.
+	for _, a := range cfg.BuildingDevices {
+		ds, err := expandArchetype(cfg.NamePrefix, b, config.Floor{Name: "building", Title: "Building"}, config.Room{}, nil, a, counters)
+		if err != nil {
+			return nil, nil, err
+		}
+		devices = append(devices, ds...)
+	}
+	return b, devices, nil
+}
+
+// expandArchetype generates Count devices for one archetype, registering each
+// device's updaters on the building. room is nil for building-level devices.
+func expandArchetype(prefix string, b *Building, fc config.Floor, rc config.Room, room *Room, a config.Archetype, counters map[string]int) ([]Device, error) {
+	var dir string
+	if room != nil {
+		dir = fmt.Sprintf("%s/%s/%s", prefix, fc.Name, rc.Name)
+	} else {
+		dir = fmt.Sprintf("%s/building", prefix)
+	}
+	key := dir + "/" + a.Type
+
+	var devices []Device
+	for i := 0; i < count(a); i++ {
+		counters[key]++
+		n := counters[key]
+		name := fmt.Sprintf("%s/%s-%02d", dir, a.Type, n)
+
+		features, updaters, subsystem, err := buildArchetype(a, room)
+		if err != nil {
+			return nil, err
+		}
+		for _, u := range updaters {
+			b.AddUpdater(u)
+		}
+		devices = append(devices, Device{
+			Name:     name,
+			Metadata: deviceMetadata(name, deviceTitle(a, n), subsystem, fc, rc),
+			Features: features,
+		})
+	}
+	return devices, nil
+}
+
+// buildArchetype constructs the trait servers and updaters for a single device of
+// the given archetype. room is nil for building-level aggregates.
+func buildArchetype(a config.Archetype, room *Room) (features []node.Feature, updaters []Updater, subsystem string, err error) {
+	// Room-scoped archetypes read per-room state; rejecting them here (rather than
+	// letting their updater dereference a nil room on the engine goroutine) keeps a
+	// misconfigured buildingDevices entry a config error instead of a panic.
+	if room == nil && roomScoped(a.Type) {
+		return nil, nil, "", fmt.Errorf("archetype %q is room-scoped and cannot be used as a building-level device", a.Type)
+	}
+	switch a.Type {
+	case ArchetypeLighting:
+		model := lightpb.NewModel(
+			lightpb.WithPreset(0, &lightpb.LightPreset{Name: "off", Title: "Off"}),
+			lightpb.WithPreset(40, &lightpb.LightPreset{Name: "low", Title: "Low"}),
+			lightpb.WithPreset(60, &lightpb.LightPreset{Name: "med", Title: "Normal"}),
+			lightpb.WithPreset(80, &lightpb.LightPreset{Name: "high", Title: "High"}),
+			lightpb.WithPreset(100, &lightpb.LightPreset{Name: "full", Title: "Full"}),
+		)
+		server := lightpb.NewModelServer(model)
+		features = []node.Feature{
+			node.HasServer(lightpb.RegisterLightApiServer, lightpb.LightApiServer(server)),
+			node.HasServer(lightpb.RegisterLightInfoServer, lightpb.LightInfoServer(server)),
+			node.HasTrait(trait.Light),
+		}
+		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+			_, _ = model.UpdateBrightness(&lightpb.Brightness{LevelPercent: float32(room.LightLevel)},
+				resource.WithUpdatePaths("level_percent"))
+		})}
+		features = append(features, statusFeatures()...)
+		return features, updaters, "lighting", nil
+
+	case ArchetypeFCU:
+		atModel := airtemperaturepb.NewModel()
+		fanModel := fanspeedpb.NewModel(fanspeedpb.WithPresets(fanPresets...))
+		onModel := onoffpb.NewModel(resource.WithInitialValue(&onoffpb.OnOff{State: onoffpb.OnOff_OFF}))
+		features = []node.Feature{
+			node.HasServer(airtemperaturepb.RegisterAirTemperatureApiServer, airtemperaturepb.AirTemperatureApiServer(airtemperaturepb.NewModelServer(atModel))),
+			node.HasTrait(trait.AirTemperature),
+			node.HasServer(fanspeedpb.RegisterFanSpeedApiServer, fanspeedpb.FanSpeedApiServer(fanspeedpb.NewModelServer(fanModel))),
+			node.HasTrait(trait.FanSpeed),
+			node.HasServer(onoffpb.RegisterOnOffApiServer, onoffpb.OnOffApiServer(onoffpb.NewModelServer(onModel))),
+			node.HasTrait(trait.OnOff),
+		}
+		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+			_, _ = atModel.UpdateAirTemperature(&airtemperaturepb.AirTemperature{
+				AmbientTemperature: &typespb.Temperature{ValueCelsius: room.TempC},
+				TemperatureGoal: &airtemperaturepb.AirTemperature_TemperatureSetPoint{
+					TemperatureSetPoint: &typespb.Temperature{ValueCelsius: room.SetPointC},
+				},
+			})
+			_, _ = fanModel.UpdateFanSpeed(&fanspeedpb.FanSpeed{Percentage: float32(room.FanPct)})
+			state := onoffpb.OnOff_OFF
+			if room.FanPct > 1 {
+				state = onoffpb.OnOff_ON
+			}
+			_, _ = onModel.UpdateOnOff(&onoffpb.OnOff{State: state})
+		})}
+		features = append(features, statusFeatures()...)
+		return features, updaters, "hvac", nil
+
+	case ArchetypePIR, ArchetypeOccupancy:
+		model := occupancysensorpb.NewModel()
+		features = []node.Feature{
+			node.HasServer(occupancysensorpb.RegisterOccupancySensorApiServer, occupancysensorpb.OccupancySensorApiServer(occupancysensorpb.NewModelServer(model))),
+			node.HasTrait(trait.OccupancySensor),
+		}
+		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+			occ := &occupancysensorpb.Occupancy{PeopleCount: int32(room.Occupants)}
+			if room.Occupants == 0 {
+				occ.State = occupancysensorpb.Occupancy_UNOCCUPIED
+			} else {
+				occ.State = occupancysensorpb.Occupancy_OCCUPIED
+			}
+			_, _ = model.SetOccupancy(occ, resource.WithUpdatePaths("state", "people_count"))
+		})}
+		return features, updaters, "sensors", nil
+
+	case ArchetypeMotion:
+		model := motionsensorpb.NewModel()
+		features = []node.Feature{
+			node.HasServer(motionsensorpb.RegisterMotionSensorApiServer, motionsensorpb.MotionSensorApiServer(motionsensorpb.NewModelServer(model))),
+			node.HasTrait(trait.MotionSensor),
+		}
+		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+			state := motionsensorpb.MotionDetection_NOT_DETECTED
+			if room.Occupants > 0 {
+				state = motionsensorpb.MotionDetection_DETECTED
+			}
+			_, _ = model.SetMotionDetection(&motionsensorpb.MotionDetection{State: state, StateChangeTime: timestamppb.New(now)})
+		})}
+		return features, updaters, "sensors", nil
+
+	case ArchetypeBrightness:
+		model := brightnesssensorpb.NewModel()
+		features = []node.Feature{
+			node.HasServer(brightnesssensorpb.RegisterBrightnessSensorApiServer, brightnesssensorpb.BrightnessSensorApiServer(brightnesssensorpb.NewModelServer(model))),
+			node.HasTrait(trait.BrightnessSensor),
+		}
+		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+			// Lux = daylight through the windows + the room's own electric lighting.
+			// b.day is the daylight factor Tick already computed for this instant.
+			lux := b.day*800 + room.LightLevel/100*400
+			_, _ = model.UpdateAmbientBrightness(&brightnesssensorpb.AmbientBrightness{BrightnessLux: float32(lux)},
+				resource.WithUpdatePaths("brightness_lux"))
+		})}
+		return features, updaters, "sensors", nil
+
+	case ArchetypeAirQuality:
+		model := airqualitysensorpb.NewModel()
+		features = []node.Feature{
+			node.HasServer(airqualitysensorpb.RegisterAirQualitySensorApiServer, airqualitysensorpb.AirQualitySensorApiServer(airqualitysensorpb.NewModelServer(model))),
+			node.HasTrait(trait.AirQualitySensor),
+		}
+		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+			co2 := float32(room.CO2ppm)
+			comfort := airqualitysensorpb.AirQuality_COMFORTABLE
+			if co2 > 1000 {
+				comfort = airqualitysensorpb.AirQuality_UNCOMFORTABLE
+			}
+			// Score 100 at baseline, falling as CO2 rises.
+			score := float32(min(max(100-(room.CO2ppm-420)/12, 0), 100))
+			_, _ = model.UpdateAirQuality(&airqualitysensorpb.AirQuality{
+				CarbonDioxideLevel: &co2,
+				Comfort:            comfort,
+				Score:              &score,
+			})
+		})}
+		return features, updaters, "sensors", nil
+
+	case ArchetypeEnterLeave:
+		model := enterleavesensorpb.NewModel()
+		features = []node.Feature{
+			node.HasServer(enterleavesensorpb.RegisterEnterLeaveSensorApiServer, enterleavesensorpb.EnterLeaveSensorApiServer(enterleavesensorpb.NewModelServer(model))),
+			node.HasTrait(trait.EnterLeaveSensor),
+		}
+		// Building-level enter/leave aggregates all rooms; room-level tracks just its room.
+		var lastEnter, lastLeave int64
+		primed := false
+		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+			enter, leave := enterLeaveTotals(b, room)
+			if primed && enter == lastEnter && leave == lastLeave {
+				return
+			}
+			emit := func(dir enterleavesensorpb.EnterLeaveEvent_Direction) {
+				// Totals truncate to int32 for the proto fields; sim-scale
+				// totals stay far below the limit.
+				e32, l32 := int32(enter), int32(leave)
+				_ = model.CreateEnterLeaveEvent(&enterleavesensorpb.EnterLeaveEvent{
+					Direction:  dir,
+					EnterTotal: &e32,
+					LeaveTotal: &l32,
+				})
+			}
+			switch {
+			case !primed:
+				// Baseline event so the sensor reports totals before any movement.
+				emit(enterleavesensorpb.EnterLeaveEvent_DIRECTION_UNSPECIFIED)
+			default:
+				// One event per direction that changed this tick, so simultaneous
+				// enters and leaves (e.g. across rooms at building level) are both seen.
+				if enter != lastEnter {
+					emit(enterleavesensorpb.EnterLeaveEvent_ENTER)
+				}
+				if leave != lastLeave {
+					emit(enterleavesensorpb.EnterLeaveEvent_LEAVE)
+				}
+			}
+			primed = true
+			lastEnter, lastLeave = enter, leave
+		})}
+		return features, updaters, "acs", nil
+
+	case ArchetypeMeter:
+		model := meterpb.NewModel()
+		info := &meterpb.InfoServer{MeterReading: &meterpb.MeterReadingSupport{
+			ResourceSupport: &typespb.ResourceSupport{Readable: true, Observable: true},
+			UsageUnit:       "kWh",
+		}}
+		features = []node.Feature{
+			node.HasServer(meterpb.RegisterMeterApiServer, meterpb.MeterApiServer(meterpb.NewModelServer(model))),
+			node.HasServer(meterpb.RegisterMeterInfoServer, meterpb.MeterInfoServer(info)),
+			node.HasTrait(meterpb.TraitName),
+		}
+		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+			_, _ = model.UpdateMeterReading(&meterpb.MeterReading{
+				Usage:     float32(b.MeterKWh),
+				StartTime: timestamppb.New(b.meterFrom),
+				EndTime:   timestamppb.New(now),
+			})
+		})}
+		return features, updaters, "metering", nil
+
+	case ArchetypeElectric:
+		model := electricpb.NewModel()
+		features = []node.Feature{
+			node.HasServer(electricpb.RegisterElectricApiServer, electricpb.ElectricApiServer(electricpb.NewModelServer(model))),
+			node.HasTrait(trait.Electric),
+		}
+		const voltage, pf float32 = 240, 0.95
+		// Constant for every tick, so box/compute them once per device rather than
+		// on the hot path. reactiveFactor = sin(acos(pf)) = sqrt(1 - pf²).
+		voltagePtr, pfPtr := ptr(voltage), ptr(pf)
+		reactiveFactor := float32(math.Sqrt(float64(1 - pf*pf)))
+		updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
+			real := float32(b.DemandW)
+			apparent := real / pf
+			current := apparent / voltage
+			reactive := apparent * reactiveFactor
+			_, _ = model.UpdateDemand(&electricpb.ElectricDemand{
+				Current:       current,
+				Voltage:       voltagePtr,
+				PowerFactor:   pfPtr,
+				RealPower:     ptr(real),
+				ApparentPower: ptr(apparent),
+				ReactivePower: ptr(reactive),
+			})
+		})}
+		return features, updaters, "metering", nil
+	}
+	return nil, nil, "", fmt.Errorf("unknown archetype type %q", a.Type)
+}
+
+var fanPresets = []fanspeedpb.Preset{
+	{Name: "off", Percentage: 0},
+	{Name: "low", Percentage: 15},
+	{Name: "med", Percentage: 40},
+	{Name: "high", Percentage: 75},
+	{Name: "full", Percentage: 100},
+}
+
+// statusFeatures adds a Status trait reporting a static NOMINAL state. The
+// simulation does not vary per-device health (driver-level health does), so it
+// registers no updater.
+func statusFeatures() []node.Feature {
+	model := statuspb.NewModel()
+	_, _ = model.UpdateProblem(&statuspb.StatusLog_Problem{Level: statuspb.StatusLog_NOMINAL, Description: "All systems operational"})
+	return []node.Feature{
+		node.HasServer(statuspb.RegisterStatusApiServer, statuspb.StatusApiServer(statuspb.NewModelServer(model))),
+		node.HasTrait(statuspb.TraitName),
+	}
+}
+
+// enterLeaveTotals returns the enter/leave totals for room, or the whole-building
+// sum when room is nil (a building-level enterleave device).
+func enterLeaveTotals(b *Building, room *Room) (enter, leave int64) {
+	if room != nil {
+		return room.EnterTotal, room.LeaveTotal
+	}
+	for _, f := range b.Floors {
+		for _, r := range f.Rooms {
+			enter += r.EnterTotal
+			leave += r.LeaveTotal
+		}
+	}
+	return enter, leave
+}
+
+func deviceMetadata(name, title, subsystem string, fc config.Floor, rc config.Room) *metadatapb.Metadata {
+	md := &metadatapb.Metadata{
+		Name:       name,
+		Appearance: &metadatapb.Metadata_Appearance{Title: title},
+		Membership: &metadatapb.Metadata_Membership{Subsystem: subsystem},
+	}
+	floorTitle := fc.Title
+	if floorTitle == "" {
+		floorTitle = fc.Name
+	}
+	roomTitle := rc.Title
+	if roomTitle == "" {
+		roomTitle = rc.Name
+	}
+	if floorTitle != "" || roomTitle != "" {
+		md.Location = &metadatapb.Metadata_Location{Floor: floorTitle, Zone: roomTitle}
+	}
+	return md
+}
+
+// deviceTitle numbers the title with the same per-location counter as the device
+// name, so "Light 3" is always lighting-03.
+func deviceTitle(a config.Archetype, n int) string {
+	base := a.Title
+	if base == "" {
+		base = displayName(a.Type)
+	}
+	return fmt.Sprintf("%s %d", base, n)
+}
+
+func displayName(typ string) string {
+	switch typ {
+	case ArchetypeLighting:
+		return "Light"
+	case ArchetypeFCU:
+		return "Fan Coil Unit"
+	case ArchetypePIR, ArchetypeOccupancy:
+		return "Occupancy Sensor"
+	case ArchetypeMotion:
+		return "Motion Sensor"
+	case ArchetypeBrightness:
+		return "Brightness Sensor"
+	case ArchetypeAirQuality:
+		return "Air Quality Sensor"
+	case ArchetypeMeter:
+		return "Meter"
+	case ArchetypeElectric:
+		return "Electricity Meter"
+	case ArchetypeEnterLeave:
+		return "Access Reader"
+	}
+	return typ
+}
+
+func count(a config.Archetype) int {
+	if a.Count <= 0 {
+		return 1
+	}
+	return a.Count
+}
+
+// roomScoped reports whether an archetype belongs to a specific room and reads
+// per-room state. These cannot be configured as building-level devices (where
+// room is nil); only meter, electric and enterleave aggregate at the building.
+func roomScoped(typ string) bool {
+	switch typ {
+	case ArchetypeLighting, ArchetypeFCU, ArchetypePIR, ArchetypeOccupancy,
+		ArchetypeMotion, ArchetypeBrightness, ArchetypeAirQuality:
+		return true
+	}
+	return false
+}
+
+func ratedPower(a config.Archetype, def float64) float64 {
+	if a.RatedPowerW > 0 {
+		return a.RatedPowerW
+	}
+	return def
+}
+
+// occupancyDriven reports whether an archetype's readings come entirely from room
+// occupancy, making it permanently empty/idle in a room whose max occupancy
+// resolves to zero. Lighting, brightness and fcu are excluded: they still produce
+// sensible time-of-day output in an unoccupied room (e.g. corridor lighting).
+func occupancyDriven(typ string) bool {
+	switch typ {
+	case ArchetypePIR, ArchetypeOccupancy, ArchetypeMotion,
+		ArchetypeAirQuality, ArchetypeEnterLeave:
+		return true
+	}
+	return false
+}
+
+// zeroOccupancyRooms returns the floor/room paths of rooms that contain
+// occupancy-driven archetypes but resolve to a max occupancy of zero — almost
+// always a forgotten maxOccupancy rather than intent.
+func zeroOccupancyRooms(cfg config.Root) []string {
+	var out []string
+	for _, fc := range cfg.Floors {
+		roomMax := sharedOccupancy(fc)
+		for _, rc := range fc.Rooms {
+			if roomMax(rc) > 0 {
+				continue
+			}
+			for _, a := range rc.Archetypes {
+				if occupancyDriven(a.Type) {
+					out = append(out, fc.Name+"/"+rc.Name)
+					break
+				}
+			}
+		}
+	}
+	return out
+}
+
+// sharedOccupancy returns a function giving each room its max occupancy: the room's
+// own value if set, otherwise the floor's occupancy shared evenly between rooms that
+// don't set their own.
+func sharedOccupancy(fc config.Floor) func(config.Room) int {
+	explicit, rooms := 0, 0
+	for _, r := range fc.Rooms {
+		if r.MaxOccupancy > 0 {
+			explicit += r.MaxOccupancy
+		} else {
+			rooms++
+		}
+	}
+	share := 0
+	if rooms > 0 {
+		remaining := fc.MaxOccupancy - explicit
+		if remaining < 0 {
+			remaining = 0
+		}
+		share = remaining / rooms
+	}
+	return func(r config.Room) int {
+		if r.MaxOccupancy > 0 {
+			return r.MaxOccupancy
+		}
+		return share
+	}
+}

--- a/pkg/driver/sim/archetype.go
+++ b/pkg/driver/sim/archetype.go
@@ -177,32 +177,53 @@ type archetypeDesc struct {
 	Subsystem       string
 	RoomScoped      bool // reads per-room state, so cannot be a building-level device
 	OccupancyDriven bool // readings come entirely from room occupancy
-	Build           buildFunc
+	// Traits is the set of SmartCore traits a device of this archetype exposes. It
+	// is the authoritative definition of the archetype's capabilities, expressed in
+	// the standard trait vocabulary rather than a driver-private string: the
+	// expansion announces exactly these traits (see buildArchetype), and every
+	// Forceable input trait must appear here. An archetype is therefore a named
+	// device type composed of multiple SmartCore traits — e.g. an fcu is
+	// {AirTemperature, FanSpeed, OnOff, Status} — which a config UI can read to
+	// present archetypes in terms of the trait standard.
+	Traits []trait.Name
+	Build  buildFunc
 	// Forceable maps the archetype's input traits to the engine override they drive
 	// via the MockDeviceApi. Output-only archetypes (derived from the simulation)
-	// leave this nil and expose no MockDeviceApi.
+	// leave this nil and expose no MockDeviceApi. Its keys are always a subset of Traits.
 	Forceable map[trait.Name]roomOverride
 }
 
 // buildFunc constructs the trait servers (as node Features) and the per-tick
-// updaters for one device of an archetype. room is nil for building-level devices.
+// updaters for one device of an archetype. The HasTrait features are added by
+// buildArchetype from the descriptor's Traits, so Build returns servers only.
+// room is nil for building-level devices.
 type buildFunc func(a config.Archetype, room *Room) (features []node.Feature, updaters []Updater)
 
 var archetypeList = []archetypeDesc{
 	{Type: ArchetypeLighting, DisplayName: "Light", Subsystem: "lighting", RoomScoped: true, Build: buildLighting,
+		Traits:    []trait.Name{trait.Light, statuspb.TraitName},
 		Forceable: map[trait.Name]roomOverride{trait.Light: overrideLight}},
 	{Type: ArchetypeFCU, DisplayName: "Fan Coil Unit", Subsystem: "hvac", RoomScoped: true, Build: buildFCU,
+		Traits:    []trait.Name{trait.AirTemperature, trait.FanSpeed, trait.OnOff, statuspb.TraitName},
 		Forceable: map[trait.Name]roomOverride{trait.AirTemperature: overrideSetPoint, trait.FanSpeed: overrideFan}},
 	{Type: ArchetypePIR, DisplayName: "Occupancy Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildOccupancy,
+		Traits:    []trait.Name{trait.OccupancySensor},
 		Forceable: map[trait.Name]roomOverride{trait.OccupancySensor: overrideOccupancy}},
 	{Type: ArchetypeOccupancy, DisplayName: "Occupancy Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildOccupancy,
+		Traits:    []trait.Name{trait.OccupancySensor},
 		Forceable: map[trait.Name]roomOverride{trait.OccupancySensor: overrideOccupancy}},
-	{Type: ArchetypeMotion, DisplayName: "Motion Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildMotion},
-	{Type: ArchetypeBrightness, DisplayName: "Brightness Sensor", Subsystem: "sensors", RoomScoped: true, Build: buildBrightness},
-	{Type: ArchetypeAirQuality, DisplayName: "Air Quality Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildAirQuality},
-	{Type: ArchetypeEnterLeave, DisplayName: "Access Reader", Subsystem: "acs", OccupancyDriven: true, Build: buildEnterLeave},
-	{Type: ArchetypeMeter, DisplayName: "Meter", Subsystem: "metering", Build: buildMeter},
-	{Type: ArchetypeElectric, DisplayName: "Electricity Meter", Subsystem: "metering", Build: buildElectric},
+	{Type: ArchetypeMotion, DisplayName: "Motion Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildMotion,
+		Traits: []trait.Name{trait.MotionSensor}},
+	{Type: ArchetypeBrightness, DisplayName: "Brightness Sensor", Subsystem: "sensors", RoomScoped: true, Build: buildBrightness,
+		Traits: []trait.Name{trait.BrightnessSensor}},
+	{Type: ArchetypeAirQuality, DisplayName: "Air Quality Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildAirQuality,
+		Traits: []trait.Name{trait.AirQualitySensor}},
+	{Type: ArchetypeEnterLeave, DisplayName: "Access Reader", Subsystem: "acs", OccupancyDriven: true, Build: buildEnterLeave,
+		Traits: []trait.Name{trait.EnterLeaveSensor}},
+	{Type: ArchetypeMeter, DisplayName: "Meter", Subsystem: "metering", Build: buildMeter,
+		Traits: []trait.Name{meterpb.TraitName}},
+	{Type: ArchetypeElectric, DisplayName: "Electricity Meter", Subsystem: "metering", Build: buildElectric,
+		Traits: []trait.Name{trait.Electric}},
 }
 
 // archetypes indexes archetypeList by Type, panicking on a duplicate so a
@@ -213,6 +234,17 @@ var archetypes = func() map[string]archetypeDesc {
 	for _, d := range archetypeList {
 		if _, dup := m[d.Type]; dup {
 			panic(fmt.Sprintf("sim: duplicate archetype type %q", d.Type))
+		}
+		// A forceable input must be a trait the archetype actually exposes, so the
+		// declared trait set stays the single source of truth for its capabilities.
+		declared := make(map[trait.Name]bool, len(d.Traits))
+		for _, tn := range d.Traits {
+			declared[tn] = true
+		}
+		for tn := range d.Forceable {
+			if !declared[tn] {
+				panic(fmt.Sprintf("sim: archetype %q forces trait %q it does not declare in Traits", d.Type, tn))
+			}
 		}
 		m[d.Type] = d
 	}
@@ -233,6 +265,12 @@ func buildArchetype(a config.Archetype, room *Room) (features []node.Feature, up
 		return nil, nil, "", fmt.Errorf("archetype %q is room-scoped and cannot be used as a building-level device", a.Type)
 	}
 	features, updaters = desc.Build(a, room)
+	// Announce the archetype's traits from its descriptor rather than from each
+	// Build func, so the registry's Traits is the single source of truth for what
+	// the device exposes (Build returns the trait servers only).
+	for _, tn := range desc.Traits {
+		features = append(features, node.HasTrait(tn))
+	}
 	return features, updaters, desc.Subsystem, nil
 }
 
@@ -255,7 +293,6 @@ func buildLighting(_ config.Archetype, room *Room) (features []node.Feature, upd
 	features = []node.Feature{
 		node.HasServer(lightpb.RegisterLightApiServer, lightpb.LightApiServer(server)),
 		node.HasServer(lightpb.RegisterLightInfoServer, lightpb.LightInfoServer(server)),
-		node.HasTrait(trait.Light),
 	}
 	features = append(features, statusFeatures()...)
 	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
@@ -271,11 +308,8 @@ func buildFCU(_ config.Archetype, room *Room) (features []node.Feature, updaters
 	onModel := onoffpb.NewModel(resource.WithInitialValue(&onoffpb.OnOff{State: onoffpb.OnOff_OFF}), resource.WithNoDuplicates())
 	features = []node.Feature{
 		node.HasServer(airtemperaturepb.RegisterAirTemperatureApiServer, airtemperaturepb.AirTemperatureApiServer(airtemperaturepb.NewModelServer(atModel))),
-		node.HasTrait(trait.AirTemperature),
 		node.HasServer(fanspeedpb.RegisterFanSpeedApiServer, fanspeedpb.FanSpeedApiServer(fanspeedpb.NewModelServer(fanModel))),
-		node.HasTrait(trait.FanSpeed),
 		node.HasServer(onoffpb.RegisterOnOffApiServer, onoffpb.OnOffApiServer(onoffpb.NewModelServer(onModel))),
-		node.HasTrait(trait.OnOff),
 	}
 	features = append(features, statusFeatures()...)
 	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
@@ -299,7 +333,6 @@ func buildOccupancy(_ config.Archetype, room *Room) (features []node.Feature, up
 	model := occupancysensorpb.NewModel(resource.WithNoDuplicates())
 	features = []node.Feature{
 		node.HasServer(occupancysensorpb.RegisterOccupancySensorApiServer, occupancysensorpb.OccupancySensorApiServer(occupancysensorpb.NewModelServer(model))),
-		node.HasTrait(trait.OccupancySensor),
 	}
 	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
 		occ := &occupancysensorpb.Occupancy{PeopleCount: int32(room.Occupants)}
@@ -317,7 +350,6 @@ func buildMotion(_ config.Archetype, room *Room) (features []node.Feature, updat
 	model := motionsensorpb.NewModel(resource.WithNoDuplicates())
 	features = []node.Feature{
 		node.HasServer(motionsensorpb.RegisterMotionSensorApiServer, motionsensorpb.MotionSensorApiServer(motionsensorpb.NewModelServer(model))),
-		node.HasTrait(trait.MotionSensor),
 	}
 	// Emit only on a transition. StateChangeTime would otherwise be re-stamped every
 	// tick, making each message distinct and defeating the model's deduplication.
@@ -340,7 +372,6 @@ func buildBrightness(_ config.Archetype, room *Room) (features []node.Feature, u
 	model := brightnesssensorpb.NewModel(resource.WithNoDuplicates())
 	features = []node.Feature{
 		node.HasServer(brightnesssensorpb.RegisterBrightnessSensorApiServer, brightnesssensorpb.BrightnessSensorApiServer(brightnesssensorpb.NewModelServer(model))),
-		node.HasTrait(trait.BrightnessSensor),
 	}
 	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
 		// Lux = daylight through the windows + the room's own electric lighting.
@@ -356,7 +387,6 @@ func buildAirQuality(_ config.Archetype, room *Room) (features []node.Feature, u
 	model := airqualitysensorpb.NewModel(resource.WithNoDuplicates())
 	features = []node.Feature{
 		node.HasServer(airqualitysensorpb.RegisterAirQualitySensorApiServer, airqualitysensorpb.AirQualitySensorApiServer(airqualitysensorpb.NewModelServer(model))),
-		node.HasTrait(trait.AirQualitySensor),
 	}
 	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
 		co2 := float32(room.CO2ppm)
@@ -379,7 +409,6 @@ func buildEnterLeave(_ config.Archetype, room *Room) (features []node.Feature, u
 	model := enterleavesensorpb.NewModel()
 	features = []node.Feature{
 		node.HasServer(enterleavesensorpb.RegisterEnterLeaveSensorApiServer, enterleavesensorpb.EnterLeaveSensorApiServer(enterleavesensorpb.NewModelServer(model))),
-		node.HasTrait(trait.EnterLeaveSensor),
 	}
 	// Building-level enter/leave aggregates all rooms; room-level tracks just its room.
 	var lastEnter, lastLeave int64
@@ -428,7 +457,6 @@ func buildMeter(_ config.Archetype, _ *Room) (features []node.Feature, updaters 
 	features = []node.Feature{
 		node.HasServer(meterpb.RegisterMeterApiServer, meterpb.MeterApiServer(meterpb.NewModelServer(model))),
 		node.HasServer(meterpb.RegisterMeterInfoServer, meterpb.MeterInfoServer(info)),
-		node.HasTrait(meterpb.TraitName),
 	}
 	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
 		_, _ = model.UpdateMeterReading(&meterpb.MeterReading{
@@ -444,7 +472,6 @@ func buildElectric(_ config.Archetype, _ *Room) (features []node.Feature, update
 	model := electricpb.NewModel(resource.WithNoDuplicates())
 	features = []node.Feature{
 		node.HasServer(electricpb.RegisterElectricApiServer, electricpb.ElectricApiServer(electricpb.NewModelServer(model))),
-		node.HasTrait(trait.Electric),
 	}
 	const voltage, pf float32 = 240, 0.95
 	// Constant for every tick, so box/compute them once per device rather than
@@ -476,15 +503,15 @@ var fanPresets = []fanspeedpb.Preset{
 	{Name: "full", Percentage: 100},
 }
 
-// statusFeatures adds a Status trait reporting a static NOMINAL state. The
+// statusFeatures adds a Status server reporting a static NOMINAL state. The
 // simulation does not vary per-device health (driver-level health does), so it
-// registers no updater.
+// registers no updater. The Status trait itself is declared on the archetype
+// descriptor (Traits) for the archetypes that include this server.
 func statusFeatures() []node.Feature {
 	model := statuspb.NewModel()
 	_, _ = model.UpdateProblem(&statuspb.StatusLog_Problem{Level: statuspb.StatusLog_NOMINAL, Description: "All systems operational"})
 	return []node.Feature{
 		node.HasServer(statuspb.RegisterStatusApiServer, statuspb.StatusApiServer(statuspb.NewModelServer(model))),
-		node.HasTrait(statuspb.TraitName),
 	}
 }
 

--- a/pkg/driver/sim/archetype.go
+++ b/pkg/driver/sim/archetype.go
@@ -23,7 +23,6 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/proto/motionsensorpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/occupancysensorpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/onoffpb"
-	"github.com/smart-core-os/sc-bos/pkg/proto/statuspb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/typespb"
 	"github.com/smart-core-os/sc-bos/pkg/resource"
 	"github.com/smart-core-os/sc-bos/pkg/trait"
@@ -183,7 +182,7 @@ type archetypeDesc struct {
 	// expansion announces exactly these traits (see buildArchetype), and every
 	// Forceable input trait must appear here. An archetype is therefore a named
 	// device type composed of multiple SmartCore traits — e.g. an fcu is
-	// {AirTemperature, FanSpeed, OnOff, Status} — which a config UI can read to
+	// {AirTemperature, FanSpeed, OnOff} — which a config UI can read to
 	// present archetypes in terms of the trait standard.
 	Traits []trait.Name
 	Build  buildFunc
@@ -201,10 +200,10 @@ type buildFunc func(a config.Archetype, room *Room) (features []node.Feature, up
 
 var archetypeList = []archetypeDesc{
 	{Type: ArchetypeLighting, DisplayName: "Light", Subsystem: "lighting", RoomScoped: true, Build: buildLighting,
-		Traits:    []trait.Name{trait.Light, statuspb.TraitName},
+		Traits:    []trait.Name{trait.Light},
 		Forceable: map[trait.Name]roomOverride{trait.Light: overrideLight}},
 	{Type: ArchetypeFCU, DisplayName: "Fan Coil Unit", Subsystem: "hvac", RoomScoped: true, Build: buildFCU,
-		Traits:    []trait.Name{trait.AirTemperature, trait.FanSpeed, trait.OnOff, statuspb.TraitName},
+		Traits:    []trait.Name{trait.AirTemperature, trait.FanSpeed, trait.OnOff},
 		Forceable: map[trait.Name]roomOverride{trait.AirTemperature: overrideSetPoint, trait.FanSpeed: overrideFan}},
 	{Type: ArchetypePIR, DisplayName: "Occupancy Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildOccupancy,
 		Traits:    []trait.Name{trait.OccupancySensor},
@@ -294,7 +293,6 @@ func buildLighting(_ config.Archetype, room *Room) (features []node.Feature, upd
 		node.HasServer(lightpb.RegisterLightApiServer, lightpb.LightApiServer(server)),
 		node.HasServer(lightpb.RegisterLightInfoServer, lightpb.LightInfoServer(server)),
 	}
-	features = append(features, statusFeatures()...)
 	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
 		_, _ = model.UpdateBrightness(&lightpb.Brightness{LevelPercent: float32(room.LightLevel)},
 			resource.WithUpdatePaths("level_percent"))
@@ -311,7 +309,6 @@ func buildFCU(_ config.Archetype, room *Room) (features []node.Feature, updaters
 		node.HasServer(fanspeedpb.RegisterFanSpeedApiServer, fanspeedpb.FanSpeedApiServer(fanspeedpb.NewModelServer(fanModel))),
 		node.HasServer(onoffpb.RegisterOnOffApiServer, onoffpb.OnOffApiServer(onoffpb.NewModelServer(onModel))),
 	}
-	features = append(features, statusFeatures()...)
 	updaters = []Updater{updaterFunc(func(now time.Time, b *Building) {
 		_, _ = atModel.UpdateAirTemperature(&airtemperaturepb.AirTemperature{
 			AmbientTemperature: &typespb.Temperature{ValueCelsius: room.TempC},
@@ -501,18 +498,6 @@ var fanPresets = []fanspeedpb.Preset{
 	{Name: "med", Percentage: 40},
 	{Name: "high", Percentage: 75},
 	{Name: "full", Percentage: 100},
-}
-
-// statusFeatures adds a Status server reporting a static NOMINAL state. The
-// simulation does not vary per-device health (driver-level health does), so it
-// registers no updater. The Status trait itself is declared on the archetype
-// descriptor (Traits) for the archetypes that include this server.
-func statusFeatures() []node.Feature {
-	model := statuspb.NewModel()
-	_, _ = model.UpdateProblem(&statuspb.StatusLog_Problem{Level: statuspb.StatusLog_NOMINAL, Description: "All systems operational"})
-	return []node.Feature{
-		node.HasServer(statuspb.RegisterStatusApiServer, statuspb.StatusApiServer(statuspb.NewModelServer(model))),
-	}
 }
 
 // enterLeaveTotals returns the enter/leave totals for room, or the whole-building

--- a/pkg/driver/sim/archetype.go
+++ b/pkg/driver/sim/archetype.go
@@ -549,13 +549,6 @@ func count(a config.Archetype) int {
 	return a.Count
 }
 
-// roomScoped reports whether an archetype belongs to a specific room and reads
-// per-room state. These cannot be configured as building-level devices (where
-// room is nil); only meter, electric and enterleave aggregate at the building.
-func roomScoped(typ string) bool {
-	return archetypes[typ].RoomScoped
-}
-
 func ratedPower(a config.Archetype, def float64) float64 {
 	if a.RatedPowerW > 0 {
 		return a.RatedPowerW

--- a/pkg/driver/sim/archetype.go
+++ b/pkg/driver/sim/archetype.go
@@ -19,6 +19,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/proto/lightpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/meterpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/mockpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/motionsensorpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/occupancysensorpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/onoffpb"
@@ -98,6 +99,7 @@ func Expand(cfg config.Root, scaler scale.Time, start time.Time) (*Building, []D
 	}
 
 	b := NewBuilding(start, scaler, cfg.BaseLoadW, cfg.Seed, floors)
+	ctrl := newController(b)
 
 	// Device numbering is keyed by location+type rather than per archetype entry,
 	// so a room listing the same type twice (e.g. to mix titles or rated powers)
@@ -106,7 +108,7 @@ func Expand(cfg config.Root, scaler scale.Time, start time.Time) (*Building, []D
 	var devices []Device
 	for _, rb := range built {
 		for _, a := range rb.rc.Archetypes {
-			ds, err := expandArchetype(cfg.NamePrefix, b, rb.fc, rb.rc, rb.room, a, counters)
+			ds, err := expandArchetype(cfg.NamePrefix, b, ctrl, rb.fc, rb.rc, rb.room, a, counters)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -115,7 +117,7 @@ func Expand(cfg config.Root, scaler scale.Time, start time.Time) (*Building, []D
 	}
 	// Building-level devices (meter, electric) read whole-building aggregates.
 	for _, a := range cfg.BuildingDevices {
-		ds, err := expandArchetype(cfg.NamePrefix, b, config.Floor{Name: "building", Title: "Building"}, config.Room{}, nil, a, counters)
+		ds, err := expandArchetype(cfg.NamePrefix, b, ctrl, config.Floor{Name: "building", Title: "Building"}, config.Room{}, nil, a, counters)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -126,7 +128,7 @@ func Expand(cfg config.Root, scaler scale.Time, start time.Time) (*Building, []D
 
 // expandArchetype generates Count devices for one archetype, registering each
 // device's updaters on the building. room is nil for building-level devices.
-func expandArchetype(prefix string, b *Building, fc config.Floor, rc config.Room, room *Room, a config.Archetype, counters map[string]int) ([]Device, error) {
+func expandArchetype(prefix string, b *Building, ctrl *controller, fc config.Floor, rc config.Room, room *Room, a config.Archetype, counters map[string]int) ([]Device, error) {
 	var dir string
 	if room != nil {
 		dir = fmt.Sprintf("%s/%s/%s", prefix, fc.Name, rc.Name)
@@ -134,6 +136,7 @@ func expandArchetype(prefix string, b *Building, fc config.Floor, rc config.Room
 		dir = fmt.Sprintf("%s/building", prefix)
 	}
 	key := dir + "/" + a.Type
+	forceable := archetypes[a.Type].Forceable
 
 	var devices []Device
 	for i := 0; i < count(a); i++ {
@@ -147,6 +150,12 @@ func expandArchetype(prefix string, b *Building, fc config.Floor, rc config.Room
 		}
 		for _, u := range updaters {
 			b.AddUpdater(u)
+		}
+		// A forceable device (lighting, fcu, occupancy) exposes the MockDeviceApi so
+		// its room input can be driven live; the engine then responds via the coupling.
+		if room != nil && len(forceable) > 0 {
+			ctrl.register(name, room, forceable)
+			features = append(features, node.HasServer(mockpb.RegisterMockDeviceApiServer, mockpb.MockDeviceApiServer(ctrl)))
 		}
 		devices = append(devices, Device{
 			Name:     name,
@@ -169,6 +178,10 @@ type archetypeDesc struct {
 	RoomScoped      bool // reads per-room state, so cannot be a building-level device
 	OccupancyDriven bool // readings come entirely from room occupancy
 	Build           buildFunc
+	// Forceable maps the archetype's input traits to the engine override they drive
+	// via the MockDeviceApi. Output-only archetypes (derived from the simulation)
+	// leave this nil and expose no MockDeviceApi.
+	Forceable map[trait.Name]roomOverride
 }
 
 // buildFunc constructs the trait servers (as node Features) and the per-tick
@@ -176,10 +189,14 @@ type archetypeDesc struct {
 type buildFunc func(a config.Archetype, room *Room) (features []node.Feature, updaters []Updater)
 
 var archetypeList = []archetypeDesc{
-	{Type: ArchetypeLighting, DisplayName: "Light", Subsystem: "lighting", RoomScoped: true, Build: buildLighting},
-	{Type: ArchetypeFCU, DisplayName: "Fan Coil Unit", Subsystem: "hvac", RoomScoped: true, Build: buildFCU},
-	{Type: ArchetypePIR, DisplayName: "Occupancy Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildOccupancy},
-	{Type: ArchetypeOccupancy, DisplayName: "Occupancy Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildOccupancy},
+	{Type: ArchetypeLighting, DisplayName: "Light", Subsystem: "lighting", RoomScoped: true, Build: buildLighting,
+		Forceable: map[trait.Name]roomOverride{trait.Light: overrideLight}},
+	{Type: ArchetypeFCU, DisplayName: "Fan Coil Unit", Subsystem: "hvac", RoomScoped: true, Build: buildFCU,
+		Forceable: map[trait.Name]roomOverride{trait.AirTemperature: overrideSetPoint, trait.FanSpeed: overrideFan}},
+	{Type: ArchetypePIR, DisplayName: "Occupancy Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildOccupancy,
+		Forceable: map[trait.Name]roomOverride{trait.OccupancySensor: overrideOccupancy}},
+	{Type: ArchetypeOccupancy, DisplayName: "Occupancy Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildOccupancy,
+		Forceable: map[trait.Name]roomOverride{trait.OccupancySensor: overrideOccupancy}},
 	{Type: ArchetypeMotion, DisplayName: "Motion Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildMotion},
 	{Type: ArchetypeBrightness, DisplayName: "Brightness Sensor", Subsystem: "sensors", RoomScoped: true, Build: buildBrightness},
 	{Type: ArchetypeAirQuality, DisplayName: "Air Quality Sensor", Subsystem: "sensors", RoomScoped: true, OccupancyDriven: true, Build: buildAirQuality},
@@ -265,7 +282,7 @@ func buildFCU(_ config.Archetype, room *Room) (features []node.Feature, updaters
 		_, _ = atModel.UpdateAirTemperature(&airtemperaturepb.AirTemperature{
 			AmbientTemperature: &typespb.Temperature{ValueCelsius: room.TempC},
 			TemperatureGoal: &airtemperaturepb.AirTemperature_TemperatureSetPoint{
-				TemperatureSetPoint: &typespb.Temperature{ValueCelsius: room.SetPointC},
+				TemperatureSetPoint: &typespb.Temperature{ValueCelsius: room.setPoint()},
 			},
 		})
 		_, _ = fanModel.UpdateFanSpeed(&fanspeedpb.FanSpeed{Percentage: float32(room.FanPct)})

--- a/pkg/driver/sim/archetype_test.go
+++ b/pkg/driver/sim/archetype_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/driver/sim/scale"
 	"github.com/smart-core-os/sc-bos/pkg/node"
 	"github.com/smart-core-os/sc-bos/pkg/proto/meterpb"
-	"github.com/smart-core-os/sc-bos/pkg/proto/statuspb"
 	"github.com/smart-core-os/sc-bos/pkg/trait"
 )
 
@@ -18,8 +17,8 @@ import (
 // source of truth for what it exposes.
 func TestArchetypeTraitsDeclared(t *testing.T) {
 	cases := map[string][]trait.Name{
-		ArchetypeFCU:        {trait.AirTemperature, trait.FanSpeed, trait.OnOff, statuspb.TraitName},
-		ArchetypeLighting:   {trait.Light, statuspb.TraitName},
+		ArchetypeFCU:        {trait.AirTemperature, trait.FanSpeed, trait.OnOff},
+		ArchetypeLighting:   {trait.Light},
 		ArchetypePIR:        {trait.OccupancySensor},
 		ArchetypeMeter:      {meterpb.TraitName},
 		ArchetypeElectric:   {trait.Electric},
@@ -69,7 +68,7 @@ func TestExpand_AnnouncesDeclaredTraits(t *testing.T) {
 	}
 
 	const fcuName = "sim/demo/g/r/fcu-01"
-	want := []trait.Name{trait.AirTemperature, trait.FanSpeed, trait.OnOff, statuspb.TraitName}
+	want := []trait.Name{trait.AirTemperature, trait.FanSpeed, trait.OnOff}
 	for _, dev := range n.ListDevices() {
 		if dev.GetName() != fcuName {
 			continue

--- a/pkg/driver/sim/archetype_test.go
+++ b/pkg/driver/sim/archetype_test.go
@@ -1,0 +1,89 @@
+package sim
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim/config"
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim/scale"
+	"github.com/smart-core-os/sc-bos/pkg/node"
+	"github.com/smart-core-os/sc-bos/pkg/proto/meterpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/statuspb"
+	"github.com/smart-core-os/sc-bos/pkg/trait"
+)
+
+// TestArchetypeTraitsDeclared locks the trait sets declared on the registry. An
+// archetype is a named device type composed of one or more SmartCore traits (a
+// composite like fcu spans several), and the descriptor's Traits is the single
+// source of truth for what it exposes.
+func TestArchetypeTraitsDeclared(t *testing.T) {
+	cases := map[string][]trait.Name{
+		ArchetypeFCU:        {trait.AirTemperature, trait.FanSpeed, trait.OnOff, statuspb.TraitName},
+		ArchetypeLighting:   {trait.Light, statuspb.TraitName},
+		ArchetypePIR:        {trait.OccupancySensor},
+		ArchetypeMeter:      {meterpb.TraitName},
+		ArchetypeElectric:   {trait.Electric},
+		ArchetypeEnterLeave: {trait.EnterLeaveSensor},
+	}
+	for typ, want := range cases {
+		if got := archetypes[typ].Traits; !slices.Equal(got, want) {
+			t.Errorf("%s Traits = %v, want %v", typ, got, want)
+		}
+	}
+
+	// Every forceable input must be a declared trait (also enforced by a panic in
+	// the registry init; asserted here to document the invariant).
+	for _, d := range archetypeList {
+		declared := make(map[trait.Name]bool, len(d.Traits))
+		for _, tn := range d.Traits {
+			declared[tn] = true
+		}
+		for tn := range d.Forceable {
+			if !declared[tn] {
+				t.Errorf("archetype %q forces trait %q not in its declared Traits %v", d.Type, tn, d.Traits)
+			}
+		}
+	}
+}
+
+// TestExpand_AnnouncesDeclaredTraits confirms the declared traits reach a device's
+// announced metadata — i.e. the expansion announces HasTrait from the descriptor's
+// Traits, not from the Build funcs (which now return trait servers only).
+func TestExpand_AnnouncesDeclaredTraits(t *testing.T) {
+	cfg := config.Root{
+		NamePrefix: "sim/demo",
+		Floors: []config.Floor{{
+			Name: "g", MaxOccupancy: 10,
+			Rooms: []config.Room{{Name: "r", Archetypes: []config.Archetype{{Type: ArchetypeFCU}}}},
+		}},
+	}
+	cfg.Normalise()
+	_, devices, err := Expand(cfg, scale.WorkingHours(8, 18, nil), monday)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+
+	n := node.New("test")
+	for _, d := range devices {
+		n.Announce(d.Name, d.Features...)
+	}
+
+	const fcuName = "sim/demo/g/r/fcu-01"
+	want := []trait.Name{trait.AirTemperature, trait.FanSpeed, trait.OnOff, statuspb.TraitName}
+	for _, dev := range n.ListDevices() {
+		if dev.GetName() != fcuName {
+			continue
+		}
+		got := make(map[trait.Name]bool)
+		for _, tm := range dev.GetMetadata().GetTraits() {
+			got[trait.Name(tm.GetName())] = true
+		}
+		for _, tn := range want {
+			if !got[tn] {
+				t.Errorf("%s missing announced trait %q; got %v", fcuName, tn, dev.GetMetadata().GetTraits())
+			}
+		}
+		return
+	}
+	t.Fatalf("device %q not found in ListDevices", fcuName)
+}

--- a/pkg/driver/sim/building.go
+++ b/pkg/driver/sim/building.go
@@ -1,0 +1,236 @@
+package sim
+
+import (
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim/scale"
+)
+
+// Building is the coupled simulation engine. A single goroutine owns it: Tick
+// advances the physical state (occupancy → lights/FCUs → energy; daylight → brightness;
+// occupancy → CO2), and the registered Updaters then publish the relevant slice of
+// that state into each device's gRPC trait model.
+//
+// All state mutation happens on the engine goroutine, so the struct needs no locking;
+// the underlying trait models are independently goroutine-safe for concurrent readers.
+type Building struct {
+	scaler    scale.Time
+	baseLoadW float64
+	rng       *rand.Rand
+
+	Floors []*Floor
+
+	// Aggregates, recomputed each Tick.
+	DemandW   float64   // instantaneous whole-building electrical demand, watts
+	MeterKWh  float64   // monotonically accumulating energy use, kWh
+	meterFrom time.Time // start of the metering period
+	day       float64   // outdoor daylight factor (0..1), recomputed each Tick
+
+	updaters []Updater
+}
+
+// Floor is a level of the building.
+type Floor struct {
+	Name  string
+	Rooms []*Room
+}
+
+// Room holds the simulated state of a single space. Field values are the
+// authoritative simulation state that device updaters read from.
+type Room struct {
+	Name         string
+	MaxOccupancy int
+
+	Occupants  int
+	LightLevel float64 // 0..100 %
+	FanPct     float64 // 0..100 %
+	TempC      float64
+	SetPointC  float64
+	CO2ppm     float64
+	EnterTotal int64
+	LeaveTotal int64
+
+	// occupancyF is the continuous occupancy that Occupants is rounded from, and
+	// occNoise is a slow, mean-reverting noise term. Together they let the
+	// population wander organically without manufacturing enter/leave churn every
+	// tick (re-jittering the target each tick would flip the rounded count
+	// constantly even when the real occupancy is steady).
+	occupancyF float64
+	occNoise   float64
+
+	// rated capacities, summed from the room's lighting/fcu archetypes.
+	ratedLightingW float64
+	ratedFcuW      float64
+	// per-tick derived loads.
+	lightsW float64
+	fcuW    float64
+}
+
+// NewBuilding constructs the engine from pre-expanded floor/room state. start is
+// the simulated time the building begins at; rooms are initialised to a plausible
+// steady state for that time so devices report sensible values from the first tick.
+func NewBuilding(start time.Time, scaler scale.Time, baseLoadW float64, seed int64, floors []*Floor) *Building {
+	b := &Building{
+		scaler:    scaler,
+		baseLoadW: baseLoadW,
+		rng:       rand.New(rand.NewSource(seed)),
+		Floors:    floors,
+		meterFrom: start,
+	}
+	work := scaler.At(start)
+	day := daylight(start)
+	b.day = day
+	b.DemandW = baseLoadW
+	for _, f := range b.Floors {
+		for _, r := range f.Rooms {
+			r.reset(work, day)
+			b.DemandW += r.lightsW + r.fcuW
+		}
+	}
+	return b
+}
+
+// AddUpdater registers u to be invoked after each Tick.
+func (b *Building) AddUpdater(u Updater) {
+	b.updaters = append(b.updaters, u)
+}
+
+// Tick advances the simulation by dt of simulated time, with now being the new
+// simulated instant. dt may be zero (e.g. the priming tick), in which case state
+// targets are approached by zero and the meter does not accumulate.
+func (b *Building) Tick(now time.Time, dt time.Duration) {
+	work := b.scaler.At(now)
+	b.day = daylight(now)
+
+	b.DemandW = b.baseLoadW
+	for _, f := range b.Floors {
+		for _, r := range f.Rooms {
+			r.tick(work, b.day, dt, b.rng)
+			b.DemandW += r.lightsW + r.fcuW
+		}
+	}
+	if dt > 0 {
+		b.MeterKWh += b.DemandW / 1000 * dt.Hours()
+	}
+}
+
+// Publish invokes every registered updater with the current state.
+func (b *Building) Publish(now time.Time) {
+	for _, u := range b.updaters {
+		u.Update(now, b)
+	}
+}
+
+// roomTargets computes the steady-state values a room tends toward for the given
+// time-of-day work factor (0..1) and outdoor daylight factor (0..1).
+func roomTargets(r *Room, work, day float64) (light, fan, temp, co2 float64) {
+	occRatio := 0.0
+	if r.MaxOccupancy > 0 {
+		occRatio = float64(r.Occupants) / float64(r.MaxOccupancy)
+	}
+
+	// Lights: on when the room is occupied or during core hours; dimmer when there's
+	// more daylight coming through the windows.
+	if r.Occupants > 0 || work > 0.3 {
+		light = 85 - day*30
+		if light < 20 {
+			light = 20
+		}
+	}
+
+	// FCU: idles at a low baseline while the building is open, ramping with occupancy.
+	if work > 0 || r.Occupants > 0 {
+		fan = 20 + occRatio*80
+	}
+
+	// Temperature: occupants add heat; the FCU fan offsets part of it but can't
+	// fully cancel it, so a busier room is always warmer. An empty or idle room
+	// settles back at the setpoint (the offset is floored at zero).
+	heat := occRatio * 4     // occupant heat gain, up to +4°C at full occupancy
+	cooling := fan / 100 * 2 // the fan removes up to 2°C
+	temp = r.SetPointC + max(0, heat-cooling)
+
+	// CO2: ~420ppm baseline outdoors, rising with how full the room is.
+	co2 = 420 + occRatio*1200
+	return light, fan, temp, co2
+}
+
+// reset assigns a room's steady-state values directly (used at construction).
+func (r *Room) reset(work, day float64) {
+	if r.SetPointC == 0 {
+		r.SetPointC = defaultSetPointC
+	}
+	r.occupancyF = work * float64(r.MaxOccupancy)
+	r.Occupants = int(math.Round(r.occupancyF))
+	light, fan, temp, co2 := roomTargets(r, work, day)
+	r.LightLevel, r.FanPct, r.TempC, r.CO2ppm = light, fan, temp, co2
+	r.recomputeLoads()
+}
+
+// tick advances a room toward its targets over dt, updating occupancy first (which
+// the other targets depend on) and tracking enter/leave totals.
+func (r *Room) tick(work, day float64, dt time.Duration, rng *rand.Rand) {
+	// Occupancy drifts toward the time-of-day target. occNoise is a slow,
+	// mean-reverting noise term (a low-pass of fresh ±5% samples) so the population
+	// wanders organically; occupancyF is the continuous value the integer count is
+	// derived from. Smoothing both means the target moves gradually instead of
+	// teleporting every tick.
+	r.occNoise = approach(r.occNoise, rng.Float64()*0.1-0.05, 0.2, dt)
+	target := work * float64(r.MaxOccupancy) * (1 + r.occNoise)
+	r.occupancyF = approach(r.occupancyF, target, 0.5, dt)
+
+	// Update the integer count with hysteresis: it only moves once occupancyF has
+	// crossed more than half a person past the current count (plus a small margin),
+	// so sub-person jitter doesn't manufacture enter/leave events while the room is
+	// essentially steady. Genuine moves (the day's occupancy arc) still re-round.
+	prev := r.Occupants
+	const hysteresis = 0.5 + 0.2
+	if d := r.occupancyF - float64(prev); d > hysteresis || d < -hysteresis {
+		r.Occupants = int(math.Round(r.occupancyF))
+	}
+	if r.Occupants < 0 {
+		r.Occupants = 0
+	}
+	if r.Occupants > r.MaxOccupancy {
+		r.Occupants = r.MaxOccupancy
+	}
+	if d := r.Occupants - prev; d > 0 {
+		r.EnterTotal += int64(d)
+	} else if d < 0 {
+		r.LeaveTotal += int64(-d)
+	}
+
+	light, fan, temp, co2 := roomTargets(r, work, day)
+	r.LightLevel = approach(r.LightLevel, light, 1.0, dt)
+	r.FanPct = approach(r.FanPct, fan, 0.5, dt)
+	r.TempC = approach(r.TempC, temp, 0.3, dt)
+	r.CO2ppm = approach(r.CO2ppm, co2, 0.4, dt)
+	r.recomputeLoads()
+}
+
+func (r *Room) recomputeLoads() {
+	r.lightsW = r.LightLevel / 100 * r.ratedLightingW
+	r.fcuW = r.FanPct / 100 * r.ratedFcuW
+}
+
+// approach moves cur a fraction of the way toward target. The fraction is
+// ratePerMin scaled by dt and clamped to [0,1], which keeps the step stable for
+// any dt — including the large dt values produced under time acceleration.
+func approach(cur, target, ratePerMin float64, dt time.Duration) float64 {
+	f := min(max(ratePerMin*dt.Minutes(), 0), 1)
+	return cur + (target-cur)*f
+}
+
+// daylight returns the outdoor daylight factor (0..1) for the time of day,
+// a smooth bump that is zero before sunrise and after sunset and peaks at midday.
+func daylight(t time.Time) float64 {
+	const sunrise, sunset = 6.0, 20.0
+	h := float64(t.Hour()) + float64(t.Minute())/60.0
+	if h <= sunrise || h >= sunset {
+		return 0
+	}
+	x := (h - sunrise) / (sunset - sunrise) // 0..1 across daylight hours
+	return math.Sin(x * math.Pi)
+}

--- a/pkg/driver/sim/building.go
+++ b/pkg/driver/sim/building.go
@@ -1,12 +1,16 @@
 package sim
 
 import (
+	"errors"
 	"math"
 	"math/rand"
 	"time"
 
 	"github.com/smart-core-os/sc-bos/pkg/driver/sim/scale"
 )
+
+// errBusy is returned by submit when an override cannot be enqueued.
+var errBusy = errors.New("sim: engine busy, command dropped")
 
 // Building is the coupled simulation engine. A single goroutine owns it: Tick
 // advances the physical state (occupancy → lights/FCUs → energy; daylight → brightness;
@@ -29,6 +33,11 @@ type Building struct {
 	day       float64   // outdoor daylight factor (0..1), recomputed each Tick
 
 	updaters []Updater
+
+	// cmds carries override mutations from the MockDeviceApi onto the engine
+	// goroutine; Tick drains them before advancing, so all Room state continues to
+	// be touched by a single goroutine and needs no locking.
+	cmds chan func()
 }
 
 // Floor is a level of the building.
@@ -51,6 +60,15 @@ type Room struct {
 	CO2ppm     float64
 	EnterTotal int64
 	LeaveTotal int64
+
+	// Overrides set via the MockDeviceApi. While non-nil the engine uses the
+	// override in place of the simulated input and the coupled state responds to
+	// it (e.g. a forced occupancy still drives lighting, FCU load, CO2 and power).
+	// A nil override means the simulation drives the value as normal.
+	occupancyOverride *int
+	setPointOverride  *float64
+	lightOverride     *float64
+	fanOverride       *float64
 
 	// occupancyF is the continuous occupancy that Occupants is rounded from, and
 	// occNoise is a slow, mean-reverting noise term. Together they let the
@@ -78,6 +96,7 @@ func NewBuilding(start time.Time, scaler scale.Time, baseLoadW float64, seed int
 		rng:       rand.New(rand.NewSource(seed)),
 		Floors:    floors,
 		meterFrom: start,
+		cmds:      make(chan func(), 64),
 	}
 	work := scaler.At(start)
 	day := daylight(start)
@@ -97,10 +116,37 @@ func (b *Building) AddUpdater(u Updater) {
 	b.updaters = append(b.updaters, u)
 }
 
+// submit enqueues fn to run on the engine goroutine at the start of the next Tick.
+// It never blocks: if the queue is full (or the engine has stopped draining it)
+// the command is dropped and an error returned, which the caller surfaces to the
+// API client rather than stalling the gRPC handler.
+func (b *Building) submit(fn func()) error {
+	select {
+	case b.cmds <- fn:
+		return nil
+	default:
+		return errBusy
+	}
+}
+
+// drainCommands applies all queued override mutations. Called at the top of Tick
+// so overrides take effect on the engine goroutine that owns the Room state.
+func (b *Building) drainCommands() {
+	for {
+		select {
+		case fn := <-b.cmds:
+			fn()
+		default:
+			return
+		}
+	}
+}
+
 // Tick advances the simulation by dt of simulated time, with now being the new
 // simulated instant. dt may be zero (e.g. the priming tick), in which case state
 // targets are approached by zero and the meter does not accumulate.
 func (b *Building) Tick(now time.Time, dt time.Duration) {
+	b.drainCommands()
 	work := b.scaler.At(now)
 	b.day = daylight(now)
 
@@ -124,8 +170,9 @@ func (b *Building) Publish(now time.Time) {
 }
 
 // roomTargets computes the steady-state values a room tends toward for the given
-// time-of-day work factor (0..1) and outdoor daylight factor (0..1).
-func roomTargets(r *Room, work, day float64) (light, fan, temp, co2 float64) {
+// time-of-day work factor (0..1), outdoor daylight factor (0..1) and effective
+// temperature set point.
+func roomTargets(r *Room, work, day, setPoint float64) (light, fan, temp, co2 float64) {
 	occRatio := 0.0
 	if r.MaxOccupancy > 0 {
 		occRatio = float64(r.Occupants) / float64(r.MaxOccupancy)
@@ -150,7 +197,7 @@ func roomTargets(r *Room, work, day float64) (light, fan, temp, co2 float64) {
 	// settles back at the setpoint (the offset is floored at zero).
 	heat := occRatio * 4     // occupant heat gain, up to +4°C at full occupancy
 	cooling := fan / 100 * 2 // the fan removes up to 2°C
-	temp = r.SetPointC + max(0, heat-cooling)
+	temp = setPoint + max(0, heat-cooling)
 
 	// CO2: ~420ppm baseline outdoors, rising with how full the room is.
 	co2 = 420 + occRatio*1200
@@ -164,7 +211,7 @@ func (r *Room) reset(work, day float64) {
 	}
 	r.occupancyF = work * float64(r.MaxOccupancy)
 	r.Occupants = int(math.Round(r.occupancyF))
-	light, fan, temp, co2 := roomTargets(r, work, day)
+	light, fan, temp, co2 := roomTargets(r, work, day, r.SetPointC)
 	r.LightLevel, r.FanPct, r.TempC, r.CO2ppm = light, fan, temp, co2
 	r.recomputeLoads()
 }
@@ -172,23 +219,31 @@ func (r *Room) reset(work, day float64) {
 // tick advances a room toward its targets over dt, updating occupancy first (which
 // the other targets depend on) and tracking enter/leave totals.
 func (r *Room) tick(work, day float64, dt time.Duration, rng *rand.Rand) {
-	// Occupancy drifts toward the time-of-day target. occNoise is a slow,
-	// mean-reverting noise term (a low-pass of fresh ±5% samples) so the population
-	// wanders organically; occupancyF is the continuous value the integer count is
-	// derived from. Smoothing both means the target moves gradually instead of
-	// teleporting every tick.
-	r.occNoise = approach(r.occNoise, rng.Float64()*0.1-0.05, 0.2, dt)
-	target := work * float64(r.MaxOccupancy) * (1 + r.occNoise)
-	r.occupancyF = approach(r.occupancyF, target, 0.5, dt)
-
-	// Update the integer count with hysteresis: it only moves once occupancyF has
-	// crossed more than half a person past the current count (plus a small margin),
-	// so sub-person jitter doesn't manufacture enter/leave events while the room is
-	// essentially steady. Genuine moves (the day's occupancy arc) still re-round.
 	prev := r.Occupants
-	const hysteresis = 0.5 + 0.2
-	if d := r.occupancyF - float64(prev); d > hysteresis || d < -hysteresis {
-		r.Occupants = int(math.Round(r.occupancyF))
+	if r.occupancyOverride != nil {
+		// Held occupancy: skip the organic drift and pin the count to the forced
+		// value. The other targets below still derive from it, so the rest of the
+		// room (and the building aggregates) respond to the forced occupancy.
+		r.Occupants = *r.occupancyOverride
+		r.occupancyF = float64(r.Occupants)
+	} else {
+		// Occupancy drifts toward the time-of-day target. occNoise is a slow,
+		// mean-reverting noise term (a low-pass of fresh ±5% samples) so the population
+		// wanders organically; occupancyF is the continuous value the integer count is
+		// derived from. Smoothing both means the target moves gradually instead of
+		// teleporting every tick.
+		r.occNoise = approach(r.occNoise, rng.Float64()*0.1-0.05, 0.2, dt)
+		target := work * float64(r.MaxOccupancy) * (1 + r.occNoise)
+		r.occupancyF = approach(r.occupancyF, target, 0.5, dt)
+
+		// Update the integer count with hysteresis: it only moves once occupancyF has
+		// crossed more than half a person past the current count (plus a small margin),
+		// so sub-person jitter doesn't manufacture enter/leave events while the room is
+		// essentially steady. Genuine moves (the day's occupancy arc) still re-round.
+		const hysteresis = 0.5 + 0.2
+		if d := r.occupancyF - float64(prev); d > hysteresis || d < -hysteresis {
+			r.Occupants = int(math.Round(r.occupancyF))
+		}
 	}
 	if r.Occupants < 0 {
 		r.Occupants = 0
@@ -202,9 +257,20 @@ func (r *Room) tick(work, day float64, dt time.Duration, rng *rand.Rand) {
 		r.LeaveTotal += int64(-d)
 	}
 
-	light, fan, temp, co2 := roomTargets(r, work, day)
-	r.LightLevel = approach(r.LightLevel, light, 1.0, dt)
-	r.FanPct = approach(r.FanPct, fan, 0.5, dt)
+	light, fan, temp, co2 := roomTargets(r, work, day, r.setPoint())
+	// A forced light/fan pins the actuator directly; otherwise it eases toward the
+	// occupancy-driven target. Either way the loads (and thus building demand and
+	// metered energy) recompute from the resulting levels below.
+	if r.lightOverride != nil {
+		r.LightLevel = *r.lightOverride
+	} else {
+		r.LightLevel = approach(r.LightLevel, light, 1.0, dt)
+	}
+	if r.fanOverride != nil {
+		r.FanPct = *r.fanOverride
+	} else {
+		r.FanPct = approach(r.FanPct, fan, 0.5, dt)
+	}
 	r.TempC = approach(r.TempC, temp, 0.3, dt)
 	r.CO2ppm = approach(r.CO2ppm, co2, 0.4, dt)
 	r.recomputeLoads()
@@ -213,6 +279,79 @@ func (r *Room) tick(work, day float64, dt time.Duration, rng *rand.Rand) {
 func (r *Room) recomputeLoads() {
 	r.lightsW = r.LightLevel / 100 * r.ratedLightingW
 	r.fcuW = r.FanPct / 100 * r.ratedFcuW
+}
+
+// roomOverride identifies which simulated input a forced value drives.
+type roomOverride int
+
+const (
+	overrideOccupancy roomOverride = iota
+	overrideSetPoint
+	overrideLight
+	overrideFan
+)
+
+// setPoint returns the effective temperature set point: the forced value if one
+// is held, otherwise the room's configured set point.
+func (r *Room) setPoint() float64 {
+	if r.setPointOverride != nil {
+		return *r.setPointOverride
+	}
+	return r.SetPointC
+}
+
+// set applies a forced value to the given input. Called only on the engine
+// goroutine (via Building.drainCommands).
+func (r *Room) set(o roomOverride, v float64) {
+	switch o {
+	case overrideOccupancy:
+		n := int(math.Round(v))
+		if n < 0 {
+			n = 0
+		}
+		r.occupancyOverride = &n
+	case overrideSetPoint:
+		r.setPointOverride = &v
+	case overrideLight:
+		l := clampPct(v)
+		r.lightOverride = &l
+	case overrideFan:
+		f := clampPct(v)
+		r.fanOverride = &f
+	}
+}
+
+// hold freezes an input at its current simulated value (SetDeviceAutomation off).
+func (r *Room) hold(o roomOverride) {
+	switch o {
+	case overrideOccupancy:
+		r.set(overrideOccupancy, float64(r.Occupants))
+	case overrideSetPoint:
+		r.set(overrideSetPoint, r.setPoint())
+	case overrideLight:
+		r.set(overrideLight, r.LightLevel)
+	case overrideFan:
+		r.set(overrideFan, r.FanPct)
+	}
+}
+
+// release clears an override so the simulation drives the input again
+// (SetDeviceAutomation on).
+func (r *Room) release(o roomOverride) {
+	switch o {
+	case overrideOccupancy:
+		r.occupancyOverride = nil
+	case overrideSetPoint:
+		r.setPointOverride = nil
+	case overrideLight:
+		r.lightOverride = nil
+	case overrideFan:
+		r.fanOverride = nil
+	}
+}
+
+func clampPct(v float64) float64 {
+	return min(max(v, 0), 100)
 }
 
 // approach moves cur a fraction of the way toward target. The fraction is

--- a/pkg/driver/sim/building_test.go
+++ b/pkg/driver/sim/building_test.go
@@ -1,0 +1,227 @@
+package sim
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim/scale"
+)
+
+// A weekday and a weekend day for time-of-day tests (Jan 8 2024 is a Monday).
+var (
+	monday   = time.Date(2024, 1, 8, 0, 0, 0, 0, time.UTC)
+	saturday = time.Date(2024, 1, 13, 0, 0, 0, 0, time.UTC)
+)
+
+func at(day time.Time, hour, min int) time.Time {
+	return day.Add(time.Duration(hour)*time.Hour + time.Duration(min)*time.Minute)
+}
+
+const (
+	testBaseLoadW      = 5000
+	testRatedLightingW = 600
+	testRatedFcuW      = 800
+)
+
+// newTestBuilding builds a single-room building with known rated capacities so
+// tests can assert the energy coupling exactly.
+func newTestBuilding(start time.Time) *Building {
+	room := &Room{
+		Name:           "open-plan",
+		MaxOccupancy:   100,
+		SetPointC:      21,
+		ratedLightingW: testRatedLightingW,
+		ratedFcuW:      testRatedFcuW,
+	}
+	floor := &Floor{Name: "ground", Rooms: []*Room{room}}
+	scaler := scale.WorkingHours(8, 18, nil)
+	return NewBuilding(start, scaler, testBaseLoadW, 1, []*Floor{floor})
+}
+
+func (b *Building) room() *Room { return b.Floors[0].Rooms[0] }
+
+func TestNewBuilding_TimeOfDay(t *testing.T) {
+	tests := []struct {
+		name        string
+		start       time.Time
+		wantPeople  string // "zero", "some", "many"
+		wantDemandW string // "base" or "above"
+	}{
+		{"overnight", at(monday, 3, 0), "zero", "base"},
+		{"midday", at(monday, 13, 0), "many", "above"},
+		{"weekend", at(saturday, 13, 0), "zero", "base"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newTestBuilding(tt.start)
+			r := b.room()
+			switch tt.wantPeople {
+			case "zero":
+				if r.Occupants != 0 {
+					t.Errorf("Occupants = %d, want 0", r.Occupants)
+				}
+			case "many":
+				if r.Occupants < 50 {
+					t.Errorf("Occupants = %d, want many (>=50)", r.Occupants)
+				}
+			}
+			switch tt.wantDemandW {
+			case "base":
+				if b.DemandW != testBaseLoadW {
+					t.Errorf("DemandW = %g, want base %d", b.DemandW, testBaseLoadW)
+				}
+				if r.LightLevel != 0 {
+					t.Errorf("LightLevel = %g, want 0 when empty/off-hours", r.LightLevel)
+				}
+			case "above":
+				if b.DemandW <= testBaseLoadW {
+					t.Errorf("DemandW = %g, want above base %d", b.DemandW, testBaseLoadW)
+				}
+				if r.LightLevel <= 0 {
+					t.Errorf("LightLevel = %g, want > 0 when occupied", r.LightLevel)
+				}
+			}
+		})
+	}
+}
+
+func TestTick_DemandIdentity(t *testing.T) {
+	b := newTestBuilding(at(monday, 8, 0))
+	now := at(monday, 8, 0)
+	for i := 0; i < 60; i++ {
+		now = now.Add(time.Minute)
+		b.Tick(now, time.Minute)
+
+		// Derive the expected demand independently from the physical state (light
+		// level, fan speed and the known rated capacities) rather than reading the
+		// engine's own cached lightsW/fcuW, so a wrong load derivation is caught.
+		r := b.room()
+		want := testBaseLoadW + r.LightLevel/100*testRatedLightingW + r.FanPct/100*testRatedFcuW
+		if math.Abs(b.DemandW-want) > 1e-9 {
+			t.Fatalf("tick %d: DemandW = %g, want base + derived loads = %g (light=%g%% fan=%g%%)",
+				i, b.DemandW, want, r.LightLevel, r.FanPct)
+		}
+	}
+}
+
+func TestTick_MeterMonotonic(t *testing.T) {
+	b := newTestBuilding(at(monday, 9, 0))
+	now := at(monday, 9, 0)
+	prev := b.MeterKWh
+	for i := 0; i < 240; i++ {
+		now = now.Add(time.Minute)
+		b.Tick(now, time.Minute)
+		if b.MeterKWh < prev {
+			t.Fatalf("tick %d: MeterKWh went backwards: %g < %g", i, b.MeterKWh, prev)
+		}
+		prev = b.MeterKWh
+	}
+	// Over 4 hours with base load alone the meter must have accumulated at least
+	// baseLoad(kW) * 4h = 5kW * 4h = 20 kWh.
+	if b.MeterKWh < 20 {
+		t.Errorf("MeterKWh = %g, want >= 20 after 4h", b.MeterKWh)
+	}
+}
+
+func TestTick_OccupancyDrivesEnergy(t *testing.T) {
+	// Fill the building up over the morning, then empty it overnight and confirm
+	// demand collapses back to the base load and lights switch off.
+	b := newTestBuilding(at(monday, 7, 0))
+	now := at(monday, 7, 0)
+
+	// Run through to midday: occupancy and demand should climb.
+	for now.Before(at(monday, 12, 0)) {
+		now = now.Add(time.Minute)
+		b.Tick(now, time.Minute)
+	}
+	if b.room().Occupants < 50 {
+		t.Fatalf("midday Occupants = %d, want busy", b.room().Occupants)
+	}
+	if b.DemandW <= testBaseLoadW {
+		t.Fatalf("midday DemandW = %g, want above base", b.DemandW)
+	}
+
+	// Jump to the early hours and let everyone leave.
+	now = at(monday, 2, 0).Add(24 * time.Hour) // next day 02:00
+	for i := 0; i < 120; i++ {
+		now = now.Add(time.Minute)
+		b.Tick(now, time.Minute)
+	}
+	if b.room().Occupants != 0 {
+		t.Errorf("overnight Occupants = %d, want 0", b.room().Occupants)
+	}
+	if b.room().LightLevel != 0 {
+		t.Errorf("overnight LightLevel = %g, want 0", b.room().LightLevel)
+	}
+	if math.Abs(b.DemandW-testBaseLoadW) > 1e-6 {
+		t.Errorf("overnight DemandW = %g, want base %d", b.DemandW, testBaseLoadW)
+	}
+}
+
+func TestTick_SteadyOccupancyNoChurn(t *testing.T) {
+	// A room at steady occupancy must not manufacture enter/leave events or flicker
+	// its people count every tick. Observe a flat peak window (14:30–15:45 for an
+	// 08:00–18:00 day: past lunch recovery, before the 16:00 evening ramp).
+	b := newTestBuilding(at(monday, 14, 0))
+	now := at(monday, 14, 0)
+	for i := 0; i < 30; i++ { // settle to 14:30
+		now = now.Add(time.Minute)
+		b.Tick(now, time.Minute)
+	}
+	r := b.room()
+	enter0, leave0, occMin := r.EnterTotal, r.LeaveTotal, r.Occupants
+	for i := 0; i < 75; i++ {
+		now = now.Add(time.Minute)
+		b.Tick(now, time.Minute)
+		if r.Occupants < occMin {
+			occMin = r.Occupants
+		}
+	}
+	// The room is busy (~full); over a flat window it should barely move. The old
+	// jitter-every-tick model produced >150 enters and >150 leaves here.
+	if churn := (r.EnterTotal - enter0) + (r.LeaveTotal - leave0); churn > 15 {
+		t.Errorf("enter+leave churn = %d over a flat 75min window, want small (steady room)", churn)
+	}
+	if occMin < r.MaxOccupancy-5 {
+		t.Errorf("occupancy dipped to %d (max %d); steady busy room should not flicker far", occMin, r.MaxOccupancy)
+	}
+}
+
+func TestTick_AcceleratedStability(t *testing.T) {
+	// Large dt (24 min/tick, as produced by timeMultiplier=288 with a 5s tick)
+	// must not destabilise the model: values stay bounded over a simulated 48h.
+	b := newTestBuilding(monday)
+	now := monday
+	const dt = 24 * time.Minute
+	for i := 0; i < 120; i++ { // 120 * 24min = 48h
+		now = now.Add(dt)
+		b.Tick(now, dt)
+		r := b.room()
+		if r.Occupants < 0 || r.Occupants > r.MaxOccupancy {
+			t.Fatalf("tick %d: Occupants = %d out of range", i, r.Occupants)
+		}
+		if math.IsNaN(b.DemandW) || math.IsInf(b.DemandW, 0) || b.DemandW < testBaseLoadW {
+			t.Fatalf("tick %d: DemandW = %g invalid", i, b.DemandW)
+		}
+		if r.LightLevel < 0 || r.LightLevel > 100 || r.FanPct < 0 || r.FanPct > 100 {
+			t.Fatalf("tick %d: light=%g fan=%g out of range", i, r.LightLevel, r.FanPct)
+		}
+	}
+}
+
+func TestDaylight(t *testing.T) {
+	if d := daylight(at(monday, 3, 0)); d != 0 {
+		t.Errorf("daylight 03:00 = %g, want 0", d)
+	}
+	if d := daylight(at(monday, 22, 0)); d != 0 {
+		t.Errorf("daylight 22:00 = %g, want 0", d)
+	}
+	noon := daylight(at(monday, 13, 0))
+	if noon < 0.95 {
+		t.Errorf("daylight 13:00 = %g, want near peak", noon)
+	}
+	if morning := daylight(at(monday, 9, 0)); morning <= 0 || morning >= noon {
+		t.Errorf("daylight 09:00 = %g, want between 0 and noon peak %g", morning, noon)
+	}
+}

--- a/pkg/driver/sim/config/root.go
+++ b/pkg/driver/sim/config/root.go
@@ -1,0 +1,230 @@
+// Package config defines the configuration schema for the sim driver.
+package config
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/smart-core-os/sc-bos/pkg/block"
+	"github.com/smart-core-os/sc-bos/pkg/block/mdblock"
+	"github.com/smart-core-os/sc-bos/pkg/driver"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
+	"github.com/smart-core-os/sc-bos/pkg/util/jsontypes"
+)
+
+// Root is the top-level configuration for the sim driver.
+//
+// Unlike the mock driver, which lists every device explicitly, the sim driver is
+// configured at the building level: floors, the rooms on each floor, and the
+// device "archetypes" present in each room. The driver expands archetypes into
+// concrete devices and runs a single coupled simulation across them.
+type Root struct {
+	driver.BaseConfig
+	// Metadata is announced on the driver's own name (BaseConfig.Name).
+	Metadata *metadatapb.Metadata `json:"metadata,omitempty"`
+
+	// NamePrefix is prepended to every generated device name, e.g. "van/uk/brum/ugs".
+	NamePrefix string `json:"namePrefix,omitempty"`
+
+	// WorkingHours controls the daily occupancy/activity curve. Defaults to 08:00–18:00 Mon–Fri.
+	WorkingHours *WorkingHours `json:"workingHours,omitempty"`
+
+	// TimeMultiplier accelerates simulated time relative to the wall clock.
+	// 1 (default) runs in real time; 288 compresses a 24h day into 5 minutes.
+	TimeMultiplier float64 `json:"timeMultiplier,omitempty"`
+
+	// TickInterval is the wall-clock cadence at which the simulation advances. Defaults to 5s.
+	TickInterval *jsontypes.Duration `json:"tickInterval,omitempty"`
+
+	// BaseLoadW is the always-on building electrical load in watts (lifts, servers, etc.). Defaults to 5000.
+	BaseLoadW float64 `json:"baseLoadW,omitempty"`
+
+	// Seed seeds the simulation's random source. 0 (default) uses a fixed seed for reproducible demos.
+	Seed int64 `json:"seed,omitempty"`
+
+	Floors []Floor `json:"floors,omitempty"`
+
+	// BuildingDevices are devices that report whole-building aggregates rather than
+	// belonging to a single room, e.g. the main incoming electricity meter.
+	// Only the meter and electric archetypes are meaningful here.
+	BuildingDevices []Archetype `json:"buildingDevices,omitempty"`
+
+	// HealthCheck optionally simulates driver-level connectivity faults.
+	HealthCheck *HealthCheck `json:"healthCheck,omitempty"`
+}
+
+// WorkingHours describes the building's occupied period.
+type WorkingHours struct {
+	// Start and End are hours of the day in 24h decimal form, e.g. 8.5 == 08:30.
+	Start float64 `json:"start,omitempty"`
+	End   float64 `json:"end,omitempty"`
+	// Days lists the working weekdays as names ("Mon".."Sun" or "Monday".."Sunday").
+	// Defaults to Monday–Friday.
+	Days []string `json:"days,omitempty"`
+}
+
+// Floor is a level of the building containing rooms.
+type Floor struct {
+	Name  string `json:"name"`
+	Title string `json:"title,omitempty"`
+	// MaxOccupancy is the peak number of people on this floor. If a room does not
+	// set its own MaxOccupancy, the floor's value is shared evenly between its rooms.
+	MaxOccupancy int    `json:"maxOccupancy,omitempty"`
+	Rooms        []Room `json:"rooms,omitempty"`
+}
+
+// Room is a space within a floor containing device archetypes.
+type Room struct {
+	Name         string      `json:"name"`
+	Title        string      `json:"title,omitempty"`
+	MaxOccupancy int         `json:"maxOccupancy,omitempty"`
+	Archetypes   []Archetype `json:"archetypes,omitempty"`
+}
+
+// Archetype is a class of device present in a room (or the building).
+// The driver expands it into Count concrete devices with the traits implied by Type.
+type Archetype struct {
+	// Type selects the device kind. See the sim package for supported values
+	// (lighting, fcu, pir, motion, brightness, airquality, meter, electric, enterleave).
+	Type  string `json:"type"`
+	Title string `json:"title,omitempty"`
+	// Count is the number of devices to generate. Defaults to 1.
+	Count int `json:"count,omitempty"`
+	// RatedPowerW is the per-device power draw at full load, in watts.
+	// Used by lighting and fcu archetypes to derive building energy use. Sensible defaults apply.
+	RatedPowerW float64 `json:"ratedPowerW,omitempty"`
+	// SetPointC is the target temperature for fcu archetypes, in Celsius. Defaults to 21.
+	SetPointC float64 `json:"setPointC,omitempty"`
+}
+
+// HealthCheck configures a simulated driver-level connectivity health check for UI testing.
+type HealthCheck struct {
+	// FaultProbability is the probability (0.0–1.0) that each evaluation results in a fault state.
+	// Defaults to 0.15 when omitted; set it explicitly to 0 to never fault (always healthy).
+	FaultProbability *float64 `json:"faultProbability,omitempty"`
+}
+
+// Defaults applied during normalisation.
+const (
+	DefaultTimeMultiplier = 1.0
+	DefaultTickInterval   = 5 * time.Second
+	DefaultBaseLoadW      = 5000.0
+	DefaultWorkStart      = 8.0
+	DefaultWorkEnd        = 18.0
+	DefaultSeed           = 1
+	// DefaultFaultProbability is applied when healthCheck is present but its
+	// faultProbability is omitted. An explicit 0 is honoured (never fault).
+	DefaultFaultProbability = 0.15
+)
+
+// Normalise fills in defaults on a parsed Root. It is safe to call on a zero value.
+func (r *Root) Normalise() {
+	if r.TimeMultiplier <= 0 {
+		r.TimeMultiplier = DefaultTimeMultiplier
+	}
+	if r.TickInterval == nil || r.TickInterval.Duration <= 0 {
+		r.TickInterval = &jsontypes.Duration{Duration: DefaultTickInterval}
+	}
+	if r.BaseLoadW <= 0 {
+		r.BaseLoadW = DefaultBaseLoadW
+	}
+	if r.Seed == 0 {
+		r.Seed = DefaultSeed
+	}
+	if r.WorkingHours == nil {
+		r.WorkingHours = &WorkingHours{Start: DefaultWorkStart, End: DefaultWorkEnd}
+	}
+	if r.WorkingHours.End <= r.WorkingHours.Start {
+		r.WorkingHours.Start = DefaultWorkStart
+		r.WorkingHours.End = DefaultWorkEnd
+	}
+	if r.HealthCheck != nil && r.HealthCheck.FaultProbability == nil {
+		p := DefaultFaultProbability
+		r.HealthCheck.FaultProbability = &p
+	}
+}
+
+// Validate checks values that cannot be defaulted. Call it after Normalise.
+func (r *Root) Validate() error {
+	if r.HealthCheck != nil && r.HealthCheck.FaultProbability != nil {
+		if p := *r.HealthCheck.FaultProbability; p < 0 || p > 1 {
+			return fmt.Errorf("healthCheck.faultProbability must be between 0 and 1, got %g", p)
+		}
+	}
+	// Generated device names embed the floor and room names, so duplicates would
+	// expand to colliding device names.
+	floorNames := make(map[string]bool, len(r.Floors))
+	for fi, f := range r.Floors {
+		if f.Name == "" {
+			return fmt.Errorf("floors[%d] has no name", fi)
+		}
+		if floorNames[f.Name] {
+			return fmt.Errorf("duplicate floor name %q", f.Name)
+		}
+		floorNames[f.Name] = true
+		roomNames := make(map[string]bool, len(f.Rooms))
+		for ri, room := range f.Rooms {
+			if room.Name == "" {
+				return fmt.Errorf("floor %q rooms[%d] has no name", f.Name, ri)
+			}
+			if roomNames[room.Name] {
+				return fmt.Errorf("duplicate room name %q on floor %q", room.Name, f.Name)
+			}
+			roomNames[room.Name] = true
+		}
+	}
+	return nil
+}
+
+// Weekdays resolves the configured working day names to time.Weekday values.
+// Returns Monday–Friday if none are configured. Unknown names produce an error.
+func (w *WorkingHours) Weekdays() ([]time.Weekday, error) {
+	if w == nil || len(w.Days) == 0 {
+		return []time.Weekday{time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday}, nil
+	}
+	out := make([]time.Weekday, 0, len(w.Days))
+	for _, d := range w.Days {
+		wd, ok := weekdayByName[strings.ToLower(strings.TrimSpace(d))]
+		if !ok {
+			return nil, fmt.Errorf("unknown working day %q", d)
+		}
+		out = append(out, wd)
+	}
+	return out, nil
+}
+
+var weekdayByName = map[string]time.Weekday{
+	"sun": time.Sunday, "sunday": time.Sunday,
+	"mon": time.Monday, "monday": time.Monday,
+	"tue": time.Tuesday, "tues": time.Tuesday, "tuesday": time.Tuesday,
+	"wed": time.Wednesday, "weds": time.Wednesday, "wednesday": time.Wednesday,
+	"thu": time.Thursday, "thur": time.Thursday, "thurs": time.Thursday, "thursday": time.Thursday,
+	"fri": time.Friday, "friday": time.Friday,
+	"sat": time.Saturday, "saturday": time.Saturday,
+}
+
+// Blocks describes the config structure for the configuration UI.
+var Blocks = []block.Block{
+	{
+		Path: []string{"floors"},
+		Key:  "name",
+		Blocks: []block.Block{
+			{
+				Path: []string{"rooms"},
+				Key:  "name",
+				Blocks: []block.Block{
+					{Path: []string{"archetypes"}, Key: "type"},
+				},
+			},
+		},
+	},
+	{
+		Path: []string{"buildingDevices"},
+		Key:  "type",
+	},
+	{
+		Path:   []string{"metadata"},
+		Blocks: mdblock.Categories,
+	},
+}

--- a/pkg/driver/sim/control.go
+++ b/pkg/driver/sim/control.go
@@ -1,0 +1,143 @@
+package sim
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/smart-core-os/sc-bos/pkg/proto/airtemperaturepb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/fanspeedpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/lightpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/mockpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/occupancysensorpb"
+	"github.com/smart-core-os/sc-bos/pkg/trait"
+)
+
+// controller implements the MockDeviceApi for the sim driver. Unlike the mock
+// driver — where each device is independent — a forced value here drives the
+// coupled engine: forcing a room's occupancy, temperature set point, lighting or
+// fan speed becomes a simulation input and the rest of the building responds.
+// Forcing a derived output (power, metering, brightness, CO2, motion, enter/leave)
+// is rejected, as those follow from the inputs above.
+//
+// SetDeviceAutomation toggles whether the engine drives an input: active=false
+// freezes it at its current value, active=true releases it back to the simulation.
+type controller struct {
+	mockpb.UnimplementedMockDeviceApiServer
+	b       *Building
+	devices map[string]forceable // deviceName -> its room and forceable traits
+}
+
+// forceable records, for one device, the room it belongs to and which engine
+// override each of its traits drives.
+type forceable struct {
+	room   *Room
+	traits map[trait.Name]roomOverride
+}
+
+func newController(b *Building) *controller {
+	return &controller{b: b, devices: make(map[string]forceable)}
+}
+
+// register records a device's forceable traits. Called during Expand, before the
+// engine starts, so the map is read-only by the time requests can arrive.
+func (c *controller) register(name string, room *Room, traits map[trait.Name]roomOverride) {
+	c.devices[name] = forceable{room: room, traits: traits}
+}
+
+func (c *controller) lookup(name string) (forceable, error) {
+	f, ok := c.devices[name]
+	if !ok {
+		return forceable{}, status.Errorf(codes.NotFound, "device %q is not a forceable simulated device", name)
+	}
+	return f, nil
+}
+
+func (c *controller) ForceTraitValue(_ context.Context, req *mockpb.ForceTraitValuesRequest) (*mockpb.ForceTraitValuesResponse, error) {
+	f, err := c.lookup(req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	for _, tv := range req.GetValues() {
+		o, ok := f.traits[trait.Name(tv.GetTrait())]
+		if !ok {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"trait %q on %q is derived from the simulation and cannot be forced; force occupancy, air temperature set point, lighting or fan speed instead",
+				tv.GetTrait(), req.GetName())
+		}
+		v, err := parseOverride(o, tv.GetValueProtojson())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "force trait %q: %v", tv.GetTrait(), err)
+		}
+		room := f.room
+		if err := c.b.submit(func() { room.set(o, v) }); err != nil {
+			return nil, status.Error(codes.Unavailable, err.Error())
+		}
+	}
+	return &mockpb.ForceTraitValuesResponse{}, nil
+}
+
+func (c *controller) SetDeviceAutomation(_ context.Context, req *mockpb.SetDeviceAutomationsRequest) (*mockpb.SetDeviceAutomationsResponse, error) {
+	f, err := c.lookup(req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	for _, a := range req.GetAutomations() {
+		// An empty trait selects every forceable trait on the device.
+		for tn, ov := range f.traits {
+			if t := a.GetTrait(); t != "" && t != string(tn) {
+				continue
+			}
+			room, o, active := f.room, ov, a.GetActive()
+			err := c.b.submit(func() {
+				if active {
+					room.release(o)
+				} else {
+					room.hold(o)
+				}
+			})
+			if err != nil {
+				return nil, status.Error(codes.Unavailable, err.Error())
+			}
+		}
+	}
+	return &mockpb.SetDeviceAutomationsResponse{}, nil
+}
+
+// parseOverride extracts the engine input value from a trait's protojson value.
+func parseOverride(o roomOverride, valueJSON string) (float64, error) {
+	switch o {
+	case overrideOccupancy:
+		var v occupancysensorpb.Occupancy
+		if err := protojson.Unmarshal([]byte(valueJSON), &v); err != nil {
+			return 0, err
+		}
+		return float64(v.GetPeopleCount()), nil
+	case overrideSetPoint:
+		var v airtemperaturepb.AirTemperature
+		if err := protojson.Unmarshal([]byte(valueJSON), &v); err != nil {
+			return 0, err
+		}
+		sp := v.GetTemperatureSetPoint()
+		if sp == nil {
+			return 0, fmt.Errorf("expected temperatureSetPoint.valueCelsius")
+		}
+		return sp.GetValueCelsius(), nil
+	case overrideLight:
+		var v lightpb.Brightness
+		if err := protojson.Unmarshal([]byte(valueJSON), &v); err != nil {
+			return 0, err
+		}
+		return float64(v.GetLevelPercent()), nil
+	case overrideFan:
+		var v fanspeedpb.FanSpeed
+		if err := protojson.Unmarshal([]byte(valueJSON), &v); err != nil {
+			return 0, err
+		}
+		return float64(v.GetPercentage()), nil
+	}
+	return 0, fmt.Errorf("unsupported override")
+}

--- a/pkg/driver/sim/control_test.go
+++ b/pkg/driver/sim/control_test.go
@@ -1,0 +1,116 @@
+package sim
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/smart-core-os/sc-bos/pkg/proto/mockpb"
+	"github.com/smart-core-os/sc-bos/pkg/trait"
+)
+
+func forceValue(t *testing.T, c *controller, device string, tn trait.Name, valueJSON string) {
+	t.Helper()
+	_, err := c.ForceTraitValue(context.Background(), &mockpb.ForceTraitValuesRequest{
+		Name:   device,
+		Values: []*mockpb.TraitValue{{Trait: string(tn), ValueProtojson: valueJSON}},
+	})
+	if err != nil {
+		t.Fatalf("ForceTraitValue(%s, %s): %v", device, tn, err)
+	}
+}
+
+func TestControl_ForcedOccupancyDrivesBuilding(t *testing.T) {
+	// 03:00 — the building is empty: occupancy, lights and demand are all at rest.
+	start := at(monday, 3, 0)
+	b := newTestBuilding(start)
+	now := start
+	for i := 0; i < 30; i++ { // settle to a night-time baseline
+		now = now.Add(time.Minute)
+		b.Tick(now, time.Minute)
+	}
+	if b.room().Occupants != 0 {
+		t.Fatalf("precondition: night Occupants = %d, want 0", b.room().Occupants)
+	}
+
+	c := newController(b)
+	c.register("pir-01", b.room(), map[trait.Name]roomOverride{trait.OccupancySensor: overrideOccupancy})
+	forceValue(t, c, "pir-01", trait.OccupancySensor, `{"peopleCount":50}`)
+
+	// The force is applied on the engine goroutine at the next tick.
+	now = now.Add(time.Minute)
+	b.Tick(now, time.Minute)
+	if got := b.room().Occupants; got != 50 {
+		t.Fatalf("after force, Occupants = %d, want 50", got)
+	}
+	// And the building responds via the coupling: at 03:00 with no daylight and no
+	// simulated occupancy, the lights come on and demand climbs above the base load.
+	if b.room().LightLevel <= 0 {
+		t.Errorf("forced-occupancy LightLevel = %g, want > 0", b.room().LightLevel)
+	}
+	if b.DemandW <= testBaseLoadW {
+		t.Errorf("forced-occupancy DemandW = %g, want above base %d", b.DemandW, testBaseLoadW)
+	}
+
+	// Releasing the override hands the room back to the simulation; overnight it empties.
+	if _, err := c.SetDeviceAutomation(context.Background(), &mockpb.SetDeviceAutomationsRequest{
+		Name:        "pir-01",
+		Automations: []*mockpb.TraitAutomation{{Active: true}},
+	}); err != nil {
+		t.Fatalf("SetDeviceAutomation: %v", err)
+	}
+	for i := 0; i < 60; i++ {
+		now = now.Add(time.Minute)
+		b.Tick(now, time.Minute)
+	}
+	if got := b.room().Occupants; got != 0 {
+		t.Errorf("after release, night Occupants = %d, want 0", got)
+	}
+}
+
+func TestControl_ForcedSetPointRaisesTemperature(t *testing.T) {
+	start := at(monday, 9, 0)
+	b := newTestBuilding(start)
+	now := start
+	b.Tick(now, time.Minute)
+
+	c := newController(b)
+	c.register("fcu-01", b.room(), map[trait.Name]roomOverride{trait.AirTemperature: overrideSetPoint})
+	t0 := b.room().TempC
+	forceValue(t, c, "fcu-01", trait.AirTemperature, `{"temperatureSetPoint":{"valueCelsius":26}}`)
+
+	now = now.Add(time.Minute)
+	b.Tick(now, time.Minute)
+	if sp := b.room().setPoint(); sp != 26 {
+		t.Fatalf("forced setPoint = %g, want 26", sp)
+	}
+	for i := 0; i < 120; i++ {
+		now = now.Add(time.Minute)
+		b.Tick(now, time.Minute)
+	}
+	if b.room().TempC <= t0 {
+		t.Errorf("TempC = %g after raising set point to 26 from ~%g, want higher", b.room().TempC, t0)
+	}
+}
+
+func TestControl_RejectsDerivedAndUnknown(t *testing.T) {
+	b := newTestBuilding(at(monday, 9, 0))
+	c := newController(b)
+	c.register("pir-01", b.room(), map[trait.Name]roomOverride{trait.OccupancySensor: overrideOccupancy})
+
+	// Electric is derived from the simulation; forcing it must be rejected.
+	if _, err := c.ForceTraitValue(context.Background(), &mockpb.ForceTraitValuesRequest{
+		Name:   "pir-01",
+		Values: []*mockpb.TraitValue{{Trait: string(trait.Electric), ValueProtojson: `{}`}},
+	}); err == nil {
+		t.Error("forcing a derived trait: want error, got nil")
+	}
+
+	// An unregistered device is rejected too.
+	if _, err := c.ForceTraitValue(context.Background(), &mockpb.ForceTraitValuesRequest{
+		Name:   "no-such-device",
+		Values: []*mockpb.TraitValue{{Trait: string(trait.OccupancySensor), ValueProtojson: `{"peopleCount":1}`}},
+	}); err == nil {
+		t.Error("forcing an unknown device: want error, got nil")
+	}
+}

--- a/pkg/driver/sim/driver.go
+++ b/pkg/driver/sim/driver.go
@@ -1,0 +1,214 @@
+// Package sim implements the "sim" driver: a physically-coupled simulated building.
+//
+// Where the mock driver gives every trait its own independent random automation,
+// sim runs a single engine (see Building) in which occupancy drives lighting and
+// FCU load, which in turn derives the building's electrical demand and metered
+// energy. It is configured at the building level — floors, rooms and the device
+// archetypes in each room — rather than as an explicit device list.
+package sim
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/smart-core-os/sc-bos/pkg/block"
+	"github.com/smart-core-os/sc-bos/pkg/driver"
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim/config"
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim/scale"
+	"github.com/smart-core-os/sc-bos/pkg/node"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
+	"github.com/smart-core-os/sc-bos/pkg/task/service"
+	"github.com/smart-core-os/sc-bos/pkg/util/time/clock"
+)
+
+const DriverName = "sim"
+
+var Factory driver.Factory = factory{}
+
+type factory struct{}
+
+func (factory) New(services driver.Services) service.Lifecycle {
+	return NewDriver(services)
+}
+
+func (factory) ConfigBlocks() []block.Block {
+	return config.Blocks
+}
+
+func NewDriver(services driver.Services) *Driver {
+	d := &Driver{
+		announcer:   services.Node,
+		systemCheck: services.SystemCheck,
+		clk:         clock.Real(),
+		logger:      services.Logger.Named(DriverName),
+	}
+	d.Service = service.New(d.applyConfig, service.WithOnStop[config.Root](func() {
+		d.stop()
+		if d.systemCheck != nil {
+			d.systemCheck.Dispose()
+		}
+	}))
+	return d
+}
+
+type Driver struct {
+	*service.Service[config.Root]
+
+	logger      *zap.Logger
+	announcer   node.Announcer
+	systemCheck service.SystemCheck
+	clk         clock.Clock // wall clock; swappable in tests
+
+	mu     sync.Mutex
+	cancel context.CancelFunc // cancels the running engine + health sim
+	undo   []node.Undo        // reverses the current announcements
+}
+
+func (d *Driver) applyConfig(ctx context.Context, cfg config.Root) error {
+	cfg.Normalise()
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	days, err := cfg.WorkingHours.Weekdays()
+	if err != nil {
+		return err
+	}
+	scaler := scale.WorkingHours(cfg.WorkingHours.Start, cfg.WorkingHours.End, days)
+
+	// Tear down any previous run before (re)building.
+	d.stop()
+
+	start := d.clk.Now()
+	building, devices, err := Expand(cfg, scaler, start)
+	if err != nil {
+		return err
+	}
+	if rooms := zeroOccupancyRooms(cfg); len(rooms) > 0 {
+		d.logger.Warn("rooms resolve to zero max occupancy; their occupancy-driven sensors will always report empty",
+			zap.Strings("rooms", rooms))
+	}
+
+	var undos []node.Undo
+	if cfg.Metadata != nil {
+		undos = append(undos, d.announcer.Announce(cfg.Name, node.HasMetadata(cfg.Metadata)))
+	}
+	for _, dev := range devices {
+		feats := append([]node.Feature{
+			node.HasMetadata(dev.Metadata),
+			node.HasDeviceType(metadatapb.Metadata_DEVICE),
+		}, dev.Features...)
+		undos = append(undos, d.announcer.Announce(dev.Name, feats...))
+	}
+	d.logger.Info("announced simulated building", zap.Int("devices", len(devices)))
+
+	runCtx, cancel := context.WithCancel(ctx)
+	d.mu.Lock()
+	d.cancel = cancel
+	d.undo = undos
+	d.mu.Unlock()
+
+	go d.runEngine(runCtx, building, cfg)
+
+	if d.systemCheck != nil {
+		// Report healthy now. This also clears any FAILED state left by a previous
+		// config whose health simulation has since been reconfigured away.
+		d.systemCheck.MarkRunning()
+		if cfg.HealthCheck != nil {
+			// Normalise guarantees FaultProbability is non-nil when HealthCheck is set.
+			go runHealthSimulation(runCtx, d.clk, d.systemCheck, *cfg.HealthCheck.FaultProbability)
+		}
+	}
+	return nil
+}
+
+// runEngine advances the simulation on the wall clock, mapping wall time to
+// simulated time via the configured TimeMultiplier, and publishes device state
+// after each tick.
+func (d *Driver) runEngine(ctx context.Context, b *Building, cfg config.Root) {
+	// Contain panics to this driver rather than crashing the whole process: an
+	// updater bug would otherwise take down every system in the controller.
+	defer func() {
+		if r := recover(); r != nil {
+			d.logger.Error("simulation engine panicked; engine stopped, devices remain announced with their last published values",
+				zap.Any("panic", r), zap.ByteString("stack", debug.Stack()))
+			if d.systemCheck != nil {
+				d.systemCheck.MarkFailed(fmt.Errorf("simulation engine panicked: %v", r))
+			}
+		}
+	}()
+
+	mult := cfg.TimeMultiplier
+	tick := cfg.TickInterval.Duration
+
+	anchorWall := d.clk.Now()
+	anchorSim := anchorWall
+	simAt := func(wall time.Time) time.Time {
+		return anchorSim.Add(time.Duration(float64(wall.Sub(anchorWall)) * mult))
+	}
+
+	// Publish the initial steady state immediately so devices report sane values
+	// before the first tick elapses.
+	b.Publish(anchorSim)
+
+	ticker := d.clk.Every(tick)
+	defer ticker.Stop()
+	last := anchorSim
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case wall, ok := <-ticker.C():
+			if !ok {
+				return
+			}
+			now := simAt(wall)
+			dt := now.Sub(last)
+			last = now
+			b.Tick(now, dt)
+			b.Publish(now)
+		}
+	}
+}
+
+// stop cancels the running engine and reverses all announcements.
+func (d *Driver) stop() {
+	d.mu.Lock()
+	cancel, undo := d.cancel, d.undo
+	d.cancel, d.undo = nil, nil
+	d.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	for _, u := range undo {
+		u()
+	}
+}
+
+// runHealthSimulation periodically randomises the driver's system-level health
+// check: with probability p it reports a fault, otherwise healthy.
+//
+// It deliberately uses the package-level rand rather than the engine's seeded
+// source (which is owned by the engine goroutine), so fault timing is not part
+// of the config seed's reproducibility guarantee.
+func runHealthSimulation(ctx context.Context, clk clock.Clock, check service.SystemCheck, p float64) {
+	for {
+		wait := 30*time.Second + time.Duration(rand.Int63n(int64(60*time.Second)))
+		select {
+		case <-ctx.Done():
+			return
+		case <-clk.After(wait):
+		}
+		if rand.Float64() < p {
+			check.MarkFailed(fmt.Errorf("simulated connectivity failure"))
+		} else {
+			check.MarkRunning()
+		}
+	}
+}

--- a/pkg/driver/sim/driver_test.go
+++ b/pkg/driver/sim/driver_test.go
@@ -1,0 +1,211 @@
+package sim
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim/config"
+	"github.com/smart-core-os/sc-bos/pkg/node"
+	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
+	"github.com/smart-core-os/sc-bos/pkg/task/service"
+	"github.com/smart-core-os/sc-bos/pkg/util/time/clock"
+)
+
+// countingAnnouncer records announced names and how many announcements were undone.
+type countingAnnouncer struct {
+	mu        sync.Mutex
+	announced []string
+	undone    int
+}
+
+func (c *countingAnnouncer) Announce(name string, _ ...node.Feature) node.Undo {
+	c.mu.Lock()
+	c.announced = append(c.announced, name)
+	c.mu.Unlock()
+	return func() {
+		c.mu.Lock()
+		c.undone++
+		c.mu.Unlock()
+	}
+}
+
+func newTestDriver(a node.Announcer) *Driver {
+	d := &Driver{
+		announcer: a,
+		clk:       clock.Real(),
+		logger:    zap.NewNop(),
+	}
+	d.Service = service.New(d.applyConfig, service.WithOnStop[config.Root](func() { d.stop() }))
+	return d
+}
+
+func TestDriver_AnnounceAndStop(t *testing.T) {
+	a := &countingAnnouncer{}
+	d := newTestDriver(a)
+
+	cfg := config.Root{
+		NamePrefix: "sim/demo",
+		Floors: []config.Floor{{
+			Name: "ground", MaxOccupancy: 30,
+			Rooms: []config.Room{{Name: "open-plan", Archetypes: []config.Archetype{
+				{Type: ArchetypeLighting, Count: 2},
+				{Type: ArchetypePIR},
+			}}},
+		}},
+		BuildingDevices: []config.Archetype{{Type: ArchetypeElectric}},
+	}
+	cfg.Normalise()
+
+	if err := d.applyConfig(context.Background(), cfg); err != nil {
+		t.Fatalf("applyConfig: %v", err)
+	}
+
+	a.mu.Lock()
+	got := len(a.announced)
+	a.mu.Unlock()
+	if got != 4 { // 2 lighting + 1 pir + 1 electric
+		t.Errorf("announced %d devices, want 4", got)
+	}
+
+	d.stop()
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.undone != got {
+		t.Errorf("undone %d, want all %d announcements reversed", a.undone, got)
+	}
+}
+
+func TestDriver_InvalidFaultProbability(t *testing.T) {
+	d := newTestDriver(&countingAnnouncer{})
+	cfg := config.Root{
+		Floors:      []config.Floor{{Name: "g", Rooms: []config.Room{{Name: "r"}}}},
+		HealthCheck: &config.HealthCheck{FaultProbability: ptr(1.5)},
+	}
+	cfg.Normalise()
+	if err := d.applyConfig(context.Background(), cfg); err == nil {
+		t.Fatal("expected error for faultProbability > 1")
+	}
+}
+
+func TestConfig_FaultProbabilityBounds(t *testing.T) {
+	// 0 is a valid probability (never fault) and must be preserved, not defaulted.
+	zero := config.Root{HealthCheck: &config.HealthCheck{FaultProbability: ptr(0.0)}}
+	zero.Normalise()
+	if zero.HealthCheck.FaultProbability == nil || *zero.HealthCheck.FaultProbability != 0 {
+		t.Errorf("faultProbability 0 not preserved: %v", zero.HealthCheck.FaultProbability)
+	}
+	if err := zero.Validate(); err != nil {
+		t.Errorf("faultProbability 0 should be valid: %v", err)
+	}
+	// Omitted -> default applied.
+	def := config.Root{HealthCheck: &config.HealthCheck{}}
+	def.Normalise()
+	if def.HealthCheck.FaultProbability == nil || *def.HealthCheck.FaultProbability != config.DefaultFaultProbability {
+		t.Errorf("omitted faultProbability not defaulted to %g", config.DefaultFaultProbability)
+	}
+	// Negative -> rejected by Validate.
+	neg := config.Root{HealthCheck: &config.HealthCheck{FaultProbability: ptr(-0.1)}}
+	neg.Normalise()
+	if err := neg.Validate(); err == nil {
+		t.Error("negative faultProbability should be rejected")
+	}
+}
+
+func TestConfig_DuplicateNames(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     config.Root
+		wantErr bool
+	}{
+		{"duplicate floors", config.Root{Floors: []config.Floor{{Name: "g"}, {Name: "g"}}}, true},
+		{"duplicate rooms", config.Root{Floors: []config.Floor{{Name: "g", Rooms: []config.Room{{Name: "r"}, {Name: "r"}}}}}, true},
+		{"unnamed floor", config.Root{Floors: []config.Floor{{}}}, true},
+		{"unnamed room", config.Root{Floors: []config.Floor{{Name: "g", Rooms: []config.Room{{}}}}}, true},
+		{"same room name on different floors", config.Root{Floors: []config.Floor{
+			{Name: "g", Rooms: []config.Room{{Name: "r"}}},
+			{Name: "f1", Rooms: []config.Room{{Name: "r"}}},
+		}}, false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.cfg.Normalise()
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDriver_RootMetadata(t *testing.T) {
+	a := &countingAnnouncer{}
+	d := newTestDriver(a)
+	cfg := config.Root{
+		NamePrefix: "sim/demo",
+		Metadata:   &metadatapb.Metadata{Appearance: &metadatapb.Metadata_Appearance{Title: "Simulated Building"}},
+		Floors: []config.Floor{{Name: "g", MaxOccupancy: 10,
+			Rooms: []config.Room{{Name: "r", Archetypes: []config.Archetype{{Type: ArchetypePIR}}}}}},
+	}
+	cfg.Name = "sim/demo/driver"
+	cfg.Normalise()
+
+	if err := d.applyConfig(context.Background(), cfg); err != nil {
+		t.Fatalf("applyConfig: %v", err)
+	}
+
+	a.mu.Lock()
+	names := append([]string(nil), a.announced...)
+	a.mu.Unlock()
+	if !slices.Contains(names, "sim/demo/driver") {
+		t.Errorf("driver root device not announced; got %v", names)
+	}
+	if len(names) != 2 { // pir + driver root
+		t.Errorf("announced %d devices, want 2", len(names))
+	}
+
+	d.stop()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.undone != len(names) {
+		t.Errorf("undone %d, want all %d announcements reversed", a.undone, len(names))
+	}
+}
+
+func TestDriver_RunEngineTimeMultiplier(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		d := newTestDriver(&countingAnnouncer{})
+		b := newTestBuilding(d.clk.Now())
+		var published []time.Time
+		b.AddUpdater(updaterFunc(func(now time.Time, _ *Building) {
+			published = append(published, now)
+		}))
+
+		cfg := config.Root{TimeMultiplier: 288}
+		cfg.Normalise() // default 5s tick => 24 simulated minutes per tick
+
+		ctx, cancel := context.WithCancel(t.Context())
+		go d.runEngine(ctx, b, cfg)
+		time.Sleep(11 * time.Second) // two ticks fire, at +5s and +10s
+		cancel()
+		synctest.Wait()
+
+		// One priming publish plus one per tick, each advancing simulated time by
+		// the wall tick scaled by the multiplier.
+		want := []time.Duration{0, 24 * time.Minute, 48 * time.Minute}
+		if len(published) != len(want) {
+			t.Fatalf("publish count = %d, want %d", len(published), len(want))
+		}
+		for i, w := range want {
+			if got := published[i].Sub(published[0]); got != w {
+				t.Errorf("publish %d sim offset = %v, want %v", i, got, w)
+			}
+		}
+	})
+}

--- a/pkg/driver/sim/example_test.go
+++ b/pkg/driver/sim/example_test.go
@@ -1,0 +1,77 @@
+package sim
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim/config"
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim/scale"
+)
+
+// TestExampleConfig guards the shipped example against config drift: it parses the
+// sim driver block from example/config/sim-building and runs the engine briefly.
+func TestExampleConfig(t *testing.T) {
+	const path = "../../../example/config/sim-building/app.conf.json"
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var app struct {
+		Drivers []json.RawMessage `json:"drivers"`
+	}
+	if err := json.Unmarshal(raw, &app); err != nil {
+		t.Fatalf("parse app config: %v", err)
+	}
+
+	var cfg config.Root
+	found := false
+	for _, d := range app.Drivers {
+		var probe struct {
+			Type string `json:"type"`
+		}
+		_ = json.Unmarshal(d, &probe)
+		if probe.Type == DriverName {
+			if err := json.Unmarshal(d, &cfg); err != nil {
+				t.Fatalf("parse sim driver config: %v", err)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("no sim driver in example config")
+	}
+
+	cfg.Normalise()
+	days, err := cfg.WorkingHours.Weekdays()
+	if err != nil {
+		t.Fatalf("working hours: %v", err)
+	}
+	scaler := scale.WorkingHours(cfg.WorkingHours.Start, cfg.WorkingHours.End, days)
+
+	b, devices, err := Expand(cfg, scaler, at(monday, 9, 0))
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	if len(devices) == 0 {
+		t.Fatal("no devices generated")
+	}
+
+	// Run the engine for a simulated hour and confirm it publishes without panicking
+	// and the building draws at least its base load.
+	now := at(monday, 9, 0)
+	b.Publish(now)
+	for i := 0; i < 12; i++ {
+		now = now.Add(5 * time.Minute)
+		b.Tick(now, 5*time.Minute)
+		b.Publish(now)
+	}
+	if b.DemandW < cfg.BaseLoadW {
+		t.Errorf("DemandW = %g, want >= base %g", b.DemandW, cfg.BaseLoadW)
+	}
+	if b.MeterKWh <= 0 {
+		t.Errorf("MeterKWh = %g, want > 0", b.MeterKWh)
+	}
+}

--- a/pkg/driver/sim/expand_test.go
+++ b/pkg/driver/sim/expand_test.go
@@ -1,0 +1,179 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim/config"
+	"github.com/smart-core-os/sc-bos/pkg/driver/sim/scale"
+)
+
+func TestExpand_DeviceGeneration(t *testing.T) {
+	cfg := config.Root{
+		NamePrefix: "sim/demo",
+		Floors: []config.Floor{{
+			Name:         "ground",
+			MaxOccupancy: 60,
+			Rooms: []config.Room{
+				{Name: "open-plan", Archetypes: []config.Archetype{
+					{Type: ArchetypeLighting, Count: 3},
+					{Type: ArchetypePIR},
+					{Type: ArchetypeFCU, Count: 2},
+				}},
+				{Name: "meeting-1", Archetypes: []config.Archetype{
+					{Type: ArchetypeLighting, Count: 2},
+					{Type: ArchetypePIR},
+				}},
+			},
+		}},
+		BuildingDevices: []config.Archetype{
+			{Type: ArchetypeMeter},
+			{Type: ArchetypeElectric},
+		},
+	}
+	cfg.Normalise()
+	scaler := scale.WorkingHours(8, 18, nil)
+
+	b, devices, err := Expand(cfg, scaler, monday)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+
+	// 3+1+2 + 2+1 + 2 = 11 devices.
+	if len(devices) != 11 {
+		t.Errorf("device count = %d, want 11", len(devices))
+	}
+
+	byName := make(map[string]Device, len(devices))
+	for _, d := range devices {
+		byName[d.Name] = d
+	}
+	wantSubsystem := map[string]string{
+		"sim/demo/ground/open-plan/lighting-01": "lighting",
+		"sim/demo/ground/open-plan/lighting-03": "lighting",
+		"sim/demo/ground/open-plan/pir-01":      "sensors",
+		"sim/demo/ground/open-plan/fcu-02":      "hvac",
+		"sim/demo/ground/meeting-1/lighting-02": "lighting",
+		"sim/demo/building/meter-01":            "metering",
+		"sim/demo/building/electric-01":         "metering",
+	}
+	for name, sub := range wantSubsystem {
+		d, ok := byName[name]
+		if !ok {
+			t.Errorf("missing device %q", name)
+			continue
+		}
+		if got := d.Metadata.GetMembership().GetSubsystem(); got != sub {
+			t.Errorf("%q subsystem = %q, want %q", name, got, sub)
+		}
+	}
+
+	// Room max occupancy should be shared evenly across the two rooms (60/2 = 30).
+	for _, r := range b.Floors[0].Rooms {
+		if r.MaxOccupancy != 30 {
+			t.Errorf("room %q MaxOccupancy = %d, want 30", r.Name, r.MaxOccupancy)
+		}
+	}
+
+	// Updaters: one per device that publishes (lighting+fcu+pir = 9 room devices,
+	// meter+electric = 2 building devices) — every device here has at least one.
+	if len(b.updaters) == 0 {
+		t.Error("no updaters registered")
+	}
+}
+
+func TestExpand_UnknownArchetype(t *testing.T) {
+	cfg := config.Root{
+		NamePrefix: "sim/demo",
+		Floors: []config.Floor{{
+			Name: "ground", MaxOccupancy: 10,
+			Rooms: []config.Room{{Name: "r1", Archetypes: []config.Archetype{{Type: "nonsense"}}}},
+		}},
+	}
+	cfg.Normalise()
+	if _, _, err := Expand(cfg, scale.WorkingHours(8, 18, nil), monday); err == nil {
+		t.Fatal("expected error for unknown archetype, got nil")
+	}
+}
+
+func TestExpand_BuildingLevelRoomArchetypeErrors(t *testing.T) {
+	// Room-scoped archetypes have no room when placed in buildingDevices; this must
+	// be a config error rather than a nil-pointer panic on the engine goroutine.
+	for _, typ := range []string{ArchetypeLighting, ArchetypeFCU, ArchetypePIR, ArchetypeMotion, ArchetypeBrightness, ArchetypeAirQuality} {
+		cfg := config.Root{
+			NamePrefix:      "sim/demo",
+			Floors:          []config.Floor{{Name: "g", MaxOccupancy: 10, Rooms: []config.Room{{Name: "r", Archetypes: []config.Archetype{{Type: ArchetypePIR}}}}}},
+			BuildingDevices: []config.Archetype{{Type: typ}},
+		}
+		cfg.Normalise()
+		if _, _, err := Expand(cfg, scale.WorkingHours(8, 18, nil), monday); err == nil {
+			t.Errorf("%s as a building device: expected error, got nil", typ)
+		}
+	}
+}
+
+func TestExpand_SameTypeNumberingContinues(t *testing.T) {
+	// Two archetype entries of the same type in one room (e.g. to mix titles or
+	// rated powers) must not produce colliding device names.
+	cfg := config.Root{
+		NamePrefix: "sim/demo",
+		Floors: []config.Floor{{
+			Name: "g", MaxOccupancy: 10,
+			Rooms: []config.Room{{Name: "r", Archetypes: []config.Archetype{
+				{Type: ArchetypeLighting, Count: 2, Title: "Downlight"},
+				{Type: ArchetypeLighting, Title: "Pendant"},
+			}}},
+		}},
+	}
+	cfg.Normalise()
+	_, devices, err := Expand(cfg, scale.WorkingHours(8, 18, nil), monday)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+
+	want := []string{
+		"sim/demo/g/r/lighting-01",
+		"sim/demo/g/r/lighting-02",
+		"sim/demo/g/r/lighting-03",
+	}
+	if len(devices) != len(want) {
+		t.Fatalf("device count = %d, want %d", len(devices), len(want))
+	}
+	seen := make(map[string]bool, len(devices))
+	for i, d := range devices {
+		if d.Name != want[i] {
+			t.Errorf("device %d name = %q, want %q", i, d.Name, want[i])
+		}
+		if seen[d.Name] {
+			t.Errorf("duplicate device name %q", d.Name)
+		}
+		seen[d.Name] = true
+	}
+	// The title number tracks the device name suffix, not the archetype entry.
+	if got := devices[2].Metadata.GetAppearance().GetTitle(); got != "Pendant 3" {
+		t.Errorf("third device title = %q, want %q", got, "Pendant 3")
+	}
+}
+
+func TestZeroOccupancyRooms(t *testing.T) {
+	// No maxOccupancy anywhere: the pir room is reported, the lighting-only
+	// corridor (sensible without occupants) is not.
+	cfg := config.Root{
+		Floors: []config.Floor{{
+			Name: "g",
+			Rooms: []config.Room{
+				{Name: "office", Archetypes: []config.Archetype{{Type: ArchetypePIR}}},
+				{Name: "corridor", Archetypes: []config.Archetype{{Type: ArchetypeLighting}}},
+			},
+		}},
+	}
+	got := zeroOccupancyRooms(cfg)
+	if len(got) != 1 || got[0] != "g/office" {
+		t.Errorf("zeroOccupancyRooms = %v, want [g/office]", got)
+	}
+
+	// With a floor occupancy to share, nothing is reported.
+	cfg.Floors[0].MaxOccupancy = 10
+	if got := zeroOccupancyRooms(cfg); len(got) != 0 {
+		t.Errorf("zeroOccupancyRooms with occupancy = %v, want none", got)
+	}
+}

--- a/pkg/driver/sim/scale/scale.go
+++ b/pkg/driver/sim/scale/scale.go
@@ -1,0 +1,56 @@
+// Package scale builds the sim driver's configurable working-hours day curve.
+//
+// Where the mock driver uses a single hard-coded NineToFive curve, WorkingHours
+// builds a scaler for configurable working hours and days. Both drivers share the
+// underlying mechanism (the Time/TimeFunc list and the ramp helpers) from
+// pkg/util/timescale.
+package scale
+
+import (
+	"time"
+
+	"github.com/smart-core-os/sc-bos/pkg/util/timescale"
+)
+
+// Time aliases the shared timescale type so sim code can refer to scale.Time.
+type Time = timescale.Time
+
+const (
+	// offPeak is the baseline factor reported outside working hours/days.
+	// Zero means the building is empty overnight and at weekends; base electrical
+	// load still keeps energy use non-zero.
+	offPeak = 0.0
+	// peak is the factor reported during core working hours.
+	peak = 1.0
+	// lunchLow is the factor reached at the bottom of the midday lunch dip.
+	lunchLow = 0.6
+)
+
+// WorkingHours builds a Time scaler that reports higher values during the
+// configured working hours on working days. start and end are hours of the day
+// in 24h decimal form (e.g. 8.5 == 08:30). days lists the working weekdays
+// (empty means Monday–Friday); outside those days the scaler reports offPeak.
+//
+// The curve ramps from offPeak up to peak over the first part of the day, dips
+// to lunchLow around the midpoint, then ramps back down to offPeak by end.
+func WorkingHours(start, end float64, days []time.Weekday) Time {
+	// A degenerate window is treated as "always peak on working days".
+	if end <= start {
+		return Time{timescale.WorkdayRamp(offPeak, peak, days)}
+	}
+
+	rampDur := min((end-start)/4, 2)
+	mid := (start + end) / 2
+	lunchHalf := 0.5
+	if lunchHalf > rampDur {
+		lunchHalf = rampDur / 2
+	}
+
+	return Time{
+		timescale.WorkdayRamp(offPeak, peak, days),                    // non-working day => offPeak, must be first
+		timescale.LinearRampHour(start, start+rampDur, offPeak, peak), // morning ramp up
+		timescale.LinearRampHour(mid-lunchHalf, mid, peak, lunchLow),  // into lunch
+		timescale.LinearRampHour(mid, mid+lunchHalf, lunchLow, peak),  // out of lunch
+		timescale.LinearRampHour(end-rampDur, end, peak, offPeak),     // evening ramp down
+	}
+}

--- a/pkg/driver/sim/scale/scale_test.go
+++ b/pkg/driver/sim/scale/scale_test.go
@@ -1,0 +1,41 @@
+package scale
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWorkingHours(t *testing.T) {
+	mon := time.Date(2024, 1, 8, 0, 0, 0, 0, time.UTC) // Monday
+	sat := time.Date(2024, 1, 13, 0, 0, 0, 0, time.UTC)
+	s := WorkingHours(8, 18, nil)
+
+	at := func(d time.Time, h int) time.Time { return d.Add(time.Duration(h) * time.Hour) }
+
+	if v := s.At(at(sat, 13)); v != offPeak {
+		t.Errorf("weekend midday = %g, want offPeak %g", v, offPeak)
+	}
+	if v := s.At(at(mon, 3)); v != offPeak {
+		t.Errorf("weekday 03:00 = %g, want offPeak %g", v, offPeak)
+	}
+	// 11:00 is past the morning ramp and before the midday lunch dip → peak.
+	peakVal := s.At(at(mon, 11))
+	if peakVal < 0.95 {
+		t.Errorf("weekday 11:00 = %g, want near peak", peakVal)
+	}
+	if morning := s.At(at(mon, 9)); morning <= offPeak || morning >= peakVal {
+		t.Errorf("weekday 09:00 = %g, want ramping between offPeak and peak %g", morning, peakVal)
+	}
+	// Lunch dip: the midpoint (13:00 for an 08:00–18:00 day) is the bottom of the dip.
+	if lunch := s.At(at(mon, 13)); lunch >= peakVal {
+		t.Errorf("lunch dip 13:00 = %g, want below peak %g", lunch, peakVal)
+	}
+}
+
+func TestWorkingHours_CustomDays(t *testing.T) {
+	sun := time.Date(2024, 1, 14, 12, 0, 0, 0, time.UTC) // Sunday
+	s := WorkingHours(9, 17, []time.Weekday{time.Sunday})
+	if v := s.At(sun); v < 0.95 {
+		t.Errorf("Sunday midday with Sunday as a working day = %g, want near peak", v)
+	}
+}

--- a/pkg/driver/sim/updater.go
+++ b/pkg/driver/sim/updater.go
@@ -1,0 +1,20 @@
+package sim
+
+import (
+	"time"
+)
+
+// Updater publishes a slice of building state into a device's trait model.
+// It is invoked on the engine goroutine after each Tick, so implementations may
+// read Building state without locking.
+type Updater interface {
+	Update(now time.Time, b *Building)
+}
+
+// updaterFunc adapts a function to the Updater interface.
+type updaterFunc func(now time.Time, b *Building)
+
+func (f updaterFunc) Update(now time.Time, b *Building) { f(now, b) }
+
+// ptr returns a pointer to v. Used for the many optional (pointer) proto scalar fields.
+func ptr[T any](v T) *T { return &v }

--- a/pkg/util/timescale/timescale.go
+++ b/pkg/util/timescale/timescale.go
@@ -1,0 +1,79 @@
+// Package timescale maps a time-of-day to a [0,1] activity/occupancy factor.
+//
+// It is the shared mechanism behind the mock and sim drivers' day curves: a Time
+// is an ordered list of TimeFuncs, and At returns the value of the first func
+// whose tense is non-positive. The drivers build their own curves on top of the
+// LinearRampHour and WorkdayRamp helpers.
+package timescale
+
+import (
+	"time"
+)
+
+// TimeFunc returns a scale factor based on a time.
+// The scale return value will be in the range [0,1].
+// If t is before the period represented by this scale func, tense will be -1, 0 when during, and 1 when t is after.
+// A tense of 0 should be returned if the func applies to the entire timeline.
+type TimeFunc func(t time.Time) (scale float64, tense int)
+
+// Time scales based on time.Time values.
+// The first entry that returns a non-positive tense return value will have its value returned.
+type Time []TimeFunc
+
+// Now returns a scale factor between [0, 1] for the current time.
+func (s Time) Now() float64 {
+	return s.At(time.Now())
+}
+
+// At returns a scale factor between [0, 1] for the given time.
+func (s Time) At(t time.Time) float64 {
+	var v float64
+	for _, timeFunc := range s {
+		var cmp int
+		v, cmp = timeFunc(t)
+		if cmp <= 0 {
+			return v
+		}
+	}
+	return v
+}
+
+// LinearRampHour returns a TimeFunc that ramps linearly from lo to hi between
+// the from and to hours of the day (24h decimal form, e.g. 8.5 == 08:30). Before
+// from it reports lo with tense -1; after to it reports hi with tense 1.
+func LinearRampHour(from, to, lo, hi float64) TimeFunc {
+	return func(t time.Time) (float64, int) {
+		hour := float64(t.Hour()) + float64(t.Minute())/60.0
+		if hour < from {
+			return lo, -1
+		}
+		if hour > to {
+			return hi, 1
+		}
+		return mapRange(hour, from, to, lo, hi), 0
+	}
+}
+
+// WorkdayRamp reports lo on non-working days (tense 0, terminal) and hi on
+// working days (tense 1, deferring to the hour-based ramps that follow it). days
+// lists the working weekdays; an empty list means Monday–Friday.
+func WorkdayRamp(lo, hi float64, days []time.Weekday) TimeFunc {
+	if len(days) == 0 {
+		days = []time.Weekday{time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday}
+	}
+	working := make(map[time.Weekday]bool, len(days))
+	for _, d := range days {
+		working[d] = true
+	}
+	return func(t time.Time) (float64, int) {
+		if !working[t.Weekday()] {
+			return lo, 0
+		}
+		return hi, 1
+	}
+}
+
+// mapRange maps a value from one range to another.
+func mapRange(value, fromLow, fromHigh, toLow, toHigh float64) float64 {
+	return (value-fromLow)/(fromHigh-fromLow)*(toHigh-toLow) + toLow
+}

--- a/pkg/util/timescale/timescale_test.go
+++ b/pkg/util/timescale/timescale_test.go
@@ -1,0 +1,67 @@
+package timescale
+
+import (
+	"testing"
+	"time"
+)
+
+var (
+	monday   = time.Date(2024, 1, 8, 0, 0, 0, 0, time.UTC) // a Monday
+	saturday = time.Date(2024, 1, 13, 0, 0, 0, 0, time.UTC)
+)
+
+func at(day time.Time, hour int) time.Time {
+	return day.Add(time.Duration(hour) * time.Hour)
+}
+
+func TestAt_ReturnsFirstNonPositiveTense(t *testing.T) {
+	// A func with tense -1 (before its window) should short-circuit; a func with
+	// tense 1 (after) should defer to the next.
+	s := Time{
+		func(time.Time) (float64, int) { return 0.9, 1 },  // defer
+		func(time.Time) (float64, int) { return 0.3, -1 }, // win
+		func(time.Time) (float64, int) { return 0.7, 0 },  // not reached
+	}
+	if v := s.At(monday); v != 0.3 {
+		t.Errorf("At = %g, want 0.3 (first non-positive tense)", v)
+	}
+}
+
+func TestLinearRampHour(t *testing.T) {
+	f := LinearRampHour(8, 10, 0.0, 1.0)
+	cases := []struct {
+		hour      int
+		wantScale float64
+		wantTense int
+	}{
+		{6, 0.0, -1}, // before the window
+		{9, 0.5, 0},  // midway
+		{12, 1.0, 1}, // after the window
+	}
+	for _, c := range cases {
+		scale, tense := f(at(monday, c.hour))
+		if scale != c.wantScale || tense != c.wantTense {
+			t.Errorf("%02d:00 = (%g, %d), want (%g, %d)", c.hour, scale, tense, c.wantScale, c.wantTense)
+		}
+	}
+}
+
+func TestWorkdayRamp_DefaultsToWeekdays(t *testing.T) {
+	f := WorkdayRamp(0.1, 1, nil) // nil => Mon–Fri (the behaviour mock's NineToFive relies on)
+	if scale, tense := f(saturday); scale != 0.1 || tense != 0 {
+		t.Errorf("Saturday = (%g, %d), want (0.1, 0)", scale, tense)
+	}
+	if scale, tense := f(monday); scale != 1 || tense != 1 {
+		t.Errorf("Monday = (%g, %d), want (1, 1)", scale, tense)
+	}
+}
+
+func TestWorkdayRamp_CustomDays(t *testing.T) {
+	f := WorkdayRamp(0, 1, []time.Weekday{time.Saturday})
+	if scale, _ := f(saturday); scale != 1 {
+		t.Errorf("Saturday as a working day = %g, want 1", scale)
+	}
+	if scale, tense := f(monday); scale != 0 || tense != 0 {
+		t.Errorf("Monday (not configured) = (%g, %d), want (0, 0)", scale, tense)
+	}
+}

--- a/ui/ops/.env.sim-building
+++ b/ui/ops/.env.sim-building
@@ -1,0 +1,3 @@
+VITE_GRPC_ENDPOINT=https://localhost:8443
+VITE_AUTH_URL=https://localhost:8443
+VITE_UI_CONFIG_URL=https://localhost:8443/__/sim-building/ui-config.json


### PR DESCRIPTION
[SCB-1049](https://vanti.youtrack.cloud/issue/SCB-1049) 

Add a building simulation driver (pkg/driver/sim): a physically-coupled building simulation configured as floors, rooms and device archetypes rather than an explicit device list. A single engine drives occupancy through the working day, which drives lighting and FCU load, from which electrical demand and metered energy are derived; daylight feeds brightness sensors and occupancy feeds CO2, motion and enter/leave.

Time can be accelerated (timeMultiplier) with per-tick state changes clamped so large steps stay stable. Occupancy uses smoothed targets and hysteresis so steady rooms don't manufacture enter/leave churn. Device names are numbered per location and type, and config validation rejects duplicate or unnamed floors and rooms.

Extract the mock driver's day-curve mechanism into pkg/util/timescale, shared by mock's NineToFive and sim's configurable WorkingHours curve.

Include a self-contained two-floor example (example/config/sim-building) with zones, ui-config and system config, plus run configurations and an ops UI env file for running it locally.