### PR TITLE
fix(proxy): proxy full device metadata, not just traits

### DIFF
--- a/pkg/driver/proxy/driver.go
+++ b/pkg/driver/proxy/driver.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/smart-core-os/sc-bos/pkg/driver"
 	"github.com/smart-core-os/sc-bos/pkg/driver/proxy/config"
@@ -174,16 +175,46 @@ func (p *proxy) announceExplicitDevices(devices []config.Device) {
 
 func (p *proxy) announceChanges(changes <-chan *devicespb.PullDevicesResponse_Change) {
 	announced := announcedTraits{}
+	metadata := announcedMetadata{}
 	defer announced.deleteAll()
+	defer metadata.deleteAll()
 	for change := range changes {
-		p.announceChange(announced, change)
+		p.announceChange(announced, metadata, change)
 	}
 }
 
-func (p *proxy) announceChange(announced announcedTraits, change *devicespb.PullDevicesResponse_Change) {
+func (p *proxy) announceChange(announced announcedTraits, metadata announcedMetadata, change *devicespb.PullDevicesResponse_Change) {
 	needAnnouncing := announced.updateDevice(change.OldValue, change.NewValue)
 	deviceName := change.GetNewValue().GetName() // nil safe way to get the name
 	p.announceTraits(announced, deviceName, needAnnouncing)
+	p.announceMetadata(metadata, change.OldValue, change.NewValue)
+}
+
+// announceMetadata announces the full metadata for a device so that GetMetadata served by this
+// node returns the remote node's metadata (appearance, location, membership, device type, ...)
+// and not just the auto-generated trait list.
+//
+// The node serves the Metadata trait from its local devices collection rather than proxying it
+// (MetadataApi is registered as an unrouted service, see node.New), so the remote metadata must be
+// merged into that collection explicitly - announcing trait clients alone is not enough.
+func (p *proxy) announceMetadata(metadata announcedMetadata, oldDevice, newDevice *devicespb.Device) {
+	if p.skipDevice {
+		return // discovery, and therefore metadata, is suppressed for this node
+	}
+	if newDevice == nil {
+		if oldDevice != nil {
+			metadata.delete(oldDevice.GetName())
+		}
+		return
+	}
+	if oldDevice != nil && proto.Equal(oldDevice.GetMetadata(), newDevice.GetMetadata()) {
+		return // metadata unchanged, leave the existing announcement in place
+	}
+	name := newDevice.GetName()
+	metadata.delete(name) // remove any previous announcement before re-announcing
+	if md := newDevice.GetMetadata(); md != nil {
+		metadata.add(name, p.announcer.Announce(name, node.HasMetadata(md)))
+	}
 }
 
 // Announces traitNames for a deviceName.
@@ -213,6 +244,28 @@ func (p *proxy) announceTraits(announced announcedTraits, deviceName string, tra
 func (p *proxy) Close() error {
 	p.shutdown()
 	return p.conn.Close()
+}
+
+// announcedMetadata tracks the metadata announcement made per device name so it can be updated
+// or removed as the remote node's devices change.
+type announcedMetadata map[string]node.Undo
+
+func (a announcedMetadata) add(name string, undo node.Undo) {
+	a[name] = undo
+}
+
+func (a announcedMetadata) delete(name string) {
+	if undo, ok := a[name]; ok {
+		undo()
+		delete(a, name)
+	}
+}
+
+func (a announcedMetadata) deleteAll() {
+	for name, undo := range a {
+		undo()
+		delete(a, name)
+	}
 }
 
 // deviceTrait is used as a map key to uniquely identify a device+trait pair.

--- a/pkg/driver/proxy/driver.go
+++ b/pkg/driver/proxy/driver.go
@@ -138,9 +138,10 @@ func proxyTLSConfig(tlsConfig *tls.Config, n config.Node) *tls.Config {
 	return tlsConfig
 }
 
-// proxy manages updates to the announced traits of any proxied devices for a single node.
+// proxy manages updates to the announced traits and metadata of any proxied devices for a single node.
 // At a high level it subscribes to changes in the node's devices,
-// when new devices are added, it announces them on this node,
+// when new devices are added, it announces their traits and metadata on this node,
+// when their metadata changes, it re-announces it,
 // when devices are removed, it removes them from this node too.
 type proxy struct {
 	config     config.Node

--- a/pkg/driver/proxy/driver_test.go
+++ b/pkg/driver/proxy/driver_test.go
@@ -95,10 +95,11 @@ func Test_proxy_announceChange(t *testing.T) {
 		logger:    zap.NewNop(),
 	}
 	known := announcedTraits{}
+	knownMetadata := announcedMetadata{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			proxy.announceChange(known, tt.change)
+			proxy.announceChange(known, knownMetadata, tt.change)
 
 			for _, ct := range tt.wantPresent {
 				if _, ok := known[ct]; !ok {
@@ -113,6 +114,96 @@ func Test_proxy_announceChange(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_proxy_announceMetadata(t *testing.T) {
+	dev := func(name, title string) *devicespb.Device {
+		return &devicespb.Device{
+			Name:     name,
+			Metadata: &metadatapb.Metadata{Appearance: &metadatapb.Metadata_Appearance{Title: title}},
+		}
+	}
+
+	t.Run("announces metadata for new device", func(t *testing.T) {
+		announcer := &testAnnouncer{}
+		p := &proxy{announcer: announcer, logger: zap.NewNop()}
+		meta := announcedMetadata{}
+
+		p.announceMetadata(meta, nil, dev("device01", "Device 01"))
+
+		if _, ok := meta["device01"]; !ok {
+			t.Fatalf("expected device01 metadata to be tracked, got %v", meta)
+		}
+		if len(*announcer) != 1 {
+			t.Fatalf("expected 1 announcement, got %d", len(*announcer))
+		}
+		if got := (*announcer)[0].name; got != "device01" {
+			t.Errorf("announced name = %q, want device01", got)
+		}
+	})
+
+	t.Run("unchanged metadata is not re-announced", func(t *testing.T) {
+		announcer := &testAnnouncer{}
+		p := &proxy{announcer: announcer, logger: zap.NewNop()}
+		meta := announcedMetadata{}
+
+		old := dev("device01", "Device 01")
+		p.announceMetadata(meta, nil, old)
+		p.announceMetadata(meta, old, dev("device01", "Device 01"))
+
+		if len(*announcer) != 1 {
+			t.Fatalf("expected metadata to be announced once, got %d announcements", len(*announcer))
+		}
+	})
+
+	t.Run("changed metadata is re-announced", func(t *testing.T) {
+		announcer := &testAnnouncer{}
+		p := &proxy{announcer: announcer, logger: zap.NewNop()}
+		meta := announcedMetadata{}
+
+		old := dev("device01", "Device 01")
+		p.announceMetadata(meta, nil, old)
+		p.announceMetadata(meta, old, dev("device01", "Renamed"))
+
+		if len(*announcer) != 2 {
+			t.Fatalf("expected metadata to be announced twice, got %d", len(*announcer))
+		}
+		if (*announcer)[0].undone != 1 {
+			t.Errorf("expected the stale metadata announcement to be undone once, got %d", (*announcer)[0].undone)
+		}
+	})
+
+	t.Run("removed device undoes metadata", func(t *testing.T) {
+		announcer := &testAnnouncer{}
+		p := &proxy{announcer: announcer, logger: zap.NewNop()}
+		meta := announcedMetadata{}
+
+		old := dev("device01", "Device 01")
+		p.announceMetadata(meta, nil, old)
+		p.announceMetadata(meta, old, nil)
+
+		if _, ok := meta["device01"]; ok {
+			t.Errorf("expected device01 metadata to be forgotten, got %v", meta)
+		}
+		if (*announcer)[0].undone != 1 {
+			t.Errorf("expected metadata announcement to be undone, got %d", (*announcer)[0].undone)
+		}
+	})
+
+	t.Run("skipDevice suppresses metadata", func(t *testing.T) {
+		announcer := &testAnnouncer{}
+		p := &proxy{announcer: announcer, logger: zap.NewNop(), skipDevice: true}
+		meta := announcedMetadata{}
+
+		p.announceMetadata(meta, nil, dev("device01", "Device 01"))
+
+		if len(*announcer) != 0 {
+			t.Fatalf("expected no announcements when skipDevice is set, got %d", len(*announcer))
+		}
+		if len(meta) != 0 {
+			t.Errorf("expected no tracked metadata when skipDevice is set, got %v", meta)
+		}
+	})
 }
 
 func TestAnnouncedTraits_UpdateDevice(t *testing.T) {


### PR DESCRIPTION
Previously, proxied devices only had the auto-generated trait list announced, leaving appearance, location, membership and device_type empty after proxying.
Announce the remote device's full metadata via node.HasMetadata (as the gateway does), 