### PR TITLE
Fix two flaky tests

### DIFF
--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -159,7 +159,20 @@ func TestAuditDownload_TamperedURL(t *testing.T) {
 		t.Fatalf("GetDownloadLogUrl: %v", err)
 	}
 	good := resp.Files[0].Url
-	tampered := good[:len(good)-1] + altChar(good[len(good)-1])
+
+	// Flip the first character of the signature segment. The token is
+	// "<b64-envelope>.<b64-signature>"; the first signature character always
+	// carries significant bits, so the flip is guaranteed to change the decoded
+	// signature. Flipping the *last* character is unreliable: a 32-byte HMAC
+	// RawURLEncodes to 43 chars whose final char has non-significant trailing
+	// bits, so ~1/16 of keys produce a flip that decodes to the same bytes and
+	// still verifies.
+	dot := strings.LastIndex(good, ".")
+	if dot < 0 || dot+1 >= len(good) {
+		t.Fatalf("unexpected download URL form: %q", good)
+	}
+	sigStart := dot + 1
+	tampered := good[:sigStart] + altChar(good[sigStart]) + good[sigStart+1:]
 
 	httpResp := h.fetch(t, tampered)
 	defer httpResp.Body.Close()

--- a/pkg/driver/steinel/hpd/udmi_test.go
+++ b/pkg/driver/steinel/hpd/udmi_test.go
@@ -3,7 +3,7 @@ package hpd
 import (
 	"encoding/json"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -17,47 +17,18 @@ import (
 )
 
 func Test_PullExportMessages(t *testing.T) {
-
-	co2 := float32(0)
-	voc := float32(0)
-	humidity := float32(0)
-	aq := resource.NewValue(
-		resource.WithInitialValue(
-			&airqualitysensorpb.AirQuality{
-				CarbonDioxideLevel: &co2, VolatileOrganicCompounds: &voc,
-			},
-		), resource.WithNoDuplicates(),
-	)
-	o := resource.NewValue(
-		resource.WithInitialValue(
-			&occupancysensorpb.Occupancy{
-				PeopleCount: 0, State: occupancysensorpb.Occupancy_OCCUPIED,
-			},
-		), resource.WithNoDuplicates(),
-	)
-	temp := resource.NewValue(
-		resource.WithInitialValue(
-			&airtemperaturepb.AirTemperature{
-				AmbientTemperature: &typespb.Temperature{ValueCelsius: 0}, AmbientHumidity: &humidity,
-			},
-		), resource.WithNoDuplicates(),
-	)
-
-	server := newUdmiServiceServer(nil, aq, o, temp, "prefix")
-	client := udmipb.NewUdmiServiceClient(wrap.ServerToClient(udmipb.UdmiService_ServiceDesc, server))
-
 	req := &udmipb.PullExportMessagesRequest{
 		Name: "test",
 	}
 
 	tests := []struct {
 		name string
-		set  func()
+		set  func(aq, o, temp *resource.Value)
 		want EventPoints
 	}{
 		{
 			name: "occupancy",
-			set: func() {
+			set: func(_, o, _ *resource.Value) {
 				o.Set(
 					&occupancysensorpb.Occupancy{
 						PeopleCount: 459,
@@ -73,7 +44,7 @@ func Test_PullExportMessages(t *testing.T) {
 		},
 		{
 			name: "temp humidity",
-			set: func() {
+			set: func(_, _, temp *resource.Value) {
 				humidity := float32(98.7)
 				temp.Set(
 					&airtemperaturepb.AirTemperature{
@@ -93,7 +64,7 @@ func Test_PullExportMessages(t *testing.T) {
 		},
 		{
 			name: "air quality",
-			set: func() {
+			set: func(aq, _, _ *resource.Value) {
 				co2 := float32(123.4)
 				voc := float32(345.6)
 				aq.Set(
@@ -114,31 +85,81 @@ func Test_PullExportMessages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
-				ctx := t.Context()
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				messages, _ := client.PullExportMessages(ctx, req)
-				tt.set()
-				time.Sleep(1 * time.Millisecond)
-				tt.set()
+					co2 := float32(0)
+					voc := float32(0)
+					humidity := float32(0)
+					aq := resource.NewValue(
+						resource.WithInitialValue(
+							&airqualitysensorpb.AirQuality{
+								CarbonDioxideLevel: &co2, VolatileOrganicCompounds: &voc,
+							},
+						), resource.WithNoDuplicates(),
+					)
+					o := resource.NewValue(
+						resource.WithInitialValue(
+							&occupancysensorpb.Occupancy{
+								PeopleCount: 0, State: occupancysensorpb.Occupancy_OCCUPIED,
+							},
+						), resource.WithNoDuplicates(),
+					)
+					temp := resource.NewValue(
+						resource.WithInitialValue(
+							&airtemperaturepb.AirTemperature{
+								AmbientTemperature: &typespb.Temperature{ValueCelsius: 0}, AmbientHumidity: &humidity,
+							},
+						), resource.WithNoDuplicates(),
+					)
 
-				m, err := messages.Recv()
+					server := newUdmiServiceServer(nil, aq, o, temp, "prefix")
+					client := udmipb.NewUdmiServiceClient(wrap.ServerToClient(udmipb.UdmiService_ServiceDesc, server))
 
-				if err != nil {
-					t.Fatal("messages.RecvMsg(&pointSetMessage) is nil")
-				}
+					messages, err := client.PullExportMessages(ctx, req)
+					if err != nil {
+						t.Fatalf("PullExportMessages: %v", err)
+					}
 
-				// take the response payload which should be a valid PointsetEventMessage
-				var pointSetMessage PointsetEventMessage
-				err = json.Unmarshal([]byte(m.Message.Payload), &pointSetMessage)
+					// Receive on a goroutine so the bubble isn't held on a blocking Recv.
+					type recvResult struct {
+						msg *udmipb.PullExportMessagesResponse
+						err error
+					}
+					results := make(chan recvResult, 1)
+					go func() {
+						msg, err := messages.Recv()
+						results <- recvResult{msg, err}
+					}()
 
-				if err != nil {
-					t.Fatal("json.Unmarshal failed")
-				}
+					// Wait for the server handler to register its Pull subscriptions before
+					// changing the value. The handler pulls with WithUpdatesOnly, so a change
+					// emitted before the subscription exists is lost and Recv blocks forever.
+					synctest.Wait()
+					tt.set(aq, o, temp)
+					// Let the change propagate through the server and back to Recv.
+					synctest.Wait()
 
-				if res := cmp.Diff(pointSetMessage.Points, tt.want); res != "" {
-					t.Fatal("trait does not match " + res)
-				}
+					var r recvResult
+					select {
+					case r = <-results:
+					default:
+						t.Fatal("no message received")
+					}
+					if r.err != nil {
+						t.Fatalf("messages.Recv: %v", r.err)
+					}
 
+					// take the response payload which should be a valid PointsetEventMessage
+					var pointSetMessage PointsetEventMessage
+					if err := json.Unmarshal([]byte(r.msg.Message.Payload), &pointSetMessage); err != nil {
+						t.Fatal("json.Unmarshal failed")
+					}
+
+					if res := cmp.Diff(pointSetMessage.Points, tt.want); res != "" {
+						t.Fatal("trait does not match " + res)
+					}
+				})
 			},
 		)
 	}


### PR DESCRIPTION
## Summary

Fixes two intermittently-failing tests. Both were test bugs, not product defects.

### `driver/steinel/hpd`: `Test_PullExportMessages` [SCB-1370](https://vanti.youtrack.cloud/issue/SCB-1370)
Subscription race. The server's `PullExportMessages` handler pulls each trait with `WithUpdatesOnly(true)`, so a `Set()` that fires before the subscription is registered is lost and `Recv()` blocks until the 10-minute test timeout (the observed panic). The previous sleep + duplicate-`Set` guard was ineffective (the repeat is dropped by `WithNoDuplicates`).

Rewritten with `testing/synctest`: `synctest.Wait()` deterministically blocks until the handler is subscribed before mutating the resource.

### `audit`: `TestAuditDownload_TamperedURL` [SCB-1368](https://vanti.youtrack.cloud/issue/SCB-1368)
Base64 trailing-bit malleability. The signature is HMAC-SHA256 (32 bytes) `RawURLEncoded` to 43 chars whose final character carries only 4 significant bits. The test tampered the last character; when the signature happened to end in `'A'`, the flip to `'B'` changed only a non-significant bit, so the token decoded to the same signature bytes and still verified (200, not 401). This hit ~1/16 of random keys.

Now tampers the first character of the signature segment, which always carries significant bits, so the flip reliably changes the decoded signature.

## Testing
- `go test -count=20 ./pkg/driver/steinel/hpd/ -run Test_PullExportMessages` — pass
- `go test -count=100 ./internal/audit/ -run TestAuditDownload_TamperedURL` — pass (old code failed ~6/100)
- `go vet` clean on both packages