### PR TITLE
dataretention: fix build on platforms where Statfs_t.Bavail is int64

### DIFF
--- a/pkg/history/dataretention/statfs.go
+++ b/pkg/history/dataretention/statfs.go
@@ -23,7 +23,7 @@ func diskCapacity(dataDir string, dbUsedBytes uint64) (capacity uint64, otherUse
 	if diskUsed > dbUsedBytes {
 		otherUsed = diskUsed - dbUsedBytes
 	}
-	available = st.Bavail * bsize
+	available = uint64(st.Bavail) * bsize
 	ok = true
 	return
 }


### PR DESCRIPTION
On FreeBSD (and some other targets) `syscall.Statfs_t.Bavail` is `int64` while `Blocks`/`Bfree` are `uint64`, so the `available = st.Bavail * bsize` multiplication in `pkg/history/dataretention/statfs.go` failed to compile. The dev/CI platform (linux/amd64) has `Bavail uint64`, so the error only surfaced when building the area-controller for the target device.

Convert to `uint64` explicitly, matching the existing `bsize := uint64(st.Bsize)` conversion.

Verified with cross-compiles for linux, freebsd, darwin across amd64/arm/arm64/386.

Follow-up to 835e09cb8.