### PR TITLE
driver/steinel: detect missing sensor 

### DIFF
--- a/pkg/driver/steinel/hpd/health.go
+++ b/pkg/driver/steinel/hpd/health.go
@@ -5,9 +5,10 @@ import "github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
 const (
 	SystemName = "Steinel HPD"
 
-	BadResponse = "BadResponse"
-	DriverError = "DriverError"
-	Offline     = "Offline"
+	BadResponse   = "BadResponse"
+	DriverError   = "DriverError"
+	Offline       = "Offline"
+	SensorMissing = "SensorMissing"
 )
 
 // commsHealthCheck returns a health check that monitors whether a device is online and communicating properly.
@@ -42,6 +43,18 @@ var (
 			DetailsText: "The device has sent an unexpected response to a request",
 			Code: &healthpb.HealthCheck_Error_Code{
 				Code:   BadResponse,
+				System: SystemName,
+			},
+		},
+	}
+
+	sensorMissing = &healthpb.HealthCheck_Reliability{
+		State: healthpb.HealthCheck_Reliability_BAD_RESPONSE,
+		LastError: &healthpb.HealthCheck_Error{
+			SummaryText: "Sensor Missing",
+			DetailsText: "The device returned no sensor data; the sensor module may be missing or disconnected from its base",
+			Code: &healthpb.HealthCheck_Error_Code{
+				Code:   SensorMissing,
 				System: SystemName,
 			},
 		},

--- a/pkg/driver/steinel/hpd/poller.go
+++ b/pkg/driver/steinel/hpd/poller.go
@@ -55,12 +55,25 @@ func (p *poller) process(ctx context.Context) {
 			return // we're stopping, not a device fault
 		}
 		h := noResponse
-		var unsupportedTypeErr *json.UnmarshalTypeError
-		if errors.Is(err, unsupportedTypeErr) {
+		var (
+			typeErr   *json.UnmarshalTypeError
+			syntaxErr *json.SyntaxError
+		)
+		if errors.As(err, &typeErr) || errors.As(err, &syntaxErr) {
+			// the device responded, we just couldn't make sense of the body
 			h = badResponse
 		}
 		p.faultCheck.UpdateReliability(ctx, h)
 		p.logger.Error("failed to GET sensor", zap.Error(err))
+		return
+	}
+
+	if response.SensorName == "" {
+		// The base can answer 200 with an empty body ({}) when it is connected but the
+		// sensor module itself is missing. Comms are fine, but the response carries no
+		// sensor data, so treat it as a bad response rather than healthy.
+		p.faultCheck.UpdateReliability(ctx, badResponse)
+		p.logger.Error("sensor returned no data, the sensor module may be missing or disconnected")
 		return
 	}
 

--- a/pkg/driver/steinel/hpd/poller.go
+++ b/pkg/driver/steinel/hpd/poller.go
@@ -72,7 +72,7 @@ func (p *poller) process(ctx context.Context) {
 		// The base can answer 200 with an empty body ({}) when it is connected but the
 		// sensor module itself is missing. Comms are fine, but the response carries no
 		// sensor data, so treat it as a bad response rather than healthy.
-		p.faultCheck.UpdateReliability(ctx, badResponse)
+		p.faultCheck.UpdateReliability(ctx, sensorMissing)
 		p.logger.Error("sensor returned no data, the sensor module may be missing or disconnected")
 		return
 	}

--- a/pkg/driver/steinel/hpd/poller_test.go
+++ b/pkg/driver/steinel/hpd/poller_test.go
@@ -24,10 +24,11 @@ func TestPoller_process_reliability(t *testing.T) {
 	tests := map[string]struct {
 		body      string
 		wantState healthpb.HealthCheck_Reliability_State
+		wantCode  string // expected LastError code, empty for a reliable response
 	}{
-		"empty body":     {body: `{}`, wantState: healthpb.HealthCheck_Reliability_BAD_RESPONSE},
-		"wrong type":     {body: `{"SensorName": "HPD2", "Temperature": "warm"}`, wantState: healthpb.HealthCheck_Reliability_BAD_RESPONSE},
-		"invalid json":   {body: `not json`, wantState: healthpb.HealthCheck_Reliability_BAD_RESPONSE},
+		"empty body":     {body: `{}`, wantState: healthpb.HealthCheck_Reliability_BAD_RESPONSE, wantCode: SensorMissing},
+		"wrong type":     {body: `{"SensorName": "HPD2", "Temperature": "warm"}`, wantState: healthpb.HealthCheck_Reliability_BAD_RESPONSE, wantCode: BadResponse},
+		"invalid json":   {body: `not json`, wantState: healthpb.HealthCheck_Reliability_BAD_RESPONSE, wantCode: BadResponse},
 		"healthy sensor": {body: `{"SensorName": "HPD2", "Temperature": 20.2}`, wantState: healthpb.HealthCheck_Reliability_RELIABLE},
 	}
 
@@ -56,6 +57,9 @@ func TestPoller_process_reliability(t *testing.T) {
 			}
 			if state := got.GetReliability().GetState(); state != tc.wantState {
 				t.Errorf("reliability state = %v, want %v", state, tc.wantState)
+			}
+			if code := got.GetReliability().GetLastError().GetCode().GetCode(); code != tc.wantCode {
+				t.Errorf("reliability error code = %q, want %q", code, tc.wantCode)
 			}
 		})
 	}

