### PR TITLE
driver/steinel: announce air quality per device model

### DIFF
--- a/pkg/driver/steinel/hpd/config/root.go
+++ b/pkg/driver/steinel/hpd/config/root.go
@@ -15,6 +15,15 @@ import (
 // DefaultPollInterval is how often each device is polled for updates unless configured otherwise.
 const DefaultPollInterval = 60 * time.Second
 
+// Steinel device models. A device's Model selects which sensors it has.
+const (
+	// ModelMultisensor is the full multisensor, with every sensor including air quality.
+	// This is the default when a device does not set a model.
+	ModelMultisensor = "multisensor"
+	// ModelHPD is the HPD, which has no air quality module.
+	ModelHPD = "hpd"
+)
+
 type Root struct {
 	driver.BaseConfig
 
@@ -64,6 +73,11 @@ type Device struct {
 	// Must be unique between devices, otherwise their exports would share an MQTT topic.
 	UDMITopicPrefix string `json:"udmiTopicPrefix,omitempty"`
 
+	// Model selects the Steinel device variant, which determines the sensors it has.
+	// "" (default) and "multisensor" announce every trait; "hpd" omits air quality,
+	// which that model lacks. See the Model constants for the accepted values.
+	Model string `json:"model,omitempty"`
+
 	// password is the device password read from PasswordFile, see ResolvedPassword.
 	password string
 }
@@ -71,6 +85,12 @@ type Device struct {
 // ResolvedPassword returns the device password read from PasswordFile during ParseConfig.
 func (d Device) ResolvedPassword() string {
 	return d.password
+}
+
+// HasAirQuality reports whether the device model has an air quality sensor.
+// Only the HPD model lacks one; the default and multisensor have it.
+func (d Device) HasAirQuality() bool {
+	return d.Model != ModelHPD
 }
 
 func ParseConfig(data []byte) (Root, error) {
@@ -126,6 +146,11 @@ func ParseConfig(data []byte) (Root, error) {
 		}
 		if device.Password != "" {
 			return Root{}, fmt.Errorf("devices[%d] %q: plaintext passwords in config are not supported, use passwordFile", i, device.Name)
+		}
+		switch device.Model {
+		case "", ModelMultisensor, ModelHPD:
+		default:
+			return Root{}, fmt.Errorf("devices[%d] %q: unknown model %q, want one of %q or %q", i, device.Name, device.Model, ModelMultisensor, ModelHPD)
 		}
 		if err := device.resolvePassword(root.PasswordFile, passwords); err != nil {
 			return Root{}, fmt.Errorf("devices[%d] %q: %w", i, device.Name, err)

--- a/pkg/driver/steinel/hpd/config/root_test.go
+++ b/pkg/driver/steinel/hpd/config/root_test.go
@@ -112,6 +112,34 @@ func TestParseConfig_multiDeviceDefaults(t *testing.T) {
 	}
 }
 
+func TestParseConfig_deviceModel(t *testing.T) {
+	data := `{
+		"name": "steinel-hpd",
+		"passwordFile": ` + quote(writePasswordFile(t, "p")) + `,
+		"devices": [
+			{"name": "sensors/hpd", "ipAddress": "10.0.0.1", "model": "hpd"},
+			{"name": "sensors/multi", "ipAddress": "10.0.0.2", "model": "multisensor"},
+			{"name": "sensors/default", "ipAddress": "10.0.0.3"}
+		]
+	}`
+	root, err := ParseConfig([]byte(data))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+
+	// the hpd has no air quality module
+	if hpd := root.Devices[0]; hpd.HasAirQuality() {
+		t.Errorf("devices[0] model %q: HasAirQuality() = true, want false", hpd.Model)
+	}
+	// the multisensor and the default (no model) both have air quality
+	if multi := root.Devices[1]; !multi.HasAirQuality() {
+		t.Errorf("devices[1] model %q: HasAirQuality() = false, want true", multi.Model)
+	}
+	if def := root.Devices[2]; !def.HasAirQuality() {
+		t.Errorf("devices[2] model %q: HasAirQuality() = false, want true", def.Model)
+	}
+}
+
 func TestParseConfig_errors(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -176,6 +204,12 @@ func TestParseConfig_errors(t *testing.T) {
 			name:    "root udmiTopicPrefix with devices",
 			data:    `{"name": "x", "udmiTopicPrefix": "t", "devices": [{"name": "a", "ipAddress": "10.0.0.1"}]}`,
 			wantErr: "legacy single-device options",
+		},
+		{
+			name: "unknown model",
+			data: `{"name": "x", "passwordFile": ` + quote(writePasswordFile(t, "p")) + `,
+				"devices": [{"name": "a", "ipAddress": "10.0.0.1", "model": "not-a-model"}]}`,
+			wantErr: "unknown model",
 		},
 		{
 			name: "duplicate udmiTopicPrefix",

--- a/pkg/driver/steinel/hpd/driver.go
+++ b/pkg/driver/steinel/hpd/driver.go
@@ -97,8 +97,6 @@ func (d *Driver) applyDeviceConfig(ctx context.Context, announcer node.Announcer
 
 	features := []node.Feature{
 		node.HasMetadata(cfg.Metadata),
-		node.HasServer(airqualitysensorpb.RegisterAirQualitySensorApiServer, airqualitysensorpb.AirQualitySensorApiServer(airQualitySensor)),
-		node.HasTrait(trait.AirQualitySensor),
 		node.HasServer(airtemperaturepb.RegisterAirTemperatureApiServer, airtemperaturepb.AirTemperatureApiServer(temperature)),
 		node.HasTrait(trait.AirTemperature),
 		node.HasServer(brightnesssensorpb.RegisterBrightnessSensorApiServer, brightnesssensorpb.BrightnessSensorApiServer(brightnessSensor)),
@@ -108,6 +106,16 @@ func (d *Driver) applyDeviceConfig(ctx context.Context, announcer node.Announcer
 		node.HasServer(soundsensorpb.RegisterSoundSensorApiServer, soundsensorpb.SoundSensorApiServer(soundSensor)),
 		node.HasTrait(soundsensorpb.TraitName),
 		node.HasDeviceType(metadatapb.Metadata_DEVICE),
+	}
+	pollSensors := []sensor{temperature, occupancy}
+	// The HPD model has no air quality module, so only the multisensor announces and
+	// polls that trait. Announcing it for an HPD would produce errors when read.
+	if cfg.HasAirQuality() {
+		features = append(features,
+			node.HasServer(airqualitysensorpb.RegisterAirQualitySensorApiServer, airqualitysensorpb.AirQualitySensorApiServer(airQualitySensor)),
+			node.HasTrait(trait.AirQualitySensor),
+		)
+		pollSensors = append(pollSensors, airQualitySensor)
 	}
 	if cfg.UDMITopicPrefix != "" {
 		// without a topic prefix devices would all export to the same MQTT topic, so no prefix means no UDMI
@@ -120,7 +128,7 @@ func (d *Driver) applyDeviceConfig(ctx context.Context, announcer node.Announcer
 	}
 	announcer.Announce(cfg.Name, features...)
 
-	poller := newPoller(client, cfg.PollInterval.Or(config.DefaultPollInterval), logger.Named("SteinelPoller"), faultCheck, airQualitySensor, occupancy, temperature)
+	poller := newPoller(client, cfg.PollInterval.Or(config.DefaultPollInterval), logger.Named("SteinelPoller"), faultCheck, pollSensors...)
 
 	wg.Go(func() {
 		defer client.Client.CloseIdleConnections()

--- a/pkg/driver/steinel/hpd/driver_test.go
+++ b/pkg/driver/steinel/hpd/driver_test.go
@@ -78,3 +78,91 @@ func TestDriver_applyConfig_reapply(t *testing.T) {
 	stop2()
 	d.devicesStopped()
 }
+
+// TestDriver_applyConfig_deviceModel checks that an hpd device does not announce the air
+// quality trait, while a multisensor (and a device with no model) does.
+func TestDriver_applyConfig_deviceModel(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"SensorName": "steinel", "Temperature": 20.2, "Humidity": 50}`))
+	}))
+	defer server.Close()
+	host := strings.TrimPrefix(server.URL, "https://")
+
+	passwordFile := filepath.Join(t.TempDir(), "password")
+	if err := os.WriteFile(passwordFile, []byte("secret\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	data := `{
+		"name": "steinel-hpd",
+		"passwordFile": "` + strings.ReplaceAll(passwordFile, `\`, `\\`) + `",
+		"devices": [
+			{"name": "sensors/hpd", "ipAddress": "` + host + `", "model": "hpd"},
+			{"name": "sensors/multi", "ipAddress": "` + host + `", "model": "multisensor"},
+			{"name": "sensors/default", "ipAddress": "` + host + `"}
+		]
+	}`
+	cfg, err := config.ParseConfig([]byte(data))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+
+	n := node.New("test")
+	d := &Driver{
+		announcer: node.NewReplaceAnnouncer(n),
+		health:    healthpb.NewRegistry().ForOwner("driver:steinel-hpd"),
+		logger:    zap.NewNop(),
+	}
+
+	ctx, stop := context.WithCancel(context.Background())
+	if err := d.applyConfig(ctx, cfg); err != nil {
+		t.Fatalf("applyConfig: %v", err)
+	}
+	defer func() {
+		stop()
+		d.devicesStopped()
+	}()
+
+	deviceTraits := func(t *testing.T, name string) map[string]bool {
+		t.Helper()
+		dev, err := n.GetDevice(name)
+		if err != nil {
+			t.Fatalf("GetDevice(%q): %v", name, err)
+		}
+		traits := make(map[string]bool)
+		for _, tm := range dev.GetMetadata().GetTraits() {
+			traits[tm.GetName()] = true
+		}
+		return traits
+	}
+
+	const airQuality = "smartcore.traits.AirQualitySensor"
+	// every model has these regardless of air quality support
+	commonTraits := []string{
+		"smartcore.traits.AirTemperature",
+		"smartcore.traits.BrightnessSensor",
+		"smartcore.traits.OccupancySensor",
+		"smartcore.bos.SoundSensor",
+	}
+
+	hpd := deviceTraits(t, "sensors/hpd")
+	if hpd[airQuality] {
+		t.Errorf("sensors/hpd announced %s, want it omitted; traits = %v", airQuality, hpd)
+	}
+	for _, want := range commonTraits {
+		if !hpd[want] {
+			t.Errorf("sensors/hpd missing trait %q; traits = %v", want, hpd)
+		}
+	}
+
+	for _, name := range []string{"sensors/multi", "sensors/default"} {
+		got := deviceTraits(t, name)
+		if !got[airQuality] {
+			t.Errorf("%s missing %s, want it announced; traits = %v", name, airQuality, got)
+		}
+		for _, want := range commonTraits {
+			if !got[want] {
+				t.Errorf("%s missing trait %q; traits = %v", name, want, got)
+			}
+		}
+	}
+}


### PR DESCRIPTION
The driver announced every trait for every device, but the HPD model has no air quality module, so announcing AirQualitySensor for it produced errors when clients read the trait.

Add a per-device `model` field ("hpd" or "multisensor"). The hpd model omits air quality (trait not announced, sensor not polled); an omitted model or "multisensor" announces every trait as before, so existing configs are unaffected.