### PR TITLE
driver/bacnet: fix nil error panic in trait fault check

### DIFF
--- a/pkg/driver/bacnet/merge/fan_speed.go
+++ b/pkg/driver/bacnet/merge/fan_speed.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/smart-core-os/gobacnet"
@@ -128,9 +129,13 @@ func (t *fanSpeed) speedToPreset(speed float32) string {
 // pollPeer fetches data from the peer device and saves the data locally.
 func (t *fanSpeed) pollPeer(ctx context.Context) (*fanspeedpb.FanSpeed, error) {
 	speed, err := readPropertyFloat32(ctx, t.client, t.known, *t.config.Speed)
-	updateTraitFaultCheck(ctx, t.faultCheck, t.config.Name, trait.FanSpeed, []error{err})
+	var errs []error
 	if err != nil {
-		return nil, comm.ErrReadProperty{Prop: "speed", Cause: err}
+		errs = append(errs, comm.ErrReadProperty{Prop: "speed", Cause: err})
+	}
+	updateTraitFaultCheck(ctx, t.faultCheck, t.config.Name, trait.FanSpeed, errs)
+	if len(errs) > 0 {
+		return nil, multierr.Combine(errs...)
 	}
 	data := &fanspeedpb.FanSpeed{
 		Percentage: speed,

--- a/pkg/driver/bacnet/merge/trait.go
+++ b/pkg/driver/bacnet/merge/trait.go
@@ -74,19 +74,21 @@ func updateTraitFaultCheck(_ context.Context, faultCheck *healthpb.FaultCheck, n
 	if faultCheck == nil {
 		return
 	}
-	if len(errs) == 0 {
-		// Clear any existing fault for this trait.
-		faultCheck.ClearFaults()
-		return
-	}
 
 	var descriptions []string
 	for _, err := range errs {
+		if err == nil {
+			continue
+		}
 		descriptions = append(descriptions, err.Error())
-
+	}
+	if len(descriptions) == 0 {
+		// No (non-nil) errors, clear any existing fault for this trait.
+		faultCheck.ClearFaults()
+		return
 	}
 	faultCheck.SetFault(&healthpb.HealthCheck_Error{
-		SummaryText: fmt.Sprintf("%s[%s] has %d errors", name, trait.String(), len(errs)),
+		SummaryText: fmt.Sprintf("%s[%s] has %d errors", name, trait.String(), len(descriptions)),
 		DetailsText: fmt.Sprintf("Trait %s errors: %s", trait, strings.Join(descriptions, "; ")),
 		Code: &healthpb.HealthCheck_Error_Code{
 			Code:   BacNetCommsError,

--- a/pkg/driver/bacnet/merge/trait_test.go
+++ b/pkg/driver/bacnet/merge/trait_test.go
@@ -1,0 +1,93 @@
+package merge
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
+	"github.com/smart-core-os/sc-bos/pkg/trait"
+)
+
+// newTestFaultCheck returns a FaultCheck and a getter for its current state.
+func newTestFaultCheck(t *testing.T) (*healthpb.FaultCheck, func() *healthpb.HealthCheck) {
+	t.Helper()
+	reg := healthpb.NewRegistry()
+	hc := &healthpb.HealthCheck{Id: "trait"}
+	fc, err := reg.ForOwner("test").NewFaultCheck("dev", hc)
+	if err != nil {
+		t.Fatalf("NewFaultCheck: %v", err)
+	}
+	id := hc.Id // adjusted to the absolute id during NewFaultCheck
+	return fc, func() *healthpb.HealthCheck {
+		return reg.GetCheck("dev", id)
+	}
+}
+
+func TestUpdateTraitFaultCheck(t *testing.T) {
+	realErr := errors.New("boom")
+	tests := []struct {
+		name      string
+		errs      []error
+		wantFault bool
+	}{
+		{"nil slice", nil, false},
+		{"empty slice", []error{}, false},
+		// Regression: fanSpeed passed []error{err} even when err was nil, which
+		// used to bypass the empty-check and panic on err.Error().
+		{"single nil error", []error{nil}, false},
+		{"multiple nil errors", []error{nil, nil}, false},
+		{"single real error", []error{realErr}, true},
+		{"nil and real error", []error{nil, realErr}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc, get := newTestFaultCheck(t)
+			updateTraitFaultCheck(context.Background(), fc, "dev", trait.FanSpeed, tt.errs)
+			faults := get().GetFaults().GetCurrentFaults()
+			if gotFault := len(faults) > 0; gotFault != tt.wantFault {
+				t.Errorf("got fault=%v (%d faults), want fault=%v", gotFault, len(faults), tt.wantFault)
+			}
+		})
+	}
+}
+
+// TestUpdateTraitFaultCheck_NilFaultCheck verifies a nil FaultCheck is a no-op
+// rather than a panic, even with real errors present.
+func TestUpdateTraitFaultCheck_NilFaultCheck(t *testing.T) {
+	updateTraitFaultCheck(context.Background(), nil, "dev", trait.FanSpeed, []error{errors.New("boom")})
+}
+
+// TestUpdateTraitFaultCheck_CountsOnlyNonNil verifies nil errors are excluded
+// from the fault description and the reported error count.
+func TestUpdateTraitFaultCheck_CountsOnlyNonNil(t *testing.T) {
+	fc, get := newTestFaultCheck(t)
+	errs := []error{nil, errors.New("boom"), nil}
+	updateTraitFaultCheck(context.Background(), fc, "dev", trait.FanSpeed, errs)
+
+	faults := get().GetFaults().GetCurrentFaults()
+	if len(faults) != 1 {
+		t.Fatalf("want 1 fault, got %d", len(faults))
+	}
+	if got, want := faults[0].GetSummaryText(), "has 1 errors"; !strings.Contains(got, want) {
+		t.Errorf("summary %q does not contain %q", got, want)
+	}
+}
+
+// TestUpdateTraitFaultCheck_ClearsOnSuccess mirrors a fanSpeed poll recovering:
+// a fault is set, then a subsequent successful poll (err == nil) clears it.
+func TestUpdateTraitFaultCheck_ClearsOnSuccess(t *testing.T) {
+	fc, get := newTestFaultCheck(t)
+
+	updateTraitFaultCheck(context.Background(), fc, "dev", trait.FanSpeed, []error{errors.New("boom")})
+	if n := len(get().GetFaults().GetCurrentFaults()); n != 1 {
+		t.Fatalf("setup: want 1 fault, got %d", n)
+	}
+
+	// A recovered poll: fanSpeed would have passed []error{nil} here pre-fix.
+	updateTraitFaultCheck(context.Background(), fc, "dev", trait.FanSpeed, []error{nil})
+	if n := len(get().GetFaults().GetCurrentFaults()); n != 0 {
+		t.Errorf("want fault cleared, got %d faults", n)
+	}
+}


### PR DESCRIPTION
## Problem

A BACnet area controller panicked with a nil pointer dereference during a fan speed poll:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 ...]
...merge.updateTraitFaultCheck(...) trait.go:85
...merge.(*fanSpeed).pollPeer(...) fan_speed.go:131
```

## Root cause

`fanSpeed.pollPeer` always wrapped its read error into a one-element slice — `updateTraitFaultCheck(..., []error{err})` — even on the happy path. When the read succeeded, `err == nil`, so the slice was `[]error{nil}` (length 1, not 0).

Inside `updateTraitFaultCheck`, the `len(errs) == 0` guard was therefore skipped, the loop ran, and `err.Error()` was called on a nil `error` interface — a nil pointer dereference.

`fanSpeed` was the only trait that did this; every other trait builds its `errs` slice by appending only non-nil errors.

## Changes

- **`trait.go`** — `updateTraitFaultCheck` now skips nil errors when building descriptions and decides clear-vs-set faults on the count of non-nil errors. This protects all callers, current and future. The reported error count uses the filtered count too.
- **`fan_speed.go`** — rewrote the call site to match every other trait: accumulate only non-nil errors and return `multierr.Combine(errs...)`.
- **`trait_test.go`** — new tests covering the regression (`[]error{nil}`), nil-`FaultCheck` no-op, non-nil error counting, and fault clearing on a recovered poll. Verified the regression test reproduces the exact production panic against the pre-fix code.