--- a/pkg/driver/steinel/hpd/poller_test.go
+++ b/pkg/driver/steinel/hpd/poller_test.go
@@ -1,0 +1,62 @@
+package hpd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
+)
+
+// TestPoller_process_reliability checks how the poller classifies sensor responses. A 200 with
+// an empty body ({}) — which the base returns when it is connected but the sensor module is
+// missing — and unparseable bodies are reported as bad responses rather than treated as healthy.
+func TestPoller_process_reliability(t *testing.T) {
+	const owner = "driver:steinel-hpd"
+	const deviceName = "sensors/01"
+	checkID := healthpb.AbsID(owner, "commsCheck")
+
+	tests := map[string]struct {
+		body      string
+		wantState healthpb.HealthCheck_Reliability_State
+	}{
+		"empty body":     {body: `{}`, wantState: healthpb.HealthCheck_Reliability_BAD_RESPONSE},
+		"wrong type":     {body: `{"SensorName": "HPD2", "Temperature": "warm"}`, wantState: healthpb.HealthCheck_Reliability_BAD_RESPONSE},
+		"invalid json":   {body: `not json`, wantState: healthpb.HealthCheck_Reliability_BAD_RESPONSE},
+		"healthy sensor": {body: `{"SensorName": "HPD2", "Temperature": 20.2}`, wantState: healthpb.HealthCheck_Reliability_RELIABLE},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+			host := strings.TrimPrefix(server.URL, "https://")
+
+			registry := healthpb.NewRegistry()
+			faultCheck, err := registry.ForOwner(owner).NewFaultCheck(deviceName, commsHealthCheck())
+			if err != nil {
+				t.Fatalf("NewFaultCheck: %v", err)
+			}
+			defer faultCheck.Dispose()
+
+			client := newInsecureClient(host, "")
+			p := newPoller(client, time.Minute, zap.NewNop(), faultCheck)
+			p.process(context.Background())
+
+			got := registry.GetCheck(deviceName, checkID)
+			if got == nil {
+				t.Fatalf("GetCheck(%q, %q) = nil", deviceName, checkID)
+			}
+			if state := got.GetReliability().GetState(); state != tc.wantState {
+				t.Errorf("reliability state = %v, want %v", state, tc.wantState)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A connected base whose sensor module is missing, responds to GET /sensor with code 200 and empty body {}, which previously unmarshalled to a zero-value response and was treated as healthy. Flag an absent SensorName as a bad response instead.

Also fix the malformed-JSON check, which used errors.Is against a nil *json.UnmarshalTypeError and never matched; use errors.As and also cover *json.SyntaxError so unparseable bodies report BAD_RESPONSE.