### PR TITLE
download: accept HMAC keys of at least 32 bytes

### DIFF
--- a/internal/download/sign.go
+++ b/internal/download/sign.go
@@ -33,19 +33,28 @@ type Signer interface {
 	Verify(data, signature []byte) error
 }
 
+// keySize is the length of keys produced by GenerateHMACKey.
 const keySize = sha256.Size
+
+// minKeySize is the minimum accepted HMAC key length. HMAC-SHA256 accepts keys
+// of any length (RFC 2104) — longer keys are reduced internally, shorter ones
+// zero-padded — so we only enforce a lower bound for entropy: at least the hash
+// output size (32 bytes / 256 bits). This admits previously valid keys, such as
+// 64-byte (block-sized) keys, that an exact-length check would wrongly reject.
+const minKeySize = keySize
 
 // HMACSigner is a Signer using HMAC-SHA256.
 type HMACSigner struct {
 	key []byte
 }
 
-// NewHMACSigner returns an HMACSigner with the given key. The key must be
-// exactly 32 bytes of cryptographically random data (e.g. from crypto/rand).
+// NewHMACSigner returns an HMACSigner with the given key. The key must be at
+// least 32 bytes of cryptographically random data (e.g. from crypto/rand);
+// longer keys are accepted.
 //
-// Panics if key has incorrect length.
+// Panics if key is too short.
 func NewHMACSigner(key []byte) *HMACSigner {
-	if len(key) != keySize {
+	if len(key) < minKeySize {
 		panic(errInvalidHMACKey)
 	}
 	return &HMACSigner{key: key}
@@ -74,16 +83,18 @@ func GenerateHMACKey() []byte {
 	return key
 }
 
-// LoadHMACKey loads a 32-byte hexadecimal-encoded HMAC key from a buffer.
+// LoadHMACKey loads a hexadecimal-encoded HMAC key from a buffer.
 //
-// The buffer must be exactly the right length, except for whitespace, which is ignored.
+// The decoded key must be at least 32 bytes; longer keys are accepted, matching
+// HMAC-SHA256's support for keys of any length. Whitespace surrounding the hex
+// string is ignored.
 func LoadHMACKey(buf []byte) ([]byte, error) {
 	str := strings.TrimSpace(string(buf))
 	key, err := hex.DecodeString(str)
 	if err != nil {
 		return nil, err
 	}
-	if len(key) != keySize {
+	if len(key) < minKeySize {
 		return nil, errInvalidHMACKey
 	}
 	return key, nil

--- a/internal/download/sign_test.go
+++ b/internal/download/sign_test.go
@@ -65,6 +65,37 @@ func TestHMACSigner_DifferentKeys(t *testing.T) {
 	}
 }
 
+func TestNewHMACSigner_KeyLengths(t *testing.T) {
+	// Keys at or above the minimum (32 bytes) are accepted, including the
+	// 64-byte keys that were valid before the exact-length check was added.
+	for _, n := range []int{32, 33, 64, 128} {
+		key := make([]byte, n)
+		if _, err := rand.Read(key); err != nil {
+			t.Fatal(err)
+		}
+		s := NewHMACSigner(key)
+		sig, err := s.Sign([]byte("hello"))
+		if err != nil {
+			t.Fatalf("Sign with %d-byte key: %v", n, err)
+		}
+		if err := s.Verify([]byte("hello"), sig); err != nil {
+			t.Fatalf("Verify with %d-byte key: %v", n, err)
+		}
+	}
+
+	// Keys shorter than the minimum panic.
+	for _, n := range []int{0, 16, 31} {
+		t.Run("panics on short key", func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("NewHMACSigner(%d-byte key) did not panic", n)
+				}
+			}()
+			NewHMACSigner(make([]byte, n))
+		})
+	}
+}
+
 func TestGenerateHMACKey(t *testing.T) {
 	key := GenerateHMACKey()
 	if len(key) != 32 {
@@ -76,11 +107,19 @@ func TestGenerateHMACKey(t *testing.T) {
 }
 
 func TestLoadHMACKey(t *testing.T) {
-	keyBytes := bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 8)
+	keyBytes := bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 8) // 32 bytes
 	keyHexLower := hex.EncodeToString(keyBytes)
 	keyHexUpper := strings.ToUpper(hex.EncodeToString(keyBytes))
-	keyHexShort := keyHexLower[:len(keyHexLower)-1]
-	keyHexLong := keyHexLower + "de"
+
+	// 33 bytes: one byte over the minimum, must be accepted.
+	keyBytes33 := append(bytes.Clone(keyBytes), 0xde)
+	keyHex33 := hex.EncodeToString(keyBytes33)
+	// 64 bytes: a block-sized key, as produced before the exact-32 check was
+	// introduced. This is the regression case from the field.
+	keyBytes64 := bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 16)
+	keyHex64 := hex.EncodeToString(keyBytes64)
+	// 31 bytes: valid even-length hex but under the minimum, must be rejected.
+	keyHexUnderMin := hex.EncodeToString(keyBytes[:31])
 
 	cases := []struct {
 		name    string
@@ -91,11 +130,12 @@ func TestLoadHMACKey(t *testing.T) {
 		{name: "valid lowercase hex", input: keyHexLower, want: keyBytes},
 		{name: "valid uppercase hex", input: keyHexUpper, want: keyBytes},
 		{name: "surrounding whitespace trimmed", input: "  \n\t" + keyHexLower + "\n", want: keyBytes},
+		{name: "one byte over minimum accepted", input: keyHex33, want: keyBytes33},
+		{name: "64-byte block-sized key accepted", input: keyHex64, want: keyBytes64},
 
 		{name: "empty input", input: "", wantErr: true},
 		{name: "whitespace only", input: "   \n\t  ", wantErr: true},
-		{name: "short input", input: keyHexShort, wantErr: true},
-		{name: "long input", input: keyHexLong, wantErr: true},
+		{name: "under minimum length", input: keyHexUnderMin, wantErr: true},
 		{name: "non-hex characters", input: "zzzz" + keyHexLower[4:], wantErr: true},
 		{name: "odd hex length", input: keyHexLower[:len(keyHexLower)-1], wantErr: true},
 	}


### PR DESCRIPTION
LoadHMACKey and NewHMACSigner required keys of exactly 32 bytes, which rejected valid keys that worked before the download package refactor — e.g. 64-byte (block-sized) keys loaded from a configured key file then fatal-erroring at startup with "invalid hmac key".

HMAC-SHA256 accepts keys of any length (RFC 2104), so enforce only a 256-bit entropy floor (minKeySize) instead of an exact length. Generated keys remain 32 bytes.