### PR TITLE
dataretention: add other_used and available to DataRetentionBytes

### DIFF
--- a/pkg/history/dataretention/sqlite.go
+++ b/pkg/history/dataretention/sqlite.go
@@ -71,8 +71,10 @@ func updateSqliteModel(ctx context.Context, s *stores.Stores, model *dataretenti
 	usedItems := uint64(count)
 
 	bytesMsg := &dataretentionpb.DataRetentionBytes{Used: &used}
-	if cap, _, ok := diskCapacity(dataDir, used); ok {
+	if cap, otherUsed, available, ok := diskCapacity(dataDir, used); ok {
 		bytesMsg.Capacity = &cap
+		bytesMsg.OtherUsed = &otherUsed
+		bytesMsg.Available = &available
 	}
 
 	_, _ = model.SetDataRetention(&dataretentionpb.DataRetention{

--- a/pkg/history/dataretention/sqlite_test.go
+++ b/pkg/history/dataretention/sqlite_test.go
@@ -62,6 +62,12 @@ func TestUpdateSqliteModel_DiskCapacity(t *testing.T) {
 	if got.Bytes.Capacity == nil || *got.Bytes.Capacity == 0 {
 		t.Error("expected non-zero bytes.capacity from disk stats")
 	}
+	if got.Bytes.OtherUsed == nil {
+		t.Error("expected bytes.other_used to be populated from disk stats")
+	}
+	if got.Bytes.Available == nil {
+		t.Error("expected bytes.available to be populated from disk stats")
+	}
 }
 
 func TestSqliteBackend_Purge_All(t *testing.T) {

--- a/pkg/history/dataretention/statfs.go
+++ b/pkg/history/dataretention/statfs.go
@@ -4,16 +4,26 @@ package dataretention
 
 import "syscall"
 
-// diskCapacity returns the total disk capacity and utilisation for the filesystem
-// containing dataDir, expressed relative to the current DB size.
+// diskCapacity returns, for the filesystem containing dataDir:
+//   - capacity:  total size of the filesystem
+//   - otherUsed: bytes used by data other than this store (total used minus dbUsedBytes),
+//     clamped to zero if disk accounting would produce a negative value
+//   - available: bytes still writable by this store, excluding blocks reserved for root
+//     (so it may be less than capacity - dbUsedBytes - otherUsed)
+//
 // Returns ok=false if the stats cannot be determined.
-func diskCapacity(dataDir string, dbUsedBytes uint64) (capacity uint64, utilization float32, ok bool) {
+func diskCapacity(dataDir string, dbUsedBytes uint64) (capacity uint64, otherUsed uint64, available uint64, ok bool) {
 	var st syscall.Statfs_t
 	if err := syscall.Statfs(dataDir, &st); err != nil || st.Bsize <= 0 || st.Blocks == 0 {
 		return
 	}
-	capacity = st.Blocks * uint64(st.Bsize)
-	utilization = float32(dbUsedBytes) / float32(capacity) * 100
+	bsize := uint64(st.Bsize)
+	capacity = st.Blocks * bsize
+	diskUsed := (st.Blocks - st.Bfree) * bsize
+	if diskUsed > dbUsedBytes {
+		otherUsed = diskUsed - dbUsedBytes
+	}
+	available = st.Bavail * bsize
 	ok = true
 	return
 }

--- a/pkg/history/dataretention/statfs_windows.go
+++ b/pkg/history/dataretention/statfs_windows.go
@@ -3,6 +3,6 @@
 package dataretention
 
 // diskCapacity is not supported on Windows; always returns ok=false.
-func diskCapacity(_ string, _ uint64) (capacity uint64, utilization float32, ok bool) {
+func diskCapacity(_ string, _ uint64) (capacity uint64, otherUsed uint64, available uint64, ok bool) {
 	return
 }

--- a/pkg/proto/dataretentionpb/data_retention.pb.go
+++ b/pkg/proto/dataretentionpb/data_retention.pb.go
@@ -79,12 +79,32 @@ func (x *DataRetention) GetItems() *DataRetentionItems {
 }
 
 // DataRetentionBytes describes storage consumption measured in bytes.
+//
+// The fields partition the storage backing this store:
+//
+//	capacity = used + other_used + available + reserved
+//
+// where reserved is space that exists but this store cannot use (e.g. filesystem
+// blocks reserved for root). When the relevant fields are present, clients can derive:
+//
+//	space free to this store = available
+//	store fullness           = used / (used + available)                          // 0 when empty, 100 when this store can grow no further
+//	disk fullness (df Use%)  = (used + other_used) / (used + other_used + available)
 type DataRetentionBytes struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Bytes currently in use.
+	// Bytes currently in use by this data store.
 	Used *uint64 `protobuf:"varint,1,opt,name=used,proto3,oneof" json:"used,omitempty"`
-	// Total capacity in bytes. Omit if unlimited or unknown.
-	Capacity      *uint64 `protobuf:"varint,2,opt,name=capacity,proto3,oneof" json:"capacity,omitempty"`
+	// Total capacity in bytes of the volume backing this store: the effective limit it
+	// can grow into. For a filesystem-backed store this is the size of the containing
+	// filesystem, which reflects a volume/quota limit when that limit is enforced at the
+	// filesystem level. Omit if unlimited or unknown.
+	Capacity *uint64 `protobuf:"varint,2,opt,name=capacity,proto3,oneof" json:"capacity,omitempty"`
+	// Bytes used by other data sharing the same volume (i.e. not this data store).
+	OtherUsed *uint64 `protobuf:"varint,3,opt,name=other_used,json=otherUsed,proto3,oneof" json:"other_used,omitempty"`
+	// Bytes this store can still write before reaching capacity. Excludes space that
+	// exists but is unusable by this store (e.g. filesystem blocks reserved for root),
+	// so it may be less than capacity - used - other_used. Omit if unknown.
+	Available     *uint64 `protobuf:"varint,4,opt,name=available,proto3,oneof" json:"available,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -129,6 +149,20 @@ func (x *DataRetentionBytes) GetUsed() uint64 {
 func (x *DataRetentionBytes) GetCapacity() uint64 {
 	if x != nil && x.Capacity != nil {
 		return *x.Capacity
+	}
+	return 0
+}
+
+func (x *DataRetentionBytes) GetOtherUsed() uint64 {
+	if x != nil && x.OtherUsed != nil {
+		return *x.OtherUsed
+	}
+	return 0
+}
+
+func (x *DataRetentionBytes) GetAvailable() uint64 {
+	if x != nil && x.Available != nil {
+		return *x.Available
 	}
 	return 0
 }
@@ -729,12 +763,18 @@ const file_smartcore_bos_dataretention_v1_data_retention_proto_rawDesc = "" +
 	"3smartcore/bos/dataretention/v1/data_retention.proto\x12\x1esmartcore.bos.dataretention.v1\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa3\x01\n" +
 	"\rDataRetention\x12H\n" +
 	"\x05bytes\x18\x01 \x01(\v22.smartcore.bos.dataretention.v1.DataRetentionBytesR\x05bytes\x12H\n" +
-	"\x05items\x18\x02 \x01(\v22.smartcore.bos.dataretention.v1.DataRetentionItemsR\x05items\"d\n" +
+	"\x05items\x18\x02 \x01(\v22.smartcore.bos.dataretention.v1.DataRetentionItemsR\x05items\"\xc8\x01\n" +
 	"\x12DataRetentionBytes\x12\x17\n" +
 	"\x04used\x18\x01 \x01(\x04H\x00R\x04used\x88\x01\x01\x12\x1f\n" +
-	"\bcapacity\x18\x02 \x01(\x04H\x01R\bcapacity\x88\x01\x01B\a\n" +
+	"\bcapacity\x18\x02 \x01(\x04H\x01R\bcapacity\x88\x01\x01\x12\"\n" +
+	"\n" +
+	"other_used\x18\x03 \x01(\x04H\x02R\totherUsed\x88\x01\x01\x12!\n" +
+	"\tavailable\x18\x04 \x01(\x04H\x03R\tavailable\x88\x01\x01B\a\n" +
 	"\x05_usedB\v\n" +
-	"\t_capacity\"d\n" +
+	"\t_capacityB\r\n" +
+	"\v_other_usedB\f\n" +
+	"\n" +
+	"_available\"d\n" +
 	"\x12DataRetentionItems\x12\x17\n" +
 	"\x04used\x18\x01 \x01(\x04H\x00R\x04used\x88\x01\x01\x12\x1f\n" +
 	"\bcapacity\x18\x02 \x01(\x04H\x01R\bcapacity\x88\x01\x01B\a\n" +

--- a/proto/smartcore/bos/dataretention/v1/data_retention.proto
+++ b/proto/smartcore/bos/dataretention/v1/data_retention.proto
@@ -33,11 +33,28 @@ message DataRetention {
 }
 
 // DataRetentionBytes describes storage consumption measured in bytes.
+//
+// The fields partition the storage backing this store:
+//   capacity = used + other_used + available + reserved
+// where reserved is space that exists but this store cannot use (e.g. filesystem
+// blocks reserved for root). When the relevant fields are present, clients can derive:
+//   space free to this store = available
+//   store fullness           = used / (used + available)                          // 0 when empty, 100 when this store can grow no further
+//   disk fullness (df Use%)  = (used + other_used) / (used + other_used + available)
 message DataRetentionBytes {
-  // Bytes currently in use.
+  // Bytes currently in use by this data store.
   optional uint64 used = 1;
-  // Total capacity in bytes. Omit if unlimited or unknown.
+  // Total capacity in bytes of the volume backing this store: the effective limit it
+  // can grow into. For a filesystem-backed store this is the size of the containing
+  // filesystem, which reflects a volume/quota limit when that limit is enforced at the
+  // filesystem level. Omit if unlimited or unknown.
   optional uint64 capacity = 2;
+  // Bytes used by other data sharing the same volume (i.e. not this data store).
+  optional uint64 other_used = 3;
+  // Bytes this store can still write before reaching capacity. Excludes space that
+  // exists but is unusable by this store (e.g. filesystem blocks reserved for root),
+  // so it may be less than capacity - used - other_used. Omit if unknown.
+  optional uint64 available = 4;
 }
 
 // DataRetentionItems describes storage consumption measured in discrete items

--- a/ui/ui-gen/proto/smartcore/bos/dataretention/v1/data_retention_pb.d.ts
+++ b/ui/ui-gen/proto/smartcore/bos/dataretention/v1/data_retention_pb.d.ts
@@ -41,6 +41,16 @@ export class DataRetentionBytes extends jspb.Message {
   hasCapacity(): boolean;
   clearCapacity(): DataRetentionBytes;
 
+  getOtherUsed(): number;
+  setOtherUsed(value: number): DataRetentionBytes;
+  hasOtherUsed(): boolean;
+  clearOtherUsed(): DataRetentionBytes;
+
+  getAvailable(): number;
+  setAvailable(value: number): DataRetentionBytes;
+  hasAvailable(): boolean;
+  clearAvailable(): DataRetentionBytes;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): DataRetentionBytes.AsObject;
   static toObject(includeInstance: boolean, msg: DataRetentionBytes): DataRetentionBytes.AsObject;
@@ -53,6 +63,8 @@ export namespace DataRetentionBytes {
   export type AsObject = {
     used?: number;
     capacity?: number;
+    otherUsed?: number;
+    available?: number;
   };
 
   export enum UsedCase {
@@ -63,6 +75,16 @@ export namespace DataRetentionBytes {
   export enum CapacityCase {
     _CAPACITY_NOT_SET = 0,
     CAPACITY = 2,
+  }
+
+  export enum OtherUsedCase {
+    _OTHER_USED_NOT_SET = 0,
+    OTHER_USED = 3,
+  }
+
+  export enum AvailableCase {
+    _AVAILABLE_NOT_SET = 0,
+    AVAILABLE = 4,
   }
 }
 

--- a/ui/ui-gen/proto/smartcore/bos/dataretention/v1/data_retention_pb.js
+++ b/ui/ui-gen/proto/smartcore/bos/dataretention/v1/data_retention_pb.js
@@ -540,7 +540,9 @@ proto.smartcore.bos.dataretention.v1.DataRetentionBytes.prototype.toObject = fun
 proto.smartcore.bos.dataretention.v1.DataRetentionBytes.toObject = function(includeInstance, msg) {
   var f, obj = {
 used: (f = jspb.Message.getField(msg, 1)) == null ? undefined : f,
-capacity: (f = jspb.Message.getField(msg, 2)) == null ? undefined : f
+capacity: (f = jspb.Message.getField(msg, 2)) == null ? undefined : f,
+otherUsed: (f = jspb.Message.getField(msg, 3)) == null ? undefined : f,
+available: (f = jspb.Message.getField(msg, 4)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -585,6 +587,14 @@ proto.smartcore.bos.dataretention.v1.DataRetentionBytes.deserializeBinaryFromRea
       var value = /** @type {number} */ (reader.readUint64());
       msg.setCapacity(value);
       break;
+    case 3:
+      var value = /** @type {number} */ (reader.readUint64());
+      msg.setOtherUsed(value);
+      break;
+    case 4:
+      var value = /** @type {number} */ (reader.readUint64());
+      msg.setAvailable(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -625,6 +635,20 @@ proto.smartcore.bos.dataretention.v1.DataRetentionBytes.serializeBinaryToWriter 
   if (f != null) {
     writer.writeUint64(
       2,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 3));
+  if (f != null) {
+    writer.writeUint64(
+      3,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 4));
+  if (f != null) {
+    writer.writeUint64(
+      4,
       f
     );
   }
@@ -700,6 +724,78 @@ proto.smartcore.bos.dataretention.v1.DataRetentionBytes.prototype.clearCapacity 
  */
 proto.smartcore.bos.dataretention.v1.DataRetentionBytes.prototype.hasCapacity = function() {
   return jspb.Message.getField(this, 2) != null;
+};
+
+
+/**
+ * optional uint64 other_used = 3;
+ * @return {number}
+ */
+proto.smartcore.bos.dataretention.v1.DataRetentionBytes.prototype.getOtherUsed = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.smartcore.bos.dataretention.v1.DataRetentionBytes} returns this
+ */
+proto.smartcore.bos.dataretention.v1.DataRetentionBytes.prototype.setOtherUsed = function(value) {
+  return jspb.Message.setField(this, 3, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.smartcore.bos.dataretention.v1.DataRetentionBytes} returns this
+ */
+proto.smartcore.bos.dataretention.v1.DataRetentionBytes.prototype.clearOtherUsed = function() {
+  return jspb.Message.setField(this, 3, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.dataretention.v1.DataRetentionBytes.prototype.hasOtherUsed = function() {
+  return jspb.Message.getField(this, 3) != null;
+};
+
+
+/**
+ * optional uint64 available = 4;
+ * @return {number}
+ */
+proto.smartcore.bos.dataretention.v1.DataRetentionBytes.prototype.getAvailable = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 4, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.smartcore.bos.dataretention.v1.DataRetentionBytes} returns this
+ */
+proto.smartcore.bos.dataretention.v1.DataRetentionBytes.prototype.setAvailable = function(value) {
+  return jspb.Message.setField(this, 4, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.smartcore.bos.dataretention.v1.DataRetentionBytes} returns this
+ */
+proto.smartcore.bos.dataretention.v1.DataRetentionBytes.prototype.clearAvailable = function() {
+  return jspb.Message.setField(this, 4, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.smartcore.bos.dataretention.v1.DataRetentionBytes.prototype.hasAvailable = function() {
+  return jspb.Message.getField(this, 4) != null;
 };
 
 


### PR DESCRIPTION
## What

Adds `other_used` and `available` to the `DataRetentionBytes` trait message so clients can fully describe disk usage. The fields now partition the storage backing a store:

```
capacity = used + other_used + available + reserved
```

where `reserved` is space that exists but the store cannot use (e.g. filesystem blocks reserved for root). Clients can derive:

- **free space to this store** = `available`
- **store fullness** = `used / (used + available)` — 0 when empty, 100 when the store can grow no further
- **disk fullness (df `Use%`)** = `(used + other_used) / (used + other_used + available)`

## Why

Follows up on the review of #872, which noted that the SQLite health check measures whole-disk utilisation while the `DataRetention` trait previously exposed only DB usage vs total capacity. A disk full of *other* data would therefore show low trait usage but high health-check utilisation — confusing to the user.

- `other_used` (the reviewer's suggestion) distinguishes bytes used by the DB from bytes used by other data sharing the same volume.
- `available` is the keystone for *full* disk reporting: the headroom the store can actually write before hitting capacity, excluding space that exists but is unusable (root-reserved blocks). It is **not** derivable from the other three fields, and it lets the trait reproduce `df`'s `Use%` exactly and report correctly under **container volumes/quotas**, where `available` captures the real headroom.

## Changes

- `data_retention.proto`: add `available = 4`; document the partition; clarify `capacity` semantics.
- SQLite store populates `capacity`, `other_used`, and `available` from `statfs` (`available = Bavail × bsize`).
- Regenerated Go and UI proto bindings.

## Notes

- This only extends the **trait definition** — it does not modify #872. Wiring the health check to consume these fields (so its reported number matches the trait) and the `tickInterval` nit remain to be done on #872.
- `go build`, `go vet`, and `go test -short ./pkg/history/dataretention/` pass.
