### PR TITLE
feat(api): add pagination to List RPCs that lacked it

### DIFF
--- a/pkg/hub/pull.go
+++ b/pkg/hub/pull.go
@@ -206,9 +206,19 @@ func (c *NodeFetcher) Pull(ctx context.Context, changes chan<- *hubpb.PullHubNod
 }
 
 func (c *NodeFetcher) Poll(ctx context.Context, changes chan<- *hubpb.PullHubNodesResponse_Change) error {
-	nodes, err := c.ListHubNodes(ctx, &hubpb.ListHubNodesRequest{})
-	if err != nil {
-		return err
+	// Page through every node: Poll reconciles the full set against c.known, so a partial
+	// list would spuriously emit REMOVE changes for nodes beyond the first page.
+	var allNodes []*hubpb.HubNode
+	for pageToken := ""; ; {
+		res, err := c.ListHubNodes(ctx, &hubpb.ListHubNodesRequest{PageToken: pageToken})
+		if err != nil {
+			return err
+		}
+		allNodes = append(allNodes, res.GetNodes()...)
+		if res.GetNextPageToken() == "" {
+			break
+		}
+		pageToken = res.GetNextPageToken()
 	}
 	if c.known == nil {
 		c.known = make(map[string]*hubpb.HubNode)
@@ -218,7 +228,7 @@ func (c *NodeFetcher) Poll(ctx context.Context, changes chan<- *hubpb.PullHubNod
 		unseen[s] = struct{}{}
 	}
 
-	for _, node := range nodes.Nodes {
+	for _, node := range allNodes {
 		// we do extra work here to try and send out more accurate changes to make callers lives easier
 		change := &hubpb.PullHubNodesResponse_Change{
 			Type:     typespb.ChangeType_ADD,

--- a/pkg/proto/bookingpb/booking.pb.go
+++ b/pkg/proto/bookingpb/booking.pb.go
@@ -268,7 +268,18 @@ type ListBookingsRequest struct {
 	ReadMask *fieldmaskpb.FieldMask `protobuf:"bytes,3,opt,name=read_mask,json=readMask,proto3" json:"read_mask,omitempty"`
 	// When true the device will only send changes to the resource value.
 	// The default behaviour is to send the current value immediately followed by any updates as they happen.
-	UpdatesOnly   bool `protobuf:"varint,4,opt,name=updates_only,json=updatesOnly,proto3" json:"updates_only,omitempty"`
+	// Only applies to PullBookings; ignored by ListBookings.
+	UpdatesOnly bool `protobuf:"varint,4,opt,name=updates_only,json=updatesOnly,proto3" json:"updates_only,omitempty"`
+	// The maximum number of bookings to return.
+	// The service may return fewer than this value.
+	// If unspecified, at most 50 items will be returned.
+	// The maximum value is 1000; values above 1000 will be coerced to 1000.
+	// Only applies to ListBookings; ignored by PullBookings.
+	PageSize int32 `protobuf:"varint,5,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// A page token, received from a previous `ListBookingsResponse` call.
+	// Provide this to retrieve the subsequent page.
+	// Only applies to ListBookings; ignored by PullBookings.
+	PageToken     string `protobuf:"bytes,6,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -331,10 +342,30 @@ func (x *ListBookingsRequest) GetUpdatesOnly() bool {
 	return false
 }
 
+func (x *ListBookingsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListBookingsRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
 type ListBookingsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// the list of bookings for the given request
-	Bookings      []*Booking `protobuf:"bytes,1,rep,name=bookings,proto3" json:"bookings,omitempty"`
+	Bookings []*Booking `protobuf:"bytes,1,rep,name=bookings,proto3" json:"bookings,omitempty"`
+	// A token, which can be sent as `page_token` to retrieve the next page.
+	// If this field is omitted, there are no subsequent pages.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	// If non-zero this is the total number of bookings.
+	// This may be an estimate.
+	TotalSize     int32 `protobuf:"varint,3,opt,name=total_size,json=totalSize,proto3" json:"total_size,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -374,6 +405,20 @@ func (x *ListBookingsResponse) GetBookings() []*Booking {
 		return x.Bookings
 	}
 	return nil
+}
+
+func (x *ListBookingsResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+func (x *ListBookingsResponse) GetTotalSize() int32 {
+	if x != nil {
+		return x.TotalSize
+	}
+	return 0
 }
 
 type CheckInBookingRequest struct {
@@ -976,14 +1021,20 @@ const file_smartcore_bos_booking_v1_booking_proto_rawDesc = "" +
 	"\n" +
 	"NO_SUPPORT\x10\x01\x12\t\n" +
 	"\x05STATE\x10\x02\x12\b\n" +
-	"\x04TIME\x10\x03\"\xd9\x01\n" +
+	"\x04TIME\x10\x03\"\x95\x02\n" +
 	"\x13ListBookingsRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12R\n" +
 	"\x12booking_intersects\x18\x02 \x01(\v2#.smartcore.bos.types.time.v1.PeriodR\x11bookingIntersects\x127\n" +
 	"\tread_mask\x18\x03 \x01(\v2\x1a.google.protobuf.FieldMaskR\breadMask\x12!\n" +
-	"\fupdates_only\x18\x04 \x01(\bR\vupdatesOnly\"U\n" +
+	"\fupdates_only\x18\x04 \x01(\bR\vupdatesOnly\x12\x1b\n" +
+	"\tpage_size\x18\x05 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x06 \x01(\tR\tpageToken\"\x9c\x01\n" +
 	"\x14ListBookingsResponse\x12=\n" +
-	"\bbookings\x18\x01 \x03(\v2!.smartcore.bos.booking.v1.BookingR\bbookings\"z\n" +
+	"\bbookings\x18\x01 \x03(\v2!.smartcore.bos.booking.v1.BookingR\bbookings\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\x12\x1d\n" +
+	"\n" +
+	"total_size\x18\x03 \x01(\x05R\ttotalSize\"z\n" +
 	"\x15CheckInBookingRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1d\n" +
 	"\n" +

--- a/pkg/proto/bookingpb/model_server.go
+++ b/pkg/proto/bookingpb/model_server.go
@@ -2,6 +2,7 @@ package bookingpb
 
 import (
 	"context"
+	"sort"
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
@@ -9,7 +10,9 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	timepb2 "github.com/smart-core-os/sc-bos/pkg/proto/timepb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/typespb"
 	"github.com/smart-core-os/sc-bos/pkg/resource"
+	"github.com/smart-core-os/sc-bos/pkg/util/masks"
 	timepb "github.com/smart-core-os/sc-bos/pkg/util/time"
 )
 
@@ -32,9 +35,17 @@ func (m *ModelServer) Register(server grpc.ServiceRegistrar) {
 }
 
 func (m *ModelServer) ListBookings(_ context.Context, request *ListBookingsRequest) (*ListBookingsResponse, error) {
-	opts := []resource.ReadOption{
-		resource.WithReadMask(request.ReadMask),
+	pageToken := &typespb.PageToken{}
+	if err := decodePageToken(request.GetPageToken(), pageToken); err != nil {
+		return nil, err
 	}
+
+	lastKey := pageToken.GetLastResourceName() // the id of the last booking we sent
+	pageSize := capPageSize(int(request.GetPageSize()))
+
+	// Fetch the full (unmasked) set so pagination keys off booking id regardless of the read mask.
+	// The read mask is applied to the returned page below.
+	var opts []resource.ReadOption
 	if request.BookingIntersects != nil {
 		opts = append(opts, resource.WithInclude(func(_ string, item proto.Message) bool {
 			if item == nil {
@@ -44,8 +55,48 @@ func (m *ModelServer) ListBookings(_ context.Context, request *ListBookingsReque
 			return timepb.PeriodsIntersect(itemVal.Booked, request.BookingIntersects)
 		}))
 	}
-	bookings := m.model.ListBookings(opts...)
-	return &ListBookingsResponse{Bookings: bookings}, nil
+	all := m.model.ListBookings(opts...)
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Id < all[j].Id
+	})
+
+	nextIndex := 0
+	if lastKey != "" {
+		nextIndex = sort.Search(len(all), func(i int) bool {
+			return all[i].Id >= lastKey
+		})
+		if nextIndex < len(all) && all[nextIndex].Id == lastKey {
+			nextIndex++
+		}
+	}
+
+	result := &ListBookingsResponse{
+		TotalSize: int32(len(all)),
+	}
+	upperBound := nextIndex + pageSize
+	if upperBound > len(all) {
+		upperBound = len(all)
+		pageToken = nil
+	} else {
+		pageToken.PageStart = &typespb.PageToken_LastResourceName{
+			LastResourceName: all[upperBound-1].Id,
+		}
+	}
+
+	var err error
+	result.NextPageToken, err = encodePageToken(pageToken)
+	if err != nil {
+		return nil, err
+	}
+
+	page := all[nextIndex:upperBound]
+	mask := masks.NewResponseFilter(masks.WithFieldMask(request.ReadMask))
+	result.Bookings = make([]*Booking, len(page))
+	for i, b := range page {
+		result.Bookings[i] = mask.FilterClone(b).(*Booking)
+	}
+
+	return result, nil
 }
 
 func (m *ModelServer) CheckInBooking(_ context.Context, request *CheckInBookingRequest) (*CheckInBookingResponse, error) {

--- a/pkg/proto/bookingpb/pages.go
+++ b/pkg/proto/bookingpb/pages.go
@@ -1,0 +1,50 @@
+package bookingpb
+
+import (
+	"encoding/base64"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smart-core-os/sc-bos/pkg/proto/typespb"
+)
+
+const (
+	defaultPageSize = 50
+	maxPageSize     = 1000
+)
+
+func capPageSize(pageSize int) int {
+	if pageSize == 0 {
+		return defaultPageSize
+	}
+	if pageSize > maxPageSize {
+		return maxPageSize
+	}
+	return pageSize
+}
+
+func decodePageToken(token string, pageToken *typespb.PageToken) error {
+	if token != "" {
+		tokenBytes, err := base64.StdEncoding.DecodeString(token)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "bad page token: %v", err)
+		}
+		if err := proto.Unmarshal(tokenBytes, pageToken); err != nil {
+			return status.Errorf(codes.InvalidArgument, "bad page token: %v", err)
+		}
+	}
+	return nil
+}
+
+func encodePageToken(pageToken *typespb.PageToken) (string, error) {
+	if pageToken != nil {
+		tokenBytes, err := proto.Marshal(pageToken)
+		if err != nil {
+			return "", status.Errorf(codes.Unknown, "unable to create page token: %v", err)
+		}
+		return base64.StdEncoding.EncodeToString(tokenBytes), nil
+	}
+	return "", nil
+}

--- a/pkg/proto/hubpb/hub.pb.go
+++ b/pkg/proto/hubpb/hub.pb.go
@@ -283,7 +283,15 @@ func (x *RenewHubNodeRequest) GetAddress() string {
 }
 
 type ListHubNodesRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The maximum number of nodes to return.
+	// The service may return fewer than this value.
+	// If unspecified, at most 50 items will be returned.
+	// The maximum value is 1000; values above 1000 will be coerced to 1000.
+	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// A page token, received from a previous `ListHubNodesResponse` call.
+	// Provide this to retrieve the subsequent page.
+	PageToken     string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -318,9 +326,29 @@ func (*ListHubNodesRequest) Descriptor() ([]byte, []int) {
 	return file_smartcore_bos_hub_v1_hub_proto_rawDescGZIP(), []int{5}
 }
 
+func (x *ListHubNodesRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListHubNodesRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
 type ListHubNodesResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Nodes         []*HubNode             `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Nodes []*HubNode             `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes,omitempty"`
+	// A token, which can be sent as `page_token` to retrieve the next page.
+	// If this field is omitted, there are no subsequent pages.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	// If non-zero this is the total number of hub nodes.
+	// This may be an estimate.
+	TotalSize     int32 `protobuf:"varint,3,opt,name=total_size,json=totalSize,proto3" json:"total_size,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -360,6 +388,20 @@ func (x *ListHubNodesResponse) GetNodes() []*HubNode {
 		return x.Nodes
 	}
 	return nil
+}
+
+func (x *ListHubNodesResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+func (x *ListHubNodesResponse) GetTotalSize() int32 {
+	if x != nil {
+		return x.TotalSize
+	}
+	return 0
 }
 
 type PullHubNodesRequest struct {
@@ -755,10 +797,16 @@ const file_smartcore_bos_hub_v1_hub_proto_rawDesc = "" +
 	"\x04node\x18\x01 \x01(\v2\x1d.smartcore.bos.hub.v1.HubNodeR\x04node\x12!\n" +
 	"\fpublic_certs\x18\x02 \x03(\tR\vpublicCerts\"/\n" +
 	"\x13RenewHubNodeRequest\x12\x18\n" +
-	"\aaddress\x18\x01 \x01(\tR\aaddress\"\x15\n" +
-	"\x13ListHubNodesRequest\"K\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\"Q\n" +
+	"\x13ListHubNodesRequest\x12\x1b\n" +
+	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\"\x92\x01\n" +
 	"\x14ListHubNodesResponse\x123\n" +
-	"\x05nodes\x18\x01 \x03(\v2\x1d.smartcore.bos.hub.v1.HubNodeR\x05nodes\"8\n" +
+	"\x05nodes\x18\x01 \x03(\v2\x1d.smartcore.bos.hub.v1.HubNodeR\x05nodes\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\x12\x1d\n" +
+	"\n" +
+	"total_size\x18\x03 \x01(\x05R\ttotalSize\"8\n" +
 	"\x13PullHubNodesRequest\x12!\n" +
 	"\fupdates_only\x18\x03 \x01(\bR\vupdatesOnly\"\xdb\x02\n" +
 	"\x14PullHubNodesResponse\x12K\n" +

--- a/pkg/proto/tenantpb/tenants.pb.go
+++ b/pkg/proto/tenantpb/tenants.pb.go
@@ -225,7 +225,15 @@ func (x *Secret) GetEtag() string {
 }
 
 type ListTenantsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The maximum number of tenants to return.
+	// The service may return fewer than this value.
+	// If unspecified, at most 50 items will be returned.
+	// The maximum value is 1000; values above 1000 will be coerced to 1000.
+	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// A page token, received from a previous `ListTenantsResponse` call.
+	// Provide this to retrieve the subsequent page.
+	PageToken     string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -260,9 +268,29 @@ func (*ListTenantsRequest) Descriptor() ([]byte, []int) {
 	return file_smartcore_bos_tenant_v1_tenants_proto_rawDescGZIP(), []int{2}
 }
 
+func (x *ListTenantsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListTenantsRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
 type ListTenantsResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Tenants       []*Tenant              `protobuf:"bytes,1,rep,name=tenants,proto3" json:"tenants,omitempty"`
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Tenants []*Tenant              `protobuf:"bytes,1,rep,name=tenants,proto3" json:"tenants,omitempty"`
+	// A token, which can be sent as `page_token` to retrieve the next page.
+	// If this field is omitted, there are no subsequent pages.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	// If non-zero this is the total number of tenants.
+	// This may be an estimate.
+	TotalSize     int32 `protobuf:"varint,3,opt,name=total_size,json=totalSize,proto3" json:"total_size,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -302,6 +330,20 @@ func (x *ListTenantsResponse) GetTenants() []*Tenant {
 		return x.Tenants
 	}
 	return nil
+}
+
+func (x *ListTenantsResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+func (x *ListTenantsResponse) GetTotalSize() int32 {
+	if x != nil {
+		return x.TotalSize
+	}
+	return 0
 }
 
 type PullTenantsRequest struct {
@@ -813,9 +855,17 @@ func (x *RemoveTenantZonesRequest) GetRemoveZoneNames() []string {
 }
 
 type ListSecretsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	IncludeHash   bool                   `protobuf:"varint,1,opt,name=include_hash,json=includeHash,proto3" json:"include_hash,omitempty"`
-	Filter        string                 `protobuf:"bytes,2,opt,name=filter,proto3" json:"filter,omitempty"` // TODO: paging
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	IncludeHash bool                   `protobuf:"varint,1,opt,name=include_hash,json=includeHash,proto3" json:"include_hash,omitempty"`
+	Filter      string                 `protobuf:"bytes,2,opt,name=filter,proto3" json:"filter,omitempty"`
+	// The maximum number of secrets to return.
+	// The service may return fewer than this value.
+	// If unspecified, at most 50 items will be returned.
+	// The maximum value is 1000; values above 1000 will be coerced to 1000.
+	PageSize int32 `protobuf:"varint,3,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// A page token, received from a previous `ListSecretsResponse` call.
+	// Provide this to retrieve the subsequent page.
+	PageToken     string `protobuf:"bytes,4,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -864,9 +914,29 @@ func (x *ListSecretsRequest) GetFilter() string {
 	return ""
 }
 
+func (x *ListSecretsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListSecretsRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
 type ListSecretsResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Secrets       []*Secret              `protobuf:"bytes,1,rep,name=secrets,proto3" json:"secrets,omitempty"`
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Secrets []*Secret              `protobuf:"bytes,1,rep,name=secrets,proto3" json:"secrets,omitempty"`
+	// A token, which can be sent as `page_token` to retrieve the next page.
+	// If this field is omitted, there are no subsequent pages.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	// If non-zero this is the total number of secrets.
+	// This may be an estimate.
+	TotalSize     int32 `protobuf:"varint,3,opt,name=total_size,json=totalSize,proto3" json:"total_size,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -906,6 +976,20 @@ func (x *ListSecretsResponse) GetSecrets() []*Secret {
 		return x.Secrets
 	}
 	return nil
+}
+
+func (x *ListSecretsResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+func (x *ListSecretsResponse) GetTotalSize() int32 {
+	if x != nil {
+		return x.TotalSize
+	}
+	return 0
 }
 
 type PullSecretsRequest struct {
@@ -1704,10 +1788,16 @@ const file_smartcore_bos_tenant_v1_tenants_proto_rawDesc = "" +
 	"\x0efirst_use_time\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\ffirstUseTime\x12>\n" +
 	"\rlast_use_time\x18\t \x01(\v2\x1a.google.protobuf.TimestampR\vlastUseTime\x12\x12\n" +
 	"\x04etag\x18\n" +
-	" \x01(\tR\x04etag\"\x14\n" +
-	"\x12ListTenantsRequest\"P\n" +
+	" \x01(\tR\x04etag\"P\n" +
+	"\x12ListTenantsRequest\x12\x1b\n" +
+	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\"\x97\x01\n" +
 	"\x13ListTenantsResponse\x129\n" +
-	"\atenants\x18\x01 \x03(\v2\x1f.smartcore.bos.tenant.v1.TenantR\atenants\"7\n" +
+	"\atenants\x18\x01 \x03(\v2\x1f.smartcore.bos.tenant.v1.TenantR\atenants\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\x12\x1d\n" +
+	"\n" +
+	"total_size\x18\x03 \x01(\x05R\ttotalSize\"7\n" +
 	"\x12PullTenantsRequest\x12!\n" +
 	"\fupdates_only\x18\x01 \x01(\bR\vupdatesOnly\"\xe4\x01\n" +
 	"\x13PullTenantsResponse\x12M\n" +
@@ -1741,12 +1831,18 @@ const file_smartcore_bos_tenant_v1_tenants_proto_rawDesc = "" +
 	"\x0eadd_zone_names\x18\x02 \x03(\tR\faddZoneNames\"c\n" +
 	"\x18RemoveTenantZonesRequest\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12*\n" +
-	"\x11remove_zone_names\x18\x03 \x03(\tR\x0fremoveZoneNames\"O\n" +
+	"\x11remove_zone_names\x18\x03 \x03(\tR\x0fremoveZoneNames\"\x8b\x01\n" +
 	"\x12ListSecretsRequest\x12!\n" +
 	"\finclude_hash\x18\x01 \x01(\bR\vincludeHash\x12\x16\n" +
-	"\x06filter\x18\x02 \x01(\tR\x06filter\"P\n" +
+	"\x06filter\x18\x02 \x01(\tR\x06filter\x12\x1b\n" +
+	"\tpage_size\x18\x03 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x04 \x01(\tR\tpageToken\"\x97\x01\n" +
 	"\x13ListSecretsResponse\x129\n" +
-	"\asecrets\x18\x01 \x03(\v2\x1f.smartcore.bos.tenant.v1.SecretR\asecrets\"Z\n" +
+	"\asecrets\x18\x01 \x03(\v2\x1f.smartcore.bos.tenant.v1.SecretR\asecrets\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\x12\x1d\n" +
+	"\n" +
+	"total_size\x18\x03 \x01(\x05R\ttotalSize\"Z\n" +
 	"\x12PullSecretsRequest\x12!\n" +
 	"\finclude_hash\x18\x01 \x01(\bR\vincludeHash\x12!\n" +
 	"\fupdates_only\x18\x02 \x01(\bR\vupdatesOnly\"\xe4\x01\n" +

--- a/pkg/system/hub/bolthub/server.go
+++ b/pkg/system/hub/bolthub/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/proto/hubpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/typespb"
+	"github.com/smart-core-os/sc-bos/pkg/system/hub/internal/hubpage"
 	"github.com/smart-core-os/sc-bos/pkg/system/hub/remote"
 )
 
@@ -150,7 +151,8 @@ func (s *Server) deleteHubNode(ctx context.Context, reg *hubpb.HubNode) error {
 	}, s.TestTLSConfig)
 }
 
-func (s *Server) ListHubNodes(ctx context.Context, request *hubpb.ListHubNodesRequest) (*hubpb.ListHubNodesResponse, error) {
+// listAllHubNodes returns every enrolled node, unpaginated.
+func (s *Server) listAllHubNodes() ([]*hubpb.HubNode, error) {
 	var dbEnrollments []DbEnrollment
 	err := s.db.Find(&dbEnrollments, nil)
 	if err != nil {
@@ -166,8 +168,25 @@ func (s *Server) ListHubNodes(ctx context.Context, request *hubpb.ListHubNodesRe
 			Description: en.Description,
 		})
 	}
+	return registrations, nil
+}
 
-	return &hubpb.ListHubNodesResponse{Nodes: registrations}, nil
+func (s *Server) ListHubNodes(_ context.Context, request *hubpb.ListHubNodesRequest) (*hubpb.ListHubNodesResponse, error) {
+	all, err := s.listAllHubNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	nodes, nextPageToken, total, err := hubpage.Paginate(all, request.GetPageSize(), request.GetPageToken())
+	if err != nil {
+		return nil, err
+	}
+
+	return &hubpb.ListHubNodesResponse{
+		Nodes:         nodes,
+		NextPageToken: nextPageToken,
+		TotalSize:     total,
+	}, nil
 }
 
 func (s *Server) PullHubNodes(request *hubpb.PullHubNodesRequest, server hubpb.HubApi_PullHubNodesServer) error {
@@ -175,11 +194,11 @@ func (s *Server) PullHubNodes(request *hubpb.PullHubNodesRequest, server hubpb.H
 	events := s.dbChanges.Listen(server.Context())
 
 	if !request.UpdatesOnly {
-		nodes, err := s.ListHubNodes(server.Context(), &hubpb.ListHubNodesRequest{})
+		nodes, err := s.listAllHubNodes()
 		if err != nil {
 			return err
 		}
-		for _, node := range nodes.Nodes {
+		for _, node := range nodes {
 			err := server.Send(&hubpb.PullHubNodesResponse{Changes: []*hubpb.PullHubNodesResponse_Change{
 				{
 					Type:       typespb.ChangeType_ADD,

--- a/pkg/system/hub/internal/hubpage/hubpage.go
+++ b/pkg/system/hub/internal/hubpage/hubpage.go
@@ -1,0 +1,95 @@
+// Package hubpage provides pagination helpers shared by the hub node store implementations.
+package hubpage
+
+import (
+	"encoding/base64"
+	"sort"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smart-core-os/sc-bos/pkg/proto/hubpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/typespb"
+)
+
+const (
+	defaultPageSize = 50
+	maxPageSize     = 1000
+)
+
+// Paginate sorts nodes by name and returns the page identified by pageSize and pageToken.
+// It returns the page of nodes, a token for the next page (empty when there are no more pages),
+// and the total number of nodes across all pages.
+// nodes is sorted in place.
+func Paginate(nodes []*hubpb.HubNode, pageSize int32, pageToken string) (page []*hubpb.HubNode, nextPageToken string, total int32, err error) {
+	token := &typespb.PageToken{}
+	if err := decodePageToken(pageToken, token); err != nil {
+		return nil, "", 0, err
+	}
+
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].GetName() < nodes[j].GetName()
+	})
+
+	lastKey := token.GetLastResourceName() // the name of the last node we sent
+	nextIndex := 0
+	if lastKey != "" {
+		nextIndex = sort.Search(len(nodes), func(i int) bool {
+			return nodes[i].GetName() >= lastKey
+		})
+		if nextIndex < len(nodes) && nodes[nextIndex].GetName() == lastKey {
+			nextIndex++
+		}
+	}
+
+	upperBound := nextIndex + capPageSize(int(pageSize))
+	if upperBound > len(nodes) {
+		upperBound = len(nodes)
+		token = nil
+	} else {
+		token.PageStart = &typespb.PageToken_LastResourceName{
+			LastResourceName: nodes[upperBound-1].GetName(),
+		}
+	}
+
+	nextPageToken, err = encodePageToken(token)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	return nodes[nextIndex:upperBound], nextPageToken, int32(len(nodes)), nil
+}
+
+func capPageSize(pageSize int) int {
+	if pageSize == 0 {
+		return defaultPageSize
+	}
+	if pageSize > maxPageSize {
+		return maxPageSize
+	}
+	return pageSize
+}
+
+func decodePageToken(token string, pageToken *typespb.PageToken) error {
+	if token != "" {
+		tokenBytes, err := base64.StdEncoding.DecodeString(token)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "bad page token: %v", err)
+		}
+		if err := proto.Unmarshal(tokenBytes, pageToken); err != nil {
+			return status.Errorf(codes.InvalidArgument, "bad page token: %v", err)
+		}
+	}
+	return nil
+}
+
+func encodePageToken(pageToken *typespb.PageToken) (string, error) {
+	if pageToken != nil {
+		tokenBytes, err := proto.Marshal(pageToken)
+		if err != nil {
+			return "", status.Errorf(codes.Unknown, "unable to create page token: %v", err)
+		}
+		return base64.StdEncoding.EncodeToString(tokenBytes), nil
+	}
+	return "", nil
+}

--- a/pkg/system/hub/internal/hubpage/hubpage_test.go
+++ b/pkg/system/hub/internal/hubpage/hubpage_test.go
@@ -1,0 +1,111 @@
+package hubpage
+
+import (
+	"testing"
+
+	"github.com/smart-core-os/sc-bos/pkg/proto/hubpb"
+)
+
+func nodes(names ...string) []*hubpb.HubNode {
+	out := make([]*hubpb.HubNode, len(names))
+	for i, n := range names {
+		out[i] = &hubpb.HubNode{Name: n}
+	}
+	return out
+}
+
+func names(ns []*hubpb.HubNode) []string {
+	out := make([]string, len(ns))
+	for i, n := range ns {
+		out[i] = n.GetName()
+	}
+	return out
+}
+
+func TestPaginate_SinglePage(t *testing.T) {
+	page, next, total, err := Paginate(nodes("c", "a", "b"), 50, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	if next != "" {
+		t.Errorf("next = %q, want empty (no more pages)", next)
+	}
+	// results are sorted by name
+	got := names(page)
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("page = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("page = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestPaginate_TraversesAllPagesInOrderWithoutGapsOrDuplicates(t *testing.T) {
+	all := nodes("e", "b", "g", "a", "f", "d", "c") // 7 nodes, unsorted
+	want := []string{"a", "b", "c", "d", "e", "f", "g"}
+
+	var got []string
+	token := ""
+	iterations := 0
+	for {
+		iterations++
+		if iterations > 100 {
+			t.Fatal("pagination did not terminate")
+		}
+		page, next, total, err := Paginate(all, 3, token)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != int32(len(all)) {
+			t.Errorf("total = %d, want %d", total, len(all))
+		}
+		got = append(got, names(page)...)
+		if next == "" {
+			break
+		}
+		token = next
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("traversed %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("traversed %v, want %v", got, want)
+		}
+	}
+}
+
+func TestPaginate_Empty(t *testing.T) {
+	page, next, total, err := Paginate(nil, 10, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page) != 0 || next != "" || total != 0 {
+		t.Errorf("got page=%v next=%q total=%d, want empty", names(page), next, total)
+	}
+}
+
+func TestPaginate_PageSizeCapAndDefault(t *testing.T) {
+	all := nodes("a", "b", "c")
+	// pageSize 0 falls back to the default (50), so all fit on one page.
+	page, next, _, err := Paginate(all, 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page) != 3 || next != "" {
+		t.Errorf("default page size: got %d nodes next=%q, want 3 and empty", len(page), next)
+	}
+}
+
+func TestPaginate_BadToken(t *testing.T) {
+	if _, _, _, err := Paginate(nodes("a"), 10, "!!!not-base64!!!"); err == nil {
+		t.Error("expected error for malformed page token, got nil")
+	}
+}

--- a/pkg/system/hub/pgxhub/server.go
+++ b/pkg/system/hub/pgxhub/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/proto/hubpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/metadatapb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/typespb"
+	"github.com/smart-core-os/sc-bos/pkg/system/hub/internal/hubpage"
 	"github.com/smart-core-os/sc-bos/pkg/system/hub/remote"
 )
 
@@ -163,7 +164,8 @@ func (n *Server) deleteHubNode(ctx context.Context, reg *hubpb.HubNode) error {
 	}, n.TestTLSConfig)
 }
 
-func (n *Server) ListHubNodes(ctx context.Context, request *hubpb.ListHubNodesRequest) (*hubpb.ListHubNodesResponse, error) {
+// listAllHubNodes returns every enrolled node, unpaginated.
+func (n *Server) listAllHubNodes(ctx context.Context) ([]*hubpb.HubNode, error) {
 	logger := rpcutil.ServerLogger(ctx, n.logger)
 	var dbEnrollments []Enrollment
 	err := pgx.BeginFunc(ctx, n.pool, func(tx pgx.Tx) (err error) {
@@ -183,8 +185,25 @@ func (n *Server) ListHubNodes(ctx context.Context, request *hubpb.ListHubNodesRe
 			Description: en.Description,
 		})
 	}
+	return registrations, nil
+}
 
-	return &hubpb.ListHubNodesResponse{Nodes: registrations}, nil
+func (n *Server) ListHubNodes(ctx context.Context, request *hubpb.ListHubNodesRequest) (*hubpb.ListHubNodesResponse, error) {
+	all, err := n.listAllHubNodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes, nextPageToken, total, err := hubpage.Paginate(all, request.GetPageSize(), request.GetPageToken())
+	if err != nil {
+		return nil, err
+	}
+
+	return &hubpb.ListHubNodesResponse{
+		Nodes:         nodes,
+		NextPageToken: nextPageToken,
+		TotalSize:     total,
+	}, nil
 }
 
 func (n *Server) PullHubNodes(request *hubpb.PullHubNodesRequest, server hubpb.HubApi_PullHubNodesServer) error {
@@ -193,11 +212,11 @@ func (n *Server) PullHubNodes(request *hubpb.PullHubNodesRequest, server hubpb.H
 	events := n.dbChanges.Listen(server.Context())
 
 	if !request.UpdatesOnly {
-		nodes, err := n.ListHubNodes(server.Context(), &hubpb.ListHubNodesRequest{})
+		nodes, err := n.listAllHubNodes(server.Context())
 		if err != nil {
 			return err
 		}
-		for _, node := range nodes.Nodes {
+		for _, node := range nodes {
 			err := server.Send(&hubpb.PullHubNodesResponse{Changes: []*hubpb.PullHubNodesResponse_Change{
 				{
 					Type:       typespb.ChangeType_ADD,

--- a/pkg/system/tenants/pgxtenants/pages.go
+++ b/pkg/system/tenants/pgxtenants/pages.go
@@ -1,0 +1,92 @@
+package pgxtenants
+
+import (
+	"encoding/base64"
+	"sort"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smart-core-os/sc-bos/pkg/proto/typespb"
+)
+
+const (
+	defaultPageSize = 50
+	maxPageSize     = 1000
+)
+
+// paginate sorts items by key and returns the page identified by pageSize and pageToken.
+// It returns the page, a token for the next page (empty when there are no more pages),
+// and the total number of items across all pages. items is sorted in place.
+func paginate[T any](items []T, pageSize int32, pageToken string, key func(T) string) (page []T, nextPageToken string, total int32, err error) {
+	token := &typespb.PageToken{}
+	if err := decodePageToken(pageToken, token); err != nil {
+		return nil, "", 0, err
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return key(items[i]) < key(items[j])
+	})
+
+	lastKey := token.GetLastResourceName() // the id of the last item we sent
+	nextIndex := 0
+	if lastKey != "" {
+		nextIndex = sort.Search(len(items), func(i int) bool {
+			return key(items[i]) >= lastKey
+		})
+		if nextIndex < len(items) && key(items[nextIndex]) == lastKey {
+			nextIndex++
+		}
+	}
+
+	upperBound := nextIndex + capPageSize(int(pageSize))
+	if upperBound > len(items) {
+		upperBound = len(items)
+		token = nil
+	} else {
+		token.PageStart = &typespb.PageToken_LastResourceName{
+			LastResourceName: key(items[upperBound-1]),
+		}
+	}
+
+	nextPageToken, err = encodePageToken(token)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	return items[nextIndex:upperBound], nextPageToken, int32(len(items)), nil
+}
+
+func capPageSize(pageSize int) int {
+	if pageSize == 0 {
+		return defaultPageSize
+	}
+	if pageSize > maxPageSize {
+		return maxPageSize
+	}
+	return pageSize
+}
+
+func decodePageToken(token string, pageToken *typespb.PageToken) error {
+	if token != "" {
+		tokenBytes, err := base64.StdEncoding.DecodeString(token)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "bad page token: %v", err)
+		}
+		if err := proto.Unmarshal(tokenBytes, pageToken); err != nil {
+			return status.Errorf(codes.InvalidArgument, "bad page token: %v", err)
+		}
+	}
+	return nil
+}
+
+func encodePageToken(pageToken *typespb.PageToken) (string, error) {
+	if pageToken != nil {
+		tokenBytes, err := proto.Marshal(pageToken)
+		if err != nil {
+			return "", status.Errorf(codes.Unknown, "unable to create page token: %v", err)
+		}
+		return base64.StdEncoding.EncodeToString(tokenBytes), nil
+	}
+	return "", nil
+}

--- a/pkg/system/tenants/pgxtenants/pgx.go
+++ b/pkg/system/tenants/pgxtenants/pgx.go
@@ -81,7 +81,17 @@ func (s *Server) ListTenants(ctx context.Context, request *tenantpb.ListTenantsR
 		return nil, errDatabase
 	}
 
-	return &tenantpb.ListTenantsResponse{Tenants: tenants}, nil
+	page, nextPageToken, total, err := paginate(tenants, request.GetPageSize(), request.GetPageToken(),
+		func(t *tenantpb.Tenant) string { return t.GetId() })
+	if err != nil {
+		return nil, err
+	}
+
+	return &tenantpb.ListTenantsResponse{
+		Tenants:       page,
+		NextPageToken: nextPageToken,
+		TotalSize:     total,
+	}, nil
 }
 
 func (s *Server) PullTenants(request *tenantpb.PullTenantsRequest, server tenantpb.TenantApi_PullTenantsServer) error {
@@ -265,14 +275,25 @@ func (s *Server) ListSecrets(ctx context.Context, request *tenantpb.ListSecretsR
 		logger.Error("db.ListTenantSecrets failed", zap.Error(err))
 		return nil, errDatabase
 	}
+
+	page, nextPageToken, total, err := paginate(secrets, request.GetPageSize(), request.GetPageToken(),
+		func(s *tenantpb.Secret) string { return s.GetId() })
+	if err != nil {
+		return nil, err
+	}
+
 	// unless specifically requested, censor the hashes
 	if !request.IncludeHash {
-		for i := range secrets {
-			secrets[i].SecretHash = nil
+		for i := range page {
+			page[i].SecretHash = nil
 		}
 	}
 
-	return &tenantpb.ListSecretsResponse{Secrets: secrets}, nil
+	return &tenantpb.ListSecretsResponse{
+		Secrets:       page,
+		NextPageToken: nextPageToken,
+		TotalSize:     total,
+	}, nil
 }
 
 func (s *Server) PullSecrets(request *tenantpb.PullSecretsRequest, server tenantpb.TenantApi_PullSecretsServer) error {

--- a/proto/smartcore/bos/booking/v1/booking.proto
+++ b/proto/smartcore/bos/booking/v1/booking.proto
@@ -91,12 +91,31 @@ message ListBookingsRequest {
   google.protobuf.FieldMask read_mask = 3;
   // When true the device will only send changes to the resource value.
   // The default behaviour is to send the current value immediately followed by any updates as they happen.
+  // Only applies to PullBookings; ignored by ListBookings.
   bool updates_only = 4;
+
+  // The maximum number of bookings to return.
+  // The service may return fewer than this value.
+  // If unspecified, at most 50 items will be returned.
+  // The maximum value is 1000; values above 1000 will be coerced to 1000.
+  // Only applies to ListBookings; ignored by PullBookings.
+  int32 page_size = 5;
+  // A page token, received from a previous `ListBookingsResponse` call.
+  // Provide this to retrieve the subsequent page.
+  // Only applies to ListBookings; ignored by PullBookings.
+  string page_token = 6;
 }
 
 message ListBookingsResponse {
   // the list of bookings for the given request
   repeated Booking bookings = 1;
+
+  // A token, which can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
+  // If non-zero this is the total number of bookings.
+  // This may be an estimate.
+  int32 total_size = 3;
 }
 
 message CheckInBookingRequest {

--- a/proto/smartcore/bos/hub/v1/hub.proto
+++ b/proto/smartcore/bos/hub/v1/hub.proto
@@ -64,11 +64,25 @@ message RenewHubNodeRequest {
 }
 
 message ListHubNodesRequest {
-
+  // The maximum number of nodes to return.
+  // The service may return fewer than this value.
+  // If unspecified, at most 50 items will be returned.
+  // The maximum value is 1000; values above 1000 will be coerced to 1000.
+  int32 page_size = 1;
+  // A page token, received from a previous `ListHubNodesResponse` call.
+  // Provide this to retrieve the subsequent page.
+  string page_token = 2;
 }
 
 message ListHubNodesResponse {
   repeated HubNode nodes = 1;
+
+  // A token, which can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
+  // If non-zero this is the total number of hub nodes.
+  // This may be an estimate.
+  int32 total_size = 3;
 }
 
 message PullHubNodesRequest {

--- a/proto/smartcore/bos/tenant/v1/tenants.proto
+++ b/proto/smartcore/bos/tenant/v1/tenants.proto
@@ -73,10 +73,24 @@ service TenantApi {
 }
 
 message ListTenantsRequest {
-  // TODO: paging
+  // The maximum number of tenants to return.
+  // The service may return fewer than this value.
+  // If unspecified, at most 50 items will be returned.
+  // The maximum value is 1000; values above 1000 will be coerced to 1000.
+  int32 page_size = 1;
+  // A page token, received from a previous `ListTenantsResponse` call.
+  // Provide this to retrieve the subsequent page.
+  string page_token = 2;
 }
 message ListTenantsResponse {
   repeated Tenant tenants = 1;
+
+  // A token, which can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
+  // If non-zero this is the total number of tenants.
+  // This may be an estimate.
+  int32 total_size = 3;
 }
 
 message PullTenantsRequest {
@@ -135,10 +149,25 @@ message RemoveTenantZonesRequest {
 message ListSecretsRequest {
   bool include_hash = 1;
   string filter = 2;
-  // TODO: paging
+
+  // The maximum number of secrets to return.
+  // The service may return fewer than this value.
+  // If unspecified, at most 50 items will be returned.
+  // The maximum value is 1000; values above 1000 will be coerced to 1000.
+  int32 page_size = 3;
+  // A page token, received from a previous `ListSecretsResponse` call.
+  // Provide this to retrieve the subsequent page.
+  string page_token = 4;
 }
 message ListSecretsResponse {
   repeated Secret secrets = 1;
+
+  // A token, which can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
+  // If non-zero this is the total number of secrets.
+  // This may be an estimate.
+  int32 total_size = 3;
 }
 
 message PullSecretsRequest {

--- a/ui/ui-gen/proto/smartcore/bos/booking/v1/booking_pb.d.ts
+++ b/ui/ui-gen/proto/smartcore/bos/booking/v1/booking_pb.d.ts
@@ -110,6 +110,12 @@ export class ListBookingsRequest extends jspb.Message {
   getUpdatesOnly(): boolean;
   setUpdatesOnly(value: boolean): ListBookingsRequest;
 
+  getPageSize(): number;
+  setPageSize(value: number): ListBookingsRequest;
+
+  getPageToken(): string;
+  setPageToken(value: string): ListBookingsRequest;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ListBookingsRequest.AsObject;
   static toObject(includeInstance: boolean, msg: ListBookingsRequest): ListBookingsRequest.AsObject;
@@ -124,6 +130,8 @@ export namespace ListBookingsRequest {
     bookingIntersects?: smartcore_bos_types_time_v1_period_pb.Period.AsObject;
     readMask?: google_protobuf_field_mask_pb.FieldMask.AsObject;
     updatesOnly: boolean;
+    pageSize: number;
+    pageToken: string;
   };
 }
 
@@ -132,6 +140,12 @@ export class ListBookingsResponse extends jspb.Message {
   setBookingsList(value: Array<Booking>): ListBookingsResponse;
   clearBookingsList(): ListBookingsResponse;
   addBookings(value?: Booking, index?: number): Booking;
+
+  getNextPageToken(): string;
+  setNextPageToken(value: string): ListBookingsResponse;
+
+  getTotalSize(): number;
+  setTotalSize(value: number): ListBookingsResponse;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ListBookingsResponse.AsObject;
@@ -144,6 +158,8 @@ export class ListBookingsResponse extends jspb.Message {
 export namespace ListBookingsResponse {
   export type AsObject = {
     bookingsList: Array<Booking.AsObject>;
+    nextPageToken: string;
+    totalSize: number;
   };
 }
 

--- a/ui/ui-gen/proto/smartcore/bos/booking/v1/booking_pb.js
+++ b/ui/ui-gen/proto/smartcore/bos/booking/v1/booking_pb.js
@@ -996,7 +996,9 @@ proto.smartcore.bos.booking.v1.ListBookingsRequest.toObject = function(includeIn
 name: jspb.Message.getFieldWithDefault(msg, 1, ""),
 bookingIntersects: (f = msg.getBookingIntersects()) && smartcore_bos_types_time_v1_period_pb.Period.toObject(includeInstance, f),
 readMask: (f = msg.getReadMask()) && google_protobuf_field_mask_pb.FieldMask.toObject(includeInstance, f),
-updatesOnly: jspb.Message.getBooleanFieldWithDefault(msg, 4, false)
+updatesOnly: jspb.Message.getBooleanFieldWithDefault(msg, 4, false),
+pageSize: jspb.Message.getFieldWithDefault(msg, 5, 0),
+pageToken: jspb.Message.getFieldWithDefault(msg, 6, "")
   };
 
   if (includeInstance) {
@@ -1050,6 +1052,14 @@ proto.smartcore.bos.booking.v1.ListBookingsRequest.deserializeBinaryFromReader =
     case 4:
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setUpdatesOnly(value);
+      break;
+    case 5:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setPageSize(value);
+      break;
+    case 6:
+      var value = /** @type {string} */ (reader.readStringRequireUtf8());
+      msg.setPageToken(value);
       break;
     default:
       reader.skipField();
@@ -1107,6 +1117,20 @@ proto.smartcore.bos.booking.v1.ListBookingsRequest.serializeBinaryToWriter = fun
   if (f) {
     writer.writeBool(
       4,
+      f
+    );
+  }
+  f = message.getPageSize();
+  if (f !== 0) {
+    writer.writeInt32(
+      5,
+      f
+    );
+  }
+  f = message.getPageToken();
+  if (f.length > 0) {
+    writer.writeString(
+      6,
       f
     );
   }
@@ -1223,6 +1247,42 @@ proto.smartcore.bos.booking.v1.ListBookingsRequest.prototype.setUpdatesOnly = fu
 };
 
 
+/**
+ * optional int32 page_size = 5;
+ * @return {number}
+ */
+proto.smartcore.bos.booking.v1.ListBookingsRequest.prototype.getPageSize = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 5, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.smartcore.bos.booking.v1.ListBookingsRequest} returns this
+ */
+proto.smartcore.bos.booking.v1.ListBookingsRequest.prototype.setPageSize = function(value) {
+  return jspb.Message.setProto3IntField(this, 5, value);
+};
+
+
+/**
+ * optional string page_token = 6;
+ * @return {string}
+ */
+proto.smartcore.bos.booking.v1.ListBookingsRequest.prototype.getPageToken = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 6, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.smartcore.bos.booking.v1.ListBookingsRequest} returns this
+ */
+proto.smartcore.bos.booking.v1.ListBookingsRequest.prototype.setPageToken = function(value) {
+  return jspb.Message.setProto3StringField(this, 6, value);
+};
+
+
 
 /**
  * List of repeated fields within this message type.
@@ -1263,7 +1323,9 @@ proto.smartcore.bos.booking.v1.ListBookingsResponse.prototype.toObject = functio
 proto.smartcore.bos.booking.v1.ListBookingsResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
 bookingsList: jspb.Message.toObjectList(msg.getBookingsList(),
-    proto.smartcore.bos.booking.v1.Booking.toObject, includeInstance)
+    proto.smartcore.bos.booking.v1.Booking.toObject, includeInstance),
+nextPageToken: jspb.Message.getFieldWithDefault(msg, 2, ""),
+totalSize: jspb.Message.getFieldWithDefault(msg, 3, 0)
   };
 
   if (includeInstance) {
@@ -1305,6 +1367,14 @@ proto.smartcore.bos.booking.v1.ListBookingsResponse.deserializeBinaryFromReader 
       reader.readMessage(value,proto.smartcore.bos.booking.v1.Booking.deserializeBinaryFromReader);
       msg.addBookings(value);
       break;
+    case 2:
+      var value = /** @type {string} */ (reader.readStringRequireUtf8());
+      msg.setNextPageToken(value);
+      break;
+    case 3:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setTotalSize(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -1340,6 +1410,20 @@ proto.smartcore.bos.booking.v1.ListBookingsResponse.serializeBinaryToWriter = fu
       1,
       f,
       proto.smartcore.bos.booking.v1.Booking.serializeBinaryToWriter
+    );
+  }
+  f = message.getNextPageToken();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+  f = message.getTotalSize();
+  if (f !== 0) {
+    writer.writeInt32(
+      3,
+      f
     );
   }
 };
@@ -1380,6 +1464,42 @@ proto.smartcore.bos.booking.v1.ListBookingsResponse.prototype.addBookings = func
  */
 proto.smartcore.bos.booking.v1.ListBookingsResponse.prototype.clearBookingsList = function() {
   return this.setBookingsList([]);
+};
+
+
+/**
+ * optional string next_page_token = 2;
+ * @return {string}
+ */
+proto.smartcore.bos.booking.v1.ListBookingsResponse.prototype.getNextPageToken = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.smartcore.bos.booking.v1.ListBookingsResponse} returns this
+ */
+proto.smartcore.bos.booking.v1.ListBookingsResponse.prototype.setNextPageToken = function(value) {
+  return jspb.Message.setProto3StringField(this, 2, value);
+};
+
+
+/**
+ * optional int32 total_size = 3;
+ * @return {number}
+ */
+proto.smartcore.bos.booking.v1.ListBookingsResponse.prototype.getTotalSize = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.smartcore.bos.booking.v1.ListBookingsResponse} returns this
+ */
+proto.smartcore.bos.booking.v1.ListBookingsResponse.prototype.setTotalSize = function(value) {
+  return jspb.Message.setProto3IntField(this, 3, value);
 };
 
 

--- a/ui/ui-gen/proto/smartcore/bos/hub/v1/hub_pb.d.ts
+++ b/ui/ui-gen/proto/smartcore/bos/hub/v1/hub_pb.d.ts
@@ -120,6 +120,12 @@ export namespace RenewHubNodeRequest {
 }
 
 export class ListHubNodesRequest extends jspb.Message {
+  getPageSize(): number;
+  setPageSize(value: number): ListHubNodesRequest;
+
+  getPageToken(): string;
+  setPageToken(value: string): ListHubNodesRequest;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ListHubNodesRequest.AsObject;
   static toObject(includeInstance: boolean, msg: ListHubNodesRequest): ListHubNodesRequest.AsObject;
@@ -130,6 +136,8 @@ export class ListHubNodesRequest extends jspb.Message {
 
 export namespace ListHubNodesRequest {
   export type AsObject = {
+    pageSize: number;
+    pageToken: string;
   };
 }
 
@@ -138,6 +146,12 @@ export class ListHubNodesResponse extends jspb.Message {
   setNodesList(value: Array<HubNode>): ListHubNodesResponse;
   clearNodesList(): ListHubNodesResponse;
   addNodes(value?: HubNode, index?: number): HubNode;
+
+  getNextPageToken(): string;
+  setNextPageToken(value: string): ListHubNodesResponse;
+
+  getTotalSize(): number;
+  setTotalSize(value: number): ListHubNodesResponse;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ListHubNodesResponse.AsObject;
@@ -150,6 +164,8 @@ export class ListHubNodesResponse extends jspb.Message {
 export namespace ListHubNodesResponse {
   export type AsObject = {
     nodesList: Array<HubNode.AsObject>;
+    nextPageToken: string;
+    totalSize: number;
   };
 }
 

--- a/ui/ui-gen/proto/smartcore/bos/hub/v1/hub_pb.js
+++ b/ui/ui-gen/proto/smartcore/bos/hub/v1/hub_pb.js
@@ -1247,7 +1247,8 @@ proto.smartcore.bos.hub.v1.ListHubNodesRequest.prototype.toObject = function(opt
  */
 proto.smartcore.bos.hub.v1.ListHubNodesRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
-
+pageSize: jspb.Message.getFieldWithDefault(msg, 1, 0),
+pageToken: jspb.Message.getFieldWithDefault(msg, 2, "")
   };
 
   if (includeInstance) {
@@ -1284,6 +1285,14 @@ proto.smartcore.bos.hub.v1.ListHubNodesRequest.deserializeBinaryFromReader = fun
     }
     var field = reader.getFieldNumber();
     switch (field) {
+    case 1:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setPageSize(value);
+      break;
+    case 2:
+      var value = /** @type {string} */ (reader.readStringRequireUtf8());
+      msg.setPageToken(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -1313,6 +1322,56 @@ proto.smartcore.bos.hub.v1.ListHubNodesRequest.prototype.serializeBinary = funct
  */
 proto.smartcore.bos.hub.v1.ListHubNodesRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
+  f = message.getPageSize();
+  if (f !== 0) {
+    writer.writeInt32(
+      1,
+      f
+    );
+  }
+  f = message.getPageToken();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional int32 page_size = 1;
+ * @return {number}
+ */
+proto.smartcore.bos.hub.v1.ListHubNodesRequest.prototype.getPageSize = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.smartcore.bos.hub.v1.ListHubNodesRequest} returns this
+ */
+proto.smartcore.bos.hub.v1.ListHubNodesRequest.prototype.setPageSize = function(value) {
+  return jspb.Message.setProto3IntField(this, 1, value);
+};
+
+
+/**
+ * optional string page_token = 2;
+ * @return {string}
+ */
+proto.smartcore.bos.hub.v1.ListHubNodesRequest.prototype.getPageToken = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.smartcore.bos.hub.v1.ListHubNodesRequest} returns this
+ */
+proto.smartcore.bos.hub.v1.ListHubNodesRequest.prototype.setPageToken = function(value) {
+  return jspb.Message.setProto3StringField(this, 2, value);
 };
 
 
@@ -1356,7 +1415,9 @@ proto.smartcore.bos.hub.v1.ListHubNodesResponse.prototype.toObject = function(op
 proto.smartcore.bos.hub.v1.ListHubNodesResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
 nodesList: jspb.Message.toObjectList(msg.getNodesList(),
-    proto.smartcore.bos.hub.v1.HubNode.toObject, includeInstance)
+    proto.smartcore.bos.hub.v1.HubNode.toObject, includeInstance),
+nextPageToken: jspb.Message.getFieldWithDefault(msg, 2, ""),
+totalSize: jspb.Message.getFieldWithDefault(msg, 3, 0)
   };
 
   if (includeInstance) {
@@ -1398,6 +1459,14 @@ proto.smartcore.bos.hub.v1.ListHubNodesResponse.deserializeBinaryFromReader = fu
       reader.readMessage(value,proto.smartcore.bos.hub.v1.HubNode.deserializeBinaryFromReader);
       msg.addNodes(value);
       break;
+    case 2:
+      var value = /** @type {string} */ (reader.readStringRequireUtf8());
+      msg.setNextPageToken(value);
+      break;
+    case 3:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setTotalSize(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -1433,6 +1502,20 @@ proto.smartcore.bos.hub.v1.ListHubNodesResponse.serializeBinaryToWriter = functi
       1,
       f,
       proto.smartcore.bos.hub.v1.HubNode.serializeBinaryToWriter
+    );
+  }
+  f = message.getNextPageToken();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+  f = message.getTotalSize();
+  if (f !== 0) {
+    writer.writeInt32(
+      3,
+      f
     );
   }
 };
@@ -1473,6 +1556,42 @@ proto.smartcore.bos.hub.v1.ListHubNodesResponse.prototype.addNodes = function(op
  */
 proto.smartcore.bos.hub.v1.ListHubNodesResponse.prototype.clearNodesList = function() {
   return this.setNodesList([]);
+};
+
+
+/**
+ * optional string next_page_token = 2;
+ * @return {string}
+ */
+proto.smartcore.bos.hub.v1.ListHubNodesResponse.prototype.getNextPageToken = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.smartcore.bos.hub.v1.ListHubNodesResponse} returns this
+ */
+proto.smartcore.bos.hub.v1.ListHubNodesResponse.prototype.setNextPageToken = function(value) {
+  return jspb.Message.setProto3StringField(this, 2, value);
+};
+
+
+/**
+ * optional int32 total_size = 3;
+ * @return {number}
+ */
+proto.smartcore.bos.hub.v1.ListHubNodesResponse.prototype.getTotalSize = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.smartcore.bos.hub.v1.ListHubNodesResponse} returns this
+ */
+proto.smartcore.bos.hub.v1.ListHubNodesResponse.prototype.setTotalSize = function(value) {
+  return jspb.Message.setProto3IntField(this, 3, value);
 };
 
 

--- a/ui/ui-gen/proto/smartcore/bos/tenant/v1/tenants_pb.d.ts
+++ b/ui/ui-gen/proto/smartcore/bos/tenant/v1/tenants_pb.d.ts
@@ -109,6 +109,12 @@ export namespace Secret {
 }
 
 export class ListTenantsRequest extends jspb.Message {
+  getPageSize(): number;
+  setPageSize(value: number): ListTenantsRequest;
+
+  getPageToken(): string;
+  setPageToken(value: string): ListTenantsRequest;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ListTenantsRequest.AsObject;
   static toObject(includeInstance: boolean, msg: ListTenantsRequest): ListTenantsRequest.AsObject;
@@ -119,6 +125,8 @@ export class ListTenantsRequest extends jspb.Message {
 
 export namespace ListTenantsRequest {
   export type AsObject = {
+    pageSize: number;
+    pageToken: string;
   };
 }
 
@@ -127,6 +135,12 @@ export class ListTenantsResponse extends jspb.Message {
   setTenantsList(value: Array<Tenant>): ListTenantsResponse;
   clearTenantsList(): ListTenantsResponse;
   addTenants(value?: Tenant, index?: number): Tenant;
+
+  getNextPageToken(): string;
+  setNextPageToken(value: string): ListTenantsResponse;
+
+  getTotalSize(): number;
+  setTotalSize(value: number): ListTenantsResponse;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ListTenantsResponse.AsObject;
@@ -139,6 +153,8 @@ export class ListTenantsResponse extends jspb.Message {
 export namespace ListTenantsResponse {
   export type AsObject = {
     tenantsList: Array<Tenant.AsObject>;
+    nextPageToken: string;
+    totalSize: number;
   };
 }
 
@@ -427,6 +443,12 @@ export class ListSecretsRequest extends jspb.Message {
   getFilter(): string;
   setFilter(value: string): ListSecretsRequest;
 
+  getPageSize(): number;
+  setPageSize(value: number): ListSecretsRequest;
+
+  getPageToken(): string;
+  setPageToken(value: string): ListSecretsRequest;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ListSecretsRequest.AsObject;
   static toObject(includeInstance: boolean, msg: ListSecretsRequest): ListSecretsRequest.AsObject;
@@ -439,6 +461,8 @@ export namespace ListSecretsRequest {
   export type AsObject = {
     includeHash: boolean;
     filter: string;
+    pageSize: number;
+    pageToken: string;
   };
 }
 
@@ -447,6 +471,12 @@ export class ListSecretsResponse extends jspb.Message {
   setSecretsList(value: Array<Secret>): ListSecretsResponse;
   clearSecretsList(): ListSecretsResponse;
   addSecrets(value?: Secret, index?: number): Secret;
+
+  getNextPageToken(): string;
+  setNextPageToken(value: string): ListSecretsResponse;
+
+  getTotalSize(): number;
+  setTotalSize(value: number): ListSecretsResponse;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ListSecretsResponse.AsObject;
@@ -459,6 +489,8 @@ export class ListSecretsResponse extends jspb.Message {
 export namespace ListSecretsResponse {
   export type AsObject = {
     secretsList: Array<Secret.AsObject>;
+    nextPageToken: string;
+    totalSize: number;
   };
 }
 

--- a/ui/ui-gen/proto/smartcore/bos/tenant/v1/tenants_pb.js
+++ b/ui/ui-gen/proto/smartcore/bos/tenant/v1/tenants_pb.js
@@ -1603,7 +1603,8 @@ proto.smartcore.bos.tenant.v1.ListTenantsRequest.prototype.toObject = function(o
  */
 proto.smartcore.bos.tenant.v1.ListTenantsRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
-
+pageSize: jspb.Message.getFieldWithDefault(msg, 1, 0),
+pageToken: jspb.Message.getFieldWithDefault(msg, 2, "")
   };
 
   if (includeInstance) {
@@ -1640,6 +1641,14 @@ proto.smartcore.bos.tenant.v1.ListTenantsRequest.deserializeBinaryFromReader = f
     }
     var field = reader.getFieldNumber();
     switch (field) {
+    case 1:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setPageSize(value);
+      break;
+    case 2:
+      var value = /** @type {string} */ (reader.readStringRequireUtf8());
+      msg.setPageToken(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -1669,6 +1678,56 @@ proto.smartcore.bos.tenant.v1.ListTenantsRequest.prototype.serializeBinary = fun
  */
 proto.smartcore.bos.tenant.v1.ListTenantsRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
+  f = message.getPageSize();
+  if (f !== 0) {
+    writer.writeInt32(
+      1,
+      f
+    );
+  }
+  f = message.getPageToken();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional int32 page_size = 1;
+ * @return {number}
+ */
+proto.smartcore.bos.tenant.v1.ListTenantsRequest.prototype.getPageSize = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.smartcore.bos.tenant.v1.ListTenantsRequest} returns this
+ */
+proto.smartcore.bos.tenant.v1.ListTenantsRequest.prototype.setPageSize = function(value) {
+  return jspb.Message.setProto3IntField(this, 1, value);
+};
+
+
+/**
+ * optional string page_token = 2;
+ * @return {string}
+ */
+proto.smartcore.bos.tenant.v1.ListTenantsRequest.prototype.getPageToken = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.smartcore.bos.tenant.v1.ListTenantsRequest} returns this
+ */
+proto.smartcore.bos.tenant.v1.ListTenantsRequest.prototype.setPageToken = function(value) {
+  return jspb.Message.setProto3StringField(this, 2, value);
 };
 
 
@@ -1712,7 +1771,9 @@ proto.smartcore.bos.tenant.v1.ListTenantsResponse.prototype.toObject = function(
 proto.smartcore.bos.tenant.v1.ListTenantsResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
 tenantsList: jspb.Message.toObjectList(msg.getTenantsList(),
-    proto.smartcore.bos.tenant.v1.Tenant.toObject, includeInstance)
+    proto.smartcore.bos.tenant.v1.Tenant.toObject, includeInstance),
+nextPageToken: jspb.Message.getFieldWithDefault(msg, 2, ""),
+totalSize: jspb.Message.getFieldWithDefault(msg, 3, 0)
   };
 
   if (includeInstance) {
@@ -1754,6 +1815,14 @@ proto.smartcore.bos.tenant.v1.ListTenantsResponse.deserializeBinaryFromReader = 
       reader.readMessage(value,proto.smartcore.bos.tenant.v1.Tenant.deserializeBinaryFromReader);
       msg.addTenants(value);
       break;
+    case 2:
+      var value = /** @type {string} */ (reader.readStringRequireUtf8());
+      msg.setNextPageToken(value);
+      break;
+    case 3:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setTotalSize(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -1789,6 +1858,20 @@ proto.smartcore.bos.tenant.v1.ListTenantsResponse.serializeBinaryToWriter = func
       1,
       f,
       proto.smartcore.bos.tenant.v1.Tenant.serializeBinaryToWriter
+    );
+  }
+  f = message.getNextPageToken();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+  f = message.getTotalSize();
+  if (f !== 0) {
+    writer.writeInt32(
+      3,
+      f
     );
   }
 };
@@ -1829,6 +1912,42 @@ proto.smartcore.bos.tenant.v1.ListTenantsResponse.prototype.addTenants = functio
  */
 proto.smartcore.bos.tenant.v1.ListTenantsResponse.prototype.clearTenantsList = function() {
   return this.setTenantsList([]);
+};
+
+
+/**
+ * optional string next_page_token = 2;
+ * @return {string}
+ */
+proto.smartcore.bos.tenant.v1.ListTenantsResponse.prototype.getNextPageToken = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.smartcore.bos.tenant.v1.ListTenantsResponse} returns this
+ */
+proto.smartcore.bos.tenant.v1.ListTenantsResponse.prototype.setNextPageToken = function(value) {
+  return jspb.Message.setProto3StringField(this, 2, value);
+};
+
+
+/**
+ * optional int32 total_size = 3;
+ * @return {number}
+ */
+proto.smartcore.bos.tenant.v1.ListTenantsResponse.prototype.getTotalSize = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.smartcore.bos.tenant.v1.ListTenantsResponse} returns this
+ */
+proto.smartcore.bos.tenant.v1.ListTenantsResponse.prototype.setTotalSize = function(value) {
+  return jspb.Message.setProto3IntField(this, 3, value);
 };
 
 
@@ -3965,7 +4084,9 @@ proto.smartcore.bos.tenant.v1.ListSecretsRequest.prototype.toObject = function(o
 proto.smartcore.bos.tenant.v1.ListSecretsRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
 includeHash: jspb.Message.getBooleanFieldWithDefault(msg, 1, false),
-filter: jspb.Message.getFieldWithDefault(msg, 2, "")
+filter: jspb.Message.getFieldWithDefault(msg, 2, ""),
+pageSize: jspb.Message.getFieldWithDefault(msg, 3, 0),
+pageToken: jspb.Message.getFieldWithDefault(msg, 4, "")
   };
 
   if (includeInstance) {
@@ -4010,6 +4131,14 @@ proto.smartcore.bos.tenant.v1.ListSecretsRequest.deserializeBinaryFromReader = f
       var value = /** @type {string} */ (reader.readStringRequireUtf8());
       msg.setFilter(value);
       break;
+    case 3:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setPageSize(value);
+      break;
+    case 4:
+      var value = /** @type {string} */ (reader.readStringRequireUtf8());
+      msg.setPageToken(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -4053,6 +4182,20 @@ proto.smartcore.bos.tenant.v1.ListSecretsRequest.serializeBinaryToWriter = funct
       f
     );
   }
+  f = message.getPageSize();
+  if (f !== 0) {
+    writer.writeInt32(
+      3,
+      f
+    );
+  }
+  f = message.getPageToken();
+  if (f.length > 0) {
+    writer.writeString(
+      4,
+      f
+    );
+  }
 };
 
 
@@ -4089,6 +4232,42 @@ proto.smartcore.bos.tenant.v1.ListSecretsRequest.prototype.getFilter = function(
  */
 proto.smartcore.bos.tenant.v1.ListSecretsRequest.prototype.setFilter = function(value) {
   return jspb.Message.setProto3StringField(this, 2, value);
+};
+
+
+/**
+ * optional int32 page_size = 3;
+ * @return {number}
+ */
+proto.smartcore.bos.tenant.v1.ListSecretsRequest.prototype.getPageSize = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.smartcore.bos.tenant.v1.ListSecretsRequest} returns this
+ */
+proto.smartcore.bos.tenant.v1.ListSecretsRequest.prototype.setPageSize = function(value) {
+  return jspb.Message.setProto3IntField(this, 3, value);
+};
+
+
+/**
+ * optional string page_token = 4;
+ * @return {string}
+ */
+proto.smartcore.bos.tenant.v1.ListSecretsRequest.prototype.getPageToken = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.smartcore.bos.tenant.v1.ListSecretsRequest} returns this
+ */
+proto.smartcore.bos.tenant.v1.ListSecretsRequest.prototype.setPageToken = function(value) {
+  return jspb.Message.setProto3StringField(this, 4, value);
 };
 
 
@@ -4132,7 +4311,9 @@ proto.smartcore.bos.tenant.v1.ListSecretsResponse.prototype.toObject = function(
 proto.smartcore.bos.tenant.v1.ListSecretsResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
 secretsList: jspb.Message.toObjectList(msg.getSecretsList(),
-    proto.smartcore.bos.tenant.v1.Secret.toObject, includeInstance)
+    proto.smartcore.bos.tenant.v1.Secret.toObject, includeInstance),
+nextPageToken: jspb.Message.getFieldWithDefault(msg, 2, ""),
+totalSize: jspb.Message.getFieldWithDefault(msg, 3, 0)
   };
 
   if (includeInstance) {
@@ -4174,6 +4355,14 @@ proto.smartcore.bos.tenant.v1.ListSecretsResponse.deserializeBinaryFromReader = 
       reader.readMessage(value,proto.smartcore.bos.tenant.v1.Secret.deserializeBinaryFromReader);
       msg.addSecrets(value);
       break;
+    case 2:
+      var value = /** @type {string} */ (reader.readStringRequireUtf8());
+      msg.setNextPageToken(value);
+      break;
+    case 3:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setTotalSize(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -4209,6 +4398,20 @@ proto.smartcore.bos.tenant.v1.ListSecretsResponse.serializeBinaryToWriter = func
       1,
       f,
       proto.smartcore.bos.tenant.v1.Secret.serializeBinaryToWriter
+    );
+  }
+  f = message.getNextPageToken();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+  f = message.getTotalSize();
+  if (f !== 0) {
+    writer.writeInt32(
+      3,
+      f
     );
   }
 };
@@ -4249,6 +4452,42 @@ proto.smartcore.bos.tenant.v1.ListSecretsResponse.prototype.addSecrets = functio
  */
 proto.smartcore.bos.tenant.v1.ListSecretsResponse.prototype.clearSecretsList = function() {
   return this.setSecretsList([]);
+};
+
+
+/**
+ * optional string next_page_token = 2;
+ * @return {string}
+ */
+proto.smartcore.bos.tenant.v1.ListSecretsResponse.prototype.getNextPageToken = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.smartcore.bos.tenant.v1.ListSecretsResponse} returns this
+ */
+proto.smartcore.bos.tenant.v1.ListSecretsResponse.prototype.setNextPageToken = function(value) {
+  return jspb.Message.setProto3StringField(this, 2, value);
+};
+
+
+/**
+ * optional int32 total_size = 3;
+ * @return {number}
+ */
+proto.smartcore.bos.tenant.v1.ListSecretsResponse.prototype.getTotalSize = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.smartcore.bos.tenant.v1.ListSecretsResponse} returns this
+ */
+proto.smartcore.bos.tenant.v1.ListSecretsResponse.prototype.setTotalSize = function(value) {
+  return jspb.Message.setProto3IntField(this, 3, value);
 };
 
 


### PR DESCRIPTION
[SCB-696](https://vanti.youtrack.cloud/issue/SCB-696)
Add page_size/page_token request fields and next_page_token/total_size response fields, plus server-side pagination, to the four List RPCs that previously returned unbounded lists:

- BookingApi.ListBookings
- HubApi.ListHubNodes
- TenantApi.ListTenants
- TenantApi.ListSecrets

Implementations follow the existing typespb.PageToken convention (default page size 50, max 1000), sorted by a stable key. A shared hubpage helper backs both the bolt and pgx hub stores. hub.NodeFetcher Poll and PullHubNodes page through / list all nodes so they still observe the full set.