### PR TITLE
feat(stores): support read, write, and admin pgx connection pools

### DIFF
--- a/cmd/tools/dbadd-publications-sample/main.go
+++ b/cmd/tools/dbadd-publications-sample/main.go
@@ -40,9 +40,11 @@ func main() {
 		conf = config.Root{
 			Storage: &config.Storage{
 				Type: "postgres",
-				ConnectConfig: pgxutil.ConnectConfig{
-					URI:          "postgres://postgres@localhost:5432/smart_core",
-					PasswordFile: passFile.Name(),
+				RoleConfig: pgxutil.RoleConfig{
+					ConnectConfig: pgxutil.ConnectConfig{
+						URI:          "postgres://postgres@localhost:5432/smart_core",
+						PasswordFile: passFile.Name(),
+					},
 				},
 			},
 		}

--- a/internal/util/pgxutil/roles.go
+++ b/internal/util/pgxutil/roles.go
@@ -1,0 +1,121 @@
+package pgxutil
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// RoleConfig configures per-privilege postgres connections. The embedded
+// ConnectConfig is the default for any role not explicitly overridden, so a
+// config that only sets uri/passwordFile behaves exactly as a single-pool
+// ConnectConfig did (all three roles share one connection).
+//
+// The Read/Write/Admin overrides let operators connect each role as a distinct
+// database user so that, for example, read queries run over a connection that
+// only holds SELECT permissions.
+type RoleConfig struct {
+	ConnectConfig                // default for all roles
+	Read          *ConnectConfig `json:"read,omitempty"`
+	Write         *ConnectConfig `json:"write,omitempty"`
+	Admin         *ConnectConfig `json:"admin,omitempty"`
+}
+
+// IsZero reports whether no connection is configured at all.
+func (rc RoleConfig) IsZero() bool {
+	return rc.ConnectConfig.IsZero() && rc.Read == nil && rc.Write == nil && rc.Admin == nil
+}
+
+// resolve returns the effective ConnectConfig for each role, falling back to the
+// embedded base config for any role without an explicit override.
+func (rc RoleConfig) resolve() (read, write, admin ConnectConfig) {
+	read, write, admin = rc.ConnectConfig, rc.ConnectConfig, rc.ConnectConfig
+	if rc.Read != nil {
+		read = *rc.Read
+	}
+	if rc.Write != nil {
+		write = *rc.Write
+	}
+	if rc.Admin != nil {
+		admin = *rc.Admin
+	}
+	return read, write, admin
+}
+
+// Pools holds the read, write, and admin connection pools for a postgres store.
+// Read is used for SELECT-only queries, Write for statements (and transactions)
+// that modify data, and Admin for schema DDL and maintenance (VACUUM).
+// Two or more of the pools may share the same underlying *pgxpool.Pool when
+// their configs are identical.
+type Pools struct {
+	Read  *pgxpool.Pool
+	Write *pgxpool.Pool
+	Admin *pgxpool.Pool
+}
+
+// SamePool returns a Pools that uses p for all three roles. Use it when only a
+// single connection is available (e.g. tools and tests).
+func SamePool(p *pgxpool.Pool) Pools {
+	return Pools{Read: p, Write: p, Admin: p}
+}
+
+// Close closes each distinct underlying pool exactly once, so a Pools built from
+// a shared config isn't double-closed.
+func (p Pools) Close() {
+	seen := make(map[*pgxpool.Pool]struct{}, 3)
+	for _, pool := range []*pgxpool.Pool{p.Read, p.Write, p.Admin} {
+		if pool == nil {
+			continue
+		}
+		if _, ok := seen[pool]; ok {
+			continue
+		}
+		seen[pool] = struct{}{}
+		pool.Close()
+	}
+}
+
+// ConnectRoles opens the read, write, and admin pools described by rc. Roles
+// whose effective config is identical share a single pool, so a config with only
+// a base uri opens just one connection pool. If any pool fails to connect, the
+// pools already opened are closed and the error is returned.
+func ConnectRoles(ctx context.Context, rc RoleConfig) (Pools, error) {
+	read, write, admin := rc.resolve()
+
+	cache := make(map[ConnectConfig]*pgxpool.Pool, 3)
+	var opened []*pgxpool.Pool
+
+	fail := func(err error) (Pools, error) {
+		for _, pool := range opened {
+			pool.Close()
+		}
+		return Pools{}, err
+	}
+
+	get := func(cc ConnectConfig) (*pgxpool.Pool, error) {
+		if pool, ok := cache[cc]; ok {
+			return pool, nil
+		}
+		pool, err := Connect(ctx, cc)
+		if err != nil {
+			return nil, err
+		}
+		cache[cc] = pool
+		opened = append(opened, pool)
+		return pool, nil
+	}
+
+	readPool, err := get(read)
+	if err != nil {
+		return fail(err)
+	}
+	writePool, err := get(write)
+	if err != nil {
+		return fail(err)
+	}
+	adminPool, err := get(admin)
+	if err != nil {
+		return fail(err)
+	}
+	return Pools{Read: readPool, Write: writePool, Admin: adminPool}, nil
+}

--- a/internal/util/pgxutil/roles.go
+++ b/internal/util/pgxutil/roles.go
@@ -2,6 +2,7 @@ package pgxutil
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -81,6 +82,19 @@ func (p Pools) Close() {
 // pools already opened are closed and the error is returned.
 func ConnectRoles(ctx context.Context, rc RoleConfig) (Pools, error) {
 	read, write, admin := rc.resolve()
+
+	// A role whose effective config is empty would fall through to libpq env
+	// defaults (PGHOST, ...) rather than failing, which is almost never what the
+	// operator intended. This catches a partial override (e.g. only "read" set
+	// with no base uri), which RoleConfig.IsZero() can't since a role is set.
+	for _, role := range []struct {
+		name string
+		cc   ConnectConfig
+	}{{"read", read}, {"write", write}, {"admin", admin}} {
+		if role.cc.IsZero() {
+			return Pools{}, fmt.Errorf("%s role has no connection config: set a top-level uri or a %q override", role.name, role.name)
+		}
+	}
 
 	cache := make(map[ConnectConfig]*pgxpool.Pool, 3)
 	var opened []*pgxpool.Pool

--- a/internal/util/pgxutil/roles_test.go
+++ b/internal/util/pgxutil/roles_test.go
@@ -1,0 +1,73 @@
+package pgxutil
+
+import "testing"
+
+func TestRoleConfig_IsZero(t *testing.T) {
+	base := ConnectConfig{URI: "postgres://base"}
+	tests := []struct {
+		name string
+		rc   RoleConfig
+		want bool
+	}{
+		{"empty", RoleConfig{}, true},
+		{"base uri", RoleConfig{ConnectConfig: base}, false},
+		{"read only", RoleConfig{Read: &base}, false},
+		{"write only", RoleConfig{Write: &base}, false},
+		{"admin only", RoleConfig{Admin: &base}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.rc.IsZero(); got != tt.want {
+				t.Errorf("IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRoleConfig_resolve(t *testing.T) {
+	base := ConnectConfig{URI: "postgres://base"}
+	r := ConnectConfig{URI: "postgres://read"}
+	w := ConnectConfig{URI: "postgres://write"}
+	a := ConnectConfig{URI: "postgres://admin"}
+
+	tests := []struct {
+		name                    string
+		rc                      RoleConfig
+		wantR, wantW, wantAdmin ConnectConfig
+	}{
+		{
+			name:  "base only falls back for all roles",
+			rc:    RoleConfig{ConnectConfig: base},
+			wantR: base, wantW: base, wantAdmin: base,
+		},
+		{
+			name:  "read override, others fall back to base",
+			rc:    RoleConfig{ConnectConfig: base, Read: &r},
+			wantR: r, wantW: base, wantAdmin: base,
+		},
+		{
+			name:  "each role overridden",
+			rc:    RoleConfig{ConnectConfig: base, Read: &r, Write: &w, Admin: &a},
+			wantR: r, wantW: w, wantAdmin: a,
+		},
+		{
+			name:  "no base, only role overrides",
+			rc:    RoleConfig{Read: &r, Write: &w, Admin: &a},
+			wantR: r, wantW: w, wantAdmin: a,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotR, gotW, gotAdmin := tt.rc.resolve()
+			if gotR != tt.wantR {
+				t.Errorf("read = %v, want %v", gotR, tt.wantR)
+			}
+			if gotW != tt.wantW {
+				t.Errorf("write = %v, want %v", gotW, tt.wantW)
+			}
+			if gotAdmin != tt.wantAdmin {
+				t.Errorf("admin = %v, want %v", gotAdmin, tt.wantAdmin)
+			}
+		})
+	}
+}

--- a/internal/util/pgxutil/roles_test.go
+++ b/internal/util/pgxutil/roles_test.go
@@ -1,6 +1,10 @@
 package pgxutil
 
-import "testing"
+import (
+	"context"
+	"strings"
+	"testing"
+)
 
 func TestRoleConfig_IsZero(t *testing.T) {
 	base := ConnectConfig{URI: "postgres://base"}
@@ -21,6 +25,21 @@ func TestRoleConfig_IsZero(t *testing.T) {
 				t.Errorf("IsZero() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestConnectRoles_partialOverrideNoBase(t *testing.T) {
+	// Only "read" set, no base uri: write and admin resolve to a zero config.
+	// ConnectRoles must reject this rather than let the empty configs fall through
+	// to libpq env defaults. The error should name the first unconfigured role and
+	// no connection should be attempted (the read uri is unreachable in tests).
+	rc := RoleConfig{Read: &ConnectConfig{URI: "postgres://read"}}
+	_, err := ConnectRoles(context.Background(), rc)
+	if err == nil {
+		t.Fatal("expected error for partial role override with no base, got nil")
+	}
+	if !strings.Contains(err.Error(), "write") {
+		t.Errorf("error should name the unconfigured write role, got: %v", err)
 	}
 }
 

--- a/pkg/app/stores/README.md
+++ b/pkg/app/stores/README.md
@@ -1,0 +1,78 @@
+# Stores
+
+The `stores` package provides shared storage connections (databases) for the
+systems and automations running on a controller. It is configured via the
+top-level `stores` block in the controller config:
+
+```json5
+{
+  // other config
+  "stores": {
+    "postgres": {
+      "uri": "postgres://username@localhost:5432/smart_core",
+      "passwordFile": "/secrets/postgres-password"
+    }
+  }
+}
+```
+
+Systems that use postgres (`alerts`, `hub`, `tenants`, `publications`,
+`history`) and the `history` automation borrow this shared pool by default. A
+system can instead open its own dedicated connection by setting a `storage`
+block with its own connection config; see that system's README.
+
+## Read / write / admin roles (least privilege)
+
+Each postgres query runs over a connection scoped to the minimum privilege it
+needs:
+
+- **read** — `SELECT` only
+- **write** — `INSERT` / `UPDATE` / `DELETE` (and any transaction that both reads
+  and writes)
+- **admin** — schema setup (`CREATE` / `ALTER`) and maintenance (`VACUUM`)
+
+By default all three roles use the single `uri`/`passwordFile` above, so a
+single connection pool is opened (no behaviour change). To harden a deployment,
+connect each role as a distinct database user by adding `read`, `write`, and/or
+`admin` sub-blocks. Any role you omit falls back to the top-level config.
+
+```json5
+{
+  "stores": {
+    "postgres": {
+      // admin defaults to the top-level config below unless overridden
+      "uri": "postgres://sc_admin@localhost:5432/smart_core",
+      "passwordFile": "/secrets/sc_admin-password",
+      "read": {
+        "uri": "postgres://sc_read@localhost:5432/smart_core",
+        "passwordFile": "/secrets/sc_read-password"
+      },
+      "write": {
+        "uri": "postgres://sc_write@localhost:5432/smart_core",
+        "passwordFile": "/secrets/sc_write-password"
+      }
+    }
+  }
+}
+```
+
+The three roles are expected to point at the **same database** and differ only
+in the database user (and therefore its privileges).
+
+### Suggested grants
+
+The `admin` role owns the schema (it runs `CREATE TABLE`/`ALTER` on startup and
+`VACUUM`). Once the tables exist, grant the read/write roles the minimum they
+need. For example, per table used by the enabled systems:
+
+```sql
+-- read role: SELECT only
+GRANT SELECT ON <table> TO sc_read;
+
+-- write role: DML (writers often need to read within a transaction too)
+GRANT SELECT, INSERT, UPDATE, DELETE ON <table> TO sc_write;
+
+-- admin role: owns the table (DDL) and can run VACUUM (needs ownership or the
+-- MAINTAIN privilege on PostgreSQL 16+)
+ALTER TABLE <table> OWNER TO sc_admin;
+```

--- a/pkg/app/stores/README.md
+++ b/pkg/app/stores/README.md
@@ -76,3 +76,27 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON <table> TO sc_write;
 -- MAINTAIN privilege on PostgreSQL 16+)
 ALTER TABLE <table> OWNER TO sc_admin;
 ```
+
+Tables with a serial/identity column (currently `history`, whose `id` is
+`BIGSERIAL`) also need the write role to hold `USAGE` on the backing sequence —
+`INSERT ... RETURNING id` calls `nextval()`, which fails with `permission denied
+for sequence` otherwise. Grant it once for the schema so sequences created by
+later migrations are covered too:
+
+```sql
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO sc_write;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO sc_write;
+```
+
+(UUID-keyed tables need nothing extra — `uuid_generate_v4()` is
+`PUBLIC`-executable.)
+
+### Connection sizing
+
+Each role with a distinct config opens its own `pgxpool` pool, and each pool
+defaults to a max of `max(4, numCPU)` connections. Splitting one shared pool
+into `read`/`write`/`admin` therefore multiplies the peak connection count to
+the database by up to three. Size each pool explicitly with the
+`pool_max_conns` query parameter on its `uri` (e.g.
+`postgres://sc_read@host/smart_core?pool_max_conns=4`) so the combined total
+stays within the database's `max_connections`.

--- a/pkg/app/stores/stores.go
+++ b/pkg/app/stores/stores.go
@@ -83,7 +83,6 @@ type postgresStore struct {
 
 	mu            sync.Mutex
 	pools         pgxutil.Pools
-	r, w, admin   *pgxpool.Pool
 	err           error
 	latestErrTime time.Time
 }
@@ -105,8 +104,8 @@ func (s *postgresStore) Postgres() (r, w, admin *pgxpool.Pool, _ error) {
 		return nil, nil, nil, s.err
 	}
 
-	if s.r != nil {
-		return s.r, s.w, s.admin, nil
+	if s.pools.Read != nil {
+		return s.pools.Read, s.pools.Write, s.pools.Admin, nil
 	}
 
 	if s.cfg == nil {
@@ -125,8 +124,7 @@ func (s *postgresStore) Postgres() (r, w, admin *pgxpool.Pool, _ error) {
 	}
 
 	s.pools = pools
-	s.r, s.w, s.admin = pools.Read, pools.Write, pools.Admin
-	return s.r, s.w, s.admin, nil
+	return s.pools.Read, s.pools.Write, s.pools.Admin, nil
 }
 
 // PostgresPoolsFor returns the postgres connection pools a subsystem should use
@@ -155,16 +153,13 @@ func (s *postgresStore) close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.err = fmt.Errorf("postgres: %w", ErrStoreClosed)
-	if s.r == nil {
+	if s.pools.Read == nil {
 		return nil
 	}
 
 	// Close each distinct pool once; roles may share an underlying pool.
 	s.pools.Close()
 	s.pools = pgxutil.Pools{}
-	s.r = nil
-	s.w = nil
-	s.admin = nil
 
 	return nil
 }

--- a/pkg/app/stores/stores.go
+++ b/pkg/app/stores/stores.go
@@ -33,7 +33,7 @@ type Config struct {
 }
 
 type PostgresConfig struct {
-	pgxutil.ConnectConfig
+	pgxutil.RoleConfig
 	// MaxSizeBytes is the maximum storage size, in bytes, the Postgres history store is
 	// allowed to use. Postgres does not report a disk capacity itself, so this must be set
 	// to enable the storage utilisation HealthCheck and the bytes.capacity DataRetention
@@ -82,6 +82,7 @@ type postgresStore struct {
 	cfg *PostgresConfig
 
 	mu            sync.Mutex
+	pools         pgxutil.Pools
 	r, w, admin   *pgxpool.Pool
 	err           error
 	latestErrTime time.Time
@@ -117,15 +118,37 @@ func (s *postgresStore) Postgres() (r, w, admin *pgxpool.Pool, _ error) {
 		return nil, nil, nil, fmt.Errorf("%w [cached]", s.err)
 	}
 
-	// todo: support r, w, and admin pools
-	pool, err := pgxutil.Connect(context.Background(), s.cfg.ConnectConfig)
+	pools, err := pgxutil.ConnectRoles(context.Background(), s.cfg.RoleConfig)
 	if err != nil {
 		s.latestErrTime = time.Now()
 		return fail(err)
 	}
 
-	s.r, s.w, s.admin = pool, pool, pool
+	s.pools = pools
+	s.r, s.w, s.admin = pools.Read, pools.Write, pools.Admin
 	return s.r, s.w, s.admin, nil
+}
+
+// PostgresPoolsFor returns the postgres connection pools a subsystem should use
+// given its storage config rc.
+//
+// If rc is zero the shared node pools are returned; these are owned by the
+// Stores and must not be closed by the caller. Otherwise a dedicated set of
+// pools is opened from rc and closed automatically when ctx is done.
+func (s *postgresStore) PostgresPoolsFor(ctx context.Context, rc pgxutil.RoleConfig) (pgxutil.Pools, error) {
+	if rc.IsZero() {
+		r, w, admin, err := s.Postgres()
+		if err != nil {
+			return pgxutil.Pools{}, err
+		}
+		return pgxutil.Pools{Read: r, Write: w, Admin: admin}, nil
+	}
+	pools, err := pgxutil.ConnectRoles(ctx, rc)
+	if err != nil {
+		return pgxutil.Pools{}, err
+	}
+	context.AfterFunc(ctx, pools.Close)
+	return pools, nil
 }
 
 func (s *postgresStore) close() error {
@@ -136,9 +159,9 @@ func (s *postgresStore) close() error {
 		return nil
 	}
 
-	s.r.Close()
-	s.w.Close()
-	s.admin.Close()
+	// Close each distinct pool once; roles may share an underlying pool.
+	s.pools.Close()
+	s.pools = pgxutil.Pools{}
 	s.r = nil
 	s.w = nil
 	s.admin = nil

--- a/pkg/app/stores/stores_test.go
+++ b/pkg/app/stores/stores_test.go
@@ -15,8 +15,10 @@ func TestPostgresStore_Postgres(t *testing.T) {
 		s := &Stores{
 			postgresStore: postgresStore{
 				cfg: &PostgresConfig{
-					ConnectConfig: pgxutil.ConnectConfig{
-						URI: "postgres://user:password@localhost:5432/dbname", // will fail to connect in test
+					RoleConfig: pgxutil.RoleConfig{
+						ConnectConfig: pgxutil.ConnectConfig{
+							URI: "postgres://user:password@localhost:5432/dbname", // will fail to connect in test
+						},
 					},
 				},
 			},

--- a/pkg/auto/history/config/root.go
+++ b/pkg/auto/history/config/root.go
@@ -85,7 +85,7 @@ func (f *FieldMask) MarshalJSON() ([]byte, error) {
 
 type Storage struct {
 	Type string `json:"type,omitempty"`
-	pgxutil.ConnectConfig
+	pgxutil.RoleConfig
 	Name string `json:"name,omitempty"`
 	// TTL is the time-to-live for records. Zero-value (not-specified) means "forever".
 	TTL *TTL `json:"ttl,omitempty"`

--- a/pkg/auto/history/factory.go
+++ b/pkg/auto/history/factory.go
@@ -7,11 +7,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/timshannon/bolthold"
 	"go.uber.org/zap"
 
-	"github.com/smart-core-os/sc-bos/internal/util/pgxutil"
 	"github.com/smart-core-os/sc-bos/pkg/app/stores"
 	"github.com/smart-core-os/sc-bos/pkg/auto"
 	"github.com/smart-core-os/sc-bos/pkg/auto/history/config"
@@ -235,13 +233,7 @@ func (a *automation) startDeviceRecording(ctx context.Context, announce node.Ann
 func (a *automation) createStore(ctx context.Context, src config.Source, storage *config.Storage) (history.Store, error) {
 	switch storage.Type {
 	case "postgres":
-		var pool *pgxpool.Pool
-		var err error
-		if storage.ConnectConfig.IsZero() {
-			_, _, pool, err = a.stores.Postgres()
-		} else {
-			pool, err = pgxutil.Connect(ctx, storage.ConnectConfig)
-		}
+		pools, err := a.stores.PostgresPoolsFor(ctx, storage.RoleConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -254,7 +246,7 @@ func (a *automation) createStore(ctx context.Context, src config.Source, storage
 				opts = append(opts, pgxstore.WithMaxCount(ttl.MaxCount))
 			}
 		}
-		return pgxstore.SetupStoreFromPool(ctx, src.SourceName(), pool, opts...)
+		return pgxstore.SetupStoreFromPools(ctx, src.SourceName(), pools, opts...)
 	case "memory":
 		var opts []memstore.Option
 		if ttl := storage.TTL; ttl != nil {

--- a/pkg/history/dataretention/postgres.go
+++ b/pkg/history/dataretention/postgres.go
@@ -85,9 +85,10 @@ func (b *postgresBackend) Purge(ctx context.Context, before *time.Time) (uint64,
 }
 
 func (b *postgresBackend) Compact(ctx context.Context) error {
-	_, w, _, err := b.stores.Postgres()
+	// VACUUM requires table ownership / the MAINTAIN privilege, so use the admin pool.
+	_, _, admin, err := b.stores.Postgres()
 	if err != nil {
 		return fmt.Errorf("postgres: %w", err)
 	}
-	return pgxstore.Vacuum(ctx, w)
+	return pgxstore.Vacuum(ctx, admin)
 }

--- a/pkg/history/pgxstore/store.go
+++ b/pkg/history/pgxstore/store.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.uber.org/zap"
 
+	"github.com/smart-core-os/sc-bos/internal/util/pgxutil"
 	"github.com/smart-core-os/sc-bos/pkg/history"
 )
 
@@ -36,22 +37,39 @@ func New(ctx context.Context, source, connStr string, opts ...Option) (*Store, e
 	return SetupStoreFromPool(ctx, source, pool, opts...)
 }
 
+// SetupStoreFromPool sets up the schema and returns a Store backed by a single
+// pool used for reads, writes, and admin (schema) operations.
 func SetupStoreFromPool(ctx context.Context, source string, pool *pgxpool.Pool, opts ...Option) (*Store, error) {
-	err := SetupDB(ctx, pool)
+	return SetupStoreFromPools(ctx, source, pgxutil.SamePool(pool), opts...)
+}
+
+// SetupStoreFromPools sets up the schema using the admin pool and returns a
+// Store that reads via pools.Read and writes via pools.Write.
+func SetupStoreFromPools(ctx context.Context, source string, pools pgxutil.Pools, opts ...Option) (*Store, error) {
+	err := SetupDB(ctx, pools.Admin)
 	if err != nil {
 		return nil, fmt.Errorf("setup %w", err)
 	}
 
-	return NewStoreFromPool(source, pool, opts...), nil
+	return NewStoreFromPools(source, pools, opts...), nil
 }
 
 const LargeMaxCount = 1e7
 
+// NewStoreFromPool returns a Store backed by a single pool used for both reads
+// and writes. The schema is assumed to already exist.
 func NewStoreFromPool(source string, pool *pgxpool.Pool, opts ...Option) *Store {
+	return NewStoreFromPools(source, pgxutil.SamePool(pool), opts...)
+}
+
+// NewStoreFromPools returns a Store that reads via pools.Read and writes via
+// pools.Write. The schema is assumed to already exist.
+func NewStoreFromPools(source string, pools pgxutil.Pools, opts ...Option) *Store {
 	s := &Store{
-		slice:  slice{pool: pool, source: source},
-		now:    time.Now,
-		logger: zap.NewNop(),
+		slice:     slice{readPool: pools.Read, source: source},
+		writePool: pools.Write,
+		now:       time.Now,
+		logger:    zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -64,6 +82,8 @@ func NewStoreFromPool(source string, pool *pgxpool.Pool, opts ...Option) *Store 
 
 type Store struct {
 	slice
+
+	writePool *pgxpool.Pool
 
 	now    func() time.Time
 	logger *zap.Logger
@@ -78,7 +98,7 @@ func (s *Store) Insert(ctx context.Context, at time.Time, payload []byte) (histo
 		Payload:    payload,
 	}
 
-	row := s.pool.QueryRow(ctx, "INSERT INTO history (source, create_time, payload) VALUES ($1, $2, $3) RETURNING id",
+	row := s.writePool.QueryRow(ctx, "INSERT INTO history (source, create_time, payload) VALUES ($1, $2, $3) RETURNING id",
 		s.source, at, payload)
 
 	var id int64
@@ -119,7 +139,7 @@ func (s *Store) gc(now time.Time) error {
 
 	if s.maxAge > 0 {
 		t := now.Add(-s.maxAge)
-		_, err := s.pool.Exec(context.Background(), "DELETE FROM history WHERE source = $1 AND create_time < $2", s.source, t)
+		_, err := s.writePool.Exec(context.Background(), "DELETE FROM history WHERE source = $1 AND create_time < $2", s.source, t)
 		if err != nil {
 			return err
 		}
@@ -128,7 +148,7 @@ func (s *Store) gc(now time.Time) error {
 		// We use create_time here as a substitute for a strict incremental id.
 		// At most we leak records equal to the collisions of create_time, which should be minimal.
 		sql := fmt.Sprintf(`DELETE FROM history WHERE source = $1 AND create_time < (SELECT create_time FROM history WHERE source = $1 ORDER BY create_time DESC LIMIT 1 OFFSET %d)`, s.maxCount)
-		_, err := s.pool.Exec(context.Background(), sql, s.source)
+		_, err := s.writePool.Exec(context.Background(), sql, s.source)
 		if err != nil {
 			return err
 		}
@@ -137,17 +157,17 @@ func (s *Store) gc(now time.Time) error {
 }
 
 type slice struct {
-	pool     *pgxpool.Pool
+	readPool *pgxpool.Pool
 	source   string // distinguishes between this store and other stores that use the same table
 	from, to history.Record
 }
 
 func (s slice) Slice(from, to history.Record) history.Slice {
 	return slice{
-		pool:   s.pool,
-		source: s.source,
-		from:   from,
-		to:     to,
+		readPool: s.readPool,
+		source:   s.source,
+		from:     from,
+		to:       to,
 	}
 }
 
@@ -174,7 +194,7 @@ func (s slice) read(ctx context.Context, into []history.Record, desc bool) (int,
 	}
 
 	sql := fmt.Sprintf("SELECT id, create_time, payload FROM history WHERE %s ORDER BY %s LIMIT %v", strings.Join(where, " AND "), orderBy, len(into))
-	rows, err := s.pool.Query(ctx, sql, args...)
+	rows, err := s.readPool.Query(ctx, sql, args...)
 	if err != nil {
 		return 0, err
 	}
@@ -203,7 +223,7 @@ func (s slice) Len(ctx context.Context) (int, error) {
 	}
 
 	sql := fmt.Sprintf("SELECT COUNT(*) FROM history WHERE %s", strings.Join(where, " AND "))
-	row := s.pool.QueryRow(ctx, sql, args...)
+	row := s.readPool.QueryRow(ctx, sql, args...)
 	var count int
 	err = row.Scan(&count)
 	return count, err

--- a/pkg/system/alerts/README.md
+++ b/pkg/system/alerts/README.md
@@ -41,6 +41,11 @@ backend by configuring the system to point to an existing postgres database:
 }
 ```
 
+The `storage` block accepts the same connection options as the shared node
+store, including the optional `read`/`write`/`admin` sub-blocks for connecting
+each privilege level as a distinct, least-privilege database user. See the
+[stores README](../../app/stores/README.md) for details and suggested grants.
+
 For development, you can use the same postgres database setup via the [docker-compose.yaml](../../../docker-compose.yml)
 file located at the root of the project. See the [dev guide](../../../docs/install/dev.md) for more info.
 

--- a/pkg/system/alerts/config/root.go
+++ b/pkg/system/alerts/config/root.go
@@ -20,5 +20,5 @@ const (
 
 type Storage struct {
 	Type StorageType `json:"type,omitempty"`
-	pgxutil.ConnectConfig
+	pgxutil.RoleConfig
 }

--- a/pkg/system/alerts/factory.go
+++ b/pkg/system/alerts/factory.go
@@ -5,9 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
-	"github.com/smart-core-os/sc-bos/internal/util/pgxutil"
 	"github.com/smart-core-os/sc-bos/pkg/app/stores"
 	"github.com/smart-core-os/sc-bos/pkg/node"
 	"github.com/smart-core-os/sc-bos/pkg/proto/alertpb"
@@ -67,18 +64,12 @@ func (s *System) applyConfig(ctx context.Context, cfg config.Root) error {
 	}
 	switch cfg.Storage.Type {
 	case config.StorageTypePostgres:
-		var pool *pgxpool.Pool
-		var err error
-		if cfg.Storage.ConnectConfig.IsZero() {
-			_, _, pool, err = s.stores.Postgres()
-		} else {
-			pool, err = pgxutil.Connect(ctx, cfg.Storage.ConnectConfig)
-		}
+		pools, err := s.stores.PostgresPoolsFor(ctx, cfg.Storage.RoleConfig)
 		if err != nil {
 			return fmt.Errorf("connect: %w", err)
 		}
 
-		server, err := pgxalerts.NewServerFromPool(ctx, pool)
+		server, err := pgxalerts.NewServerFromPools(ctx, pools)
 		if err != nil {
 			return fmt.Errorf("init: %w", err)
 		}

--- a/pkg/system/alerts/pgxalerts/md.go
+++ b/pkg/system/alerts/pgxalerts/md.go
@@ -77,7 +77,7 @@ func (s *Server) initAlertMetadata(ctx context.Context) error {
 
 		// Collect initial stats from the DB
 		md := alertmd.New()
-		err := pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		err := pgx.BeginTxFunc(ctx, s.read, pgx.TxOptions{}, func(tx pgx.Tx) error {
 			// totals
 			err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM alerts`).Scan(&md.TotalCount)
 			if err != nil {

--- a/pkg/system/alerts/pgxalerts/pgx.go
+++ b/pkg/system/alerts/pgxalerts/pgx.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
+	"github.com/smart-core-os/sc-bos/internal/util/pgxutil"
 	"github.com/smart-core-os/sc-bos/pkg/minibus"
 	"github.com/smart-core-os/sc-bos/pkg/proto/alertpb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/typespb"
@@ -43,15 +44,24 @@ func NewServer(ctx context.Context, connStr string) (*Server, error) {
 	return NewServerFromPool(ctx, pool)
 }
 
+// NewServerFromPool returns a Server backed by a single pool used for reads,
+// writes, and admin (schema) operations.
 func NewServerFromPool(ctx context.Context, pool *pgxpool.Pool) (*Server, error) {
-	err := SetupDB(ctx, pool)
+	return NewServerFromPools(ctx, pgxutil.SamePool(pool))
+}
+
+// NewServerFromPools returns a Server that sets up its schema via pools.Admin
+// and routes reads to pools.Read and writes to pools.Write.
+func NewServerFromPools(ctx context.Context, pools pgxutil.Pools) (*Server, error) {
+	err := SetupDB(ctx, pools.Admin)
 	if err != nil {
 		return nil, fmt.Errorf("setup %w", err)
 	}
 
 	return &Server{
-		pool: pool,
-		bus:  &minibus.Bus[*alertpb.PullAlertsResponse_Change]{},
+		read:  pools.Read,
+		write: pools.Write,
+		bus:   &minibus.Bus[*alertpb.PullAlertsResponse_Change]{},
 		Severity: []alertpb.Alert_Severity{
 			alertpb.Alert_INFO,
 			alertpb.Alert_WARNING,
@@ -74,8 +84,9 @@ type Server struct {
 	// Subsystems, if set, is used to pre-populate AlertMetadata with zero values for cases when no alerts appear in a subsystem.
 	Subsystems []string
 
-	pool *pgxpool.Pool
-	bus  *minibus.Bus[*alertpb.PullAlertsResponse_Change]
+	read  *pgxpool.Pool
+	write *pgxpool.Pool
+	bus   *minibus.Bus[*alertpb.PullAlertsResponse_Change]
 
 	// to support alert metadata
 	mdMu   sync.Mutex      // guards the following md fields
@@ -114,7 +125,7 @@ func (s *Server) CreateAlert(ctx context.Context, request *alertpb.CreateAlertRe
 }
 
 func (s *Server) createNewAlert(ctx context.Context, name string, alert *alertpb.Alert) (*alertpb.Alert, error) {
-	alert, err := insertAlert(ctx, s.pool, alert)
+	alert, err := insertAlert(ctx, s.write, alert)
 	if err != nil {
 		return nil, dbErrToStatus(err)
 	}
@@ -126,7 +137,7 @@ func (s *Server) createNewAlert(ctx context.Context, name string, alert *alertpb
 
 func (s *Server) mergeSourceAlert(ctx context.Context, name string, alert *alertpb.Alert) (*alertpb.Alert, error) {
 	var oldAlert, newAlert *alertpb.Alert
-	err := pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+	err := pgx.BeginTxFunc(ctx, s.write, pgx.TxOptions{}, func(tx pgx.Tx) error {
 		args := []any{
 			alert.Source,
 		}
@@ -242,7 +253,7 @@ func (s *Server) UpdateAlert(ctx context.Context, request *alertpb.UpdateAlertRe
 	original := &alertpb.Alert{}
 	updated := &alertpb.Alert{}
 
-	err := pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+	err := pgx.BeginTxFunc(ctx, s.write, pgx.TxOptions{}, func(tx pgx.Tx) error {
 		// record the original value which will be used for event notifications
 		if err := readAlertById(ctx, tx, alert.Id, original); err != nil {
 			return err
@@ -308,7 +319,7 @@ func (s *Server) ResolveAlert(ctx context.Context, request *alertpb.ResolveAlert
 
 	switch {
 	case alert.Id != "":
-		return respond(pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		return respond(pgx.BeginTxFunc(ctx, s.write, pgx.TxOptions{}, func(tx pgx.Tx) error {
 			// record the original value which will be used for event notifications
 			if err := readAlertById(ctx, tx, alert.Id, original); err != nil {
 				return err
@@ -321,7 +332,7 @@ func (s *Server) ResolveAlert(ctx context.Context, request *alertpb.ResolveAlert
 			return setResolveTime(ctx, tx, alert.Id)
 		}))
 	case alert.Source != "":
-		return respond(pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		return respond(pgx.BeginTxFunc(ctx, s.write, pgx.TxOptions{}, func(tx pgx.Tx) error {
 			args := []any{alert.Source}
 			querySql := selectAlertSQL + ` WHERE source=$1`
 			if alert.Federation != "" {
@@ -350,7 +361,7 @@ func (s *Server) DeleteAlert(ctx context.Context, request *alertpb.DeleteAlertRe
 		return nil, status.Error(codes.InvalidArgument, "id empty")
 	}
 	existing := &alertpb.Alert{}
-	err := pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+	err := pgx.BeginTxFunc(ctx, s.write, pgx.TxOptions{}, func(tx pgx.Tx) error {
 		// We do extra work to get the old value so we can include it in bus events.
 		// Without this any filtered PullAlerts call wouldn't be able to correctly include the event in responses.
 		err := readAlertById(ctx, tx, request.Id, existing)
@@ -480,7 +491,7 @@ func (s *Server) ListAlerts(ctx context.Context, request *alertpb.ListAlertsRequ
 	pageSize := normalizePageSize(request.PageSize)
 	sql += fmt.Sprintf(" LIMIT %d", pageSize+1)
 
-	rows, err := s.pool.Query(ctx, sql, args...)
+	rows, err := s.read.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, dbErrToStatus(err)
 	}
@@ -552,7 +563,7 @@ func (s *Server) AcknowledgeAlert(ctx context.Context, request *alertpb.Acknowle
 
 	existing := &alertpb.Alert{}
 	updated := &alertpb.Alert{}
-	err := pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+	err := pgx.BeginTxFunc(ctx, s.write, pgx.TxOptions{}, func(tx pgx.Tx) error {
 		err := readAlertById(ctx, tx, request.Id, existing)
 		if err != nil {
 			return err
@@ -611,7 +622,7 @@ func (s *Server) UnacknowledgeAlert(ctx context.Context, request *alertpb.Acknow
 
 	existing := &alertpb.Alert{}
 	updated := &alertpb.Alert{}
-	err := pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+	err := pgx.BeginTxFunc(ctx, s.write, pgx.TxOptions{}, func(tx pgx.Tx) error {
 		err := readAlertById(ctx, tx, request.Id, existing)
 		if err != nil {
 			return err

--- a/pkg/system/history/config/root.go
+++ b/pkg/system/history/config/root.go
@@ -21,7 +21,7 @@ const (
 
 type Storage struct {
 	Type StorageType `json:"type,omitempty"`
-	pgxutil.ConnectConfig
+	pgxutil.RoleConfig
 	// TTL is the time-to-live for records. Zero-value (not-specified) means "forever".
 	TTL *TTL `json:"ttl,omitempty"`
 }

--- a/pkg/system/history/factory.go
+++ b/pkg/system/history/factory.go
@@ -7,11 +7,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/timshannon/bolthold"
 	"go.uber.org/zap"
 
-	"github.com/smart-core-os/sc-bos/internal/util/pgxutil"
 	"github.com/smart-core-os/sc-bos/pkg/app/stores"
 	"github.com/smart-core-os/sc-bos/pkg/history"
 	"github.com/smart-core-os/sc-bos/pkg/history/boltstore"
@@ -72,18 +70,12 @@ func (s *System) applyConfig(ctx context.Context, cfg config.Root) error {
 
 	switch cfg.Storage.Type {
 	case config.StorageTypePostgres:
-		var pool *pgxpool.Pool
-		var err error
-		if cfg.Storage.ConnectConfig.IsZero() {
-			_, _, pool, err = s.stores.Postgres()
-		} else {
-			pool, err = pgxutil.Connect(ctx, cfg.Storage.ConnectConfig)
-		}
+		pools, err := s.stores.PostgresPoolsFor(ctx, cfg.Storage.RoleConfig)
 		if err != nil {
 			return fmt.Errorf("connect: %w", err)
 		}
 
-		if err := pgxstore.SetupDB(ctx, pool); err != nil {
+		if err := pgxstore.SetupDB(ctx, pools.Admin); err != nil {
 			return fmt.Errorf("setup: %w", err)
 		}
 
@@ -99,7 +91,7 @@ func (s *System) applyConfig(ctx context.Context, cfg config.Root) error {
 			}
 		}
 		store = func(source string) history.Store {
-			return pgxstore.NewStoreFromPool(source, pool, opts...)
+			return pgxstore.NewStoreFromPools(source, pools, opts...)
 		}
 	case config.StorageTypeBolt:
 		storeCollection := make(map[string]history.Store)

--- a/pkg/system/hub/config/root.go
+++ b/pkg/system/hub/config/root.go
@@ -50,7 +50,7 @@ const (
 
 type Storage struct {
 	Type StorageType `json:"type,omitempty"`
-	pgxutil.ConnectConfig
+	pgxutil.RoleConfig
 }
 
 var (

--- a/pkg/system/hub/factory.go
+++ b/pkg/system/hub/factory.go
@@ -13,14 +13,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/timshannon/bolthold"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/smart-core-os/sc-bos/internal/util/pgxutil"
 	"github.com/smart-core-os/sc-bos/internal/util/pki"
 	"github.com/smart-core-os/sc-bos/internal/util/pki/expire"
 	"github.com/smart-core-os/sc-bos/pkg/app/stores"
@@ -107,24 +105,12 @@ func (s *System) applyConfig(ctx context.Context, cfg config.Root) error {
 		}
 		hubConn = conn
 	case config.StorageTypePostgres:
-		var pool *pgxpool.Pool
-		var err error
-		if cfg.Storage.ConnectConfig.IsZero() {
-			_, _, pool, err = s.stores.Postgres()
-		} else {
-			pool, err = pgxutil.Connect(ctx, cfg.Storage.ConnectConfig)
-			if err == nil {
-				go func() {
-					<-ctx.Done()
-					pool.Close()
-				}()
-			}
-		}
+		pools, err := s.stores.PostgresPoolsFor(ctx, cfg.Storage.RoleConfig)
 		if err != nil {
 			return fmt.Errorf("connect: %w", err)
 		}
 
-		server, err := pgxhub.NewServerFromPool(ctx, pool, pgxhub.WithLogger(s.logger))
+		server, err := pgxhub.NewServerFromPools(ctx, pools, pgxhub.WithLogger(s.logger))
 		if err != nil {
 			return fmt.Errorf("init: %w", err)
 		}

--- a/pkg/system/hub/pgxhub/server.go
+++ b/pkg/system/hub/pgxhub/server.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/smart-core-os/sc-bos/internal/util/pgxutil"
 	"github.com/smart-core-os/sc-bos/internal/util/pki"
 	"github.com/smart-core-os/sc-bos/internal/util/rpcutil"
 	"github.com/smart-core-os/sc-bos/pkg/minibus"
@@ -46,14 +47,23 @@ func NewServer(ctx context.Context, connStr string) (*Server, error) {
 	return NewServerFromPool(ctx, pool)
 }
 
+// NewServerFromPool returns a Server backed by a single pool used for reads,
+// writes, and admin (schema) operations.
 func NewServerFromPool(ctx context.Context, pool *pgxpool.Pool, opts ...Option) (*Server, error) {
-	err := SetupDB(ctx, pool)
+	return NewServerFromPools(ctx, pgxutil.SamePool(pool), opts...)
+}
+
+// NewServerFromPools returns a Server that sets up its schema via pools.Admin
+// and routes reads to pools.Read and writes to pools.Write.
+func NewServerFromPools(ctx context.Context, pools pgxutil.Pools, opts ...Option) (*Server, error) {
+	err := SetupDB(ctx, pools.Admin)
 	if err != nil {
 		return nil, fmt.Errorf("setup %w", err)
 	}
 
 	s := &Server{
-		pool: pool,
+		read:  pools.Read,
+		write: pools.Write,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -64,7 +74,8 @@ func NewServerFromPool(ctx context.Context, pool *pgxpool.Pool, opts ...Option) 
 type Server struct {
 	hubpb.UnimplementedHubApiServer
 	logger *zap.Logger
-	pool   *pgxpool.Pool
+	read   *pgxpool.Pool
+	write  *pgxpool.Pool
 
 	dbChanges minibus.Bus[*hubpb.PullHubNodesResponse_Change]
 
@@ -77,7 +88,7 @@ type Server struct {
 func (n *Server) GetHubNode(ctx context.Context, request *hubpb.GetHubNodeRequest) (*hubpb.HubNode, error) {
 	logger := rpcutil.ServerLogger(ctx, n.logger)
 	var dbEnrollment Enrollment
-	err := pgx.BeginFunc(ctx, n.pool, func(tx pgx.Tx) (err error) {
+	err := pgx.BeginFunc(ctx, n.read, func(tx pgx.Tx) (err error) {
 		dbEnrollment, err = SelectEnrollment(ctx, tx, request.GetAddress())
 		return
 	})
@@ -106,7 +117,7 @@ func (n *Server) EnrollHubNode(ctx context.Context, request *hubpb.EnrollHubNode
 	}
 
 	// check if the node is already enrolled
-	err := pgx.BeginFunc(ctx, n.pool, func(tx pgx.Tx) error {
+	err := pgx.BeginFunc(ctx, n.read, func(tx pgx.Tx) error {
 		_, err := SelectEnrollment(ctx, tx, nodeReg.Address)
 		return err
 	})
@@ -126,7 +137,7 @@ func (n *Server) EnrollHubNode(ctx context.Context, request *hubpb.EnrollHubNode
 		return nil, status.Error(codes.Unknown, "enrollment failed")
 	}
 
-	err = pgx.BeginFunc(ctx, n.pool, func(tx pgx.Tx) error {
+	err = pgx.BeginFunc(ctx, n.write, func(tx pgx.Tx) error {
 		return InsertEnrollment(ctx, tx, Enrollment{
 			Name:        en.TargetName,
 			Description: nodeReg.Description,
@@ -168,7 +179,7 @@ func (n *Server) deleteHubNode(ctx context.Context, reg *hubpb.HubNode) error {
 func (n *Server) listAllHubNodes(ctx context.Context) ([]*hubpb.HubNode, error) {
 	logger := rpcutil.ServerLogger(ctx, n.logger)
 	var dbEnrollments []Enrollment
-	err := pgx.BeginFunc(ctx, n.pool, func(tx pgx.Tx) (err error) {
+	err := pgx.BeginFunc(ctx, n.read, func(tx pgx.Tx) (err error) {
 		dbEnrollments, err = SelectEnrollments(ctx, tx)
 		return
 	})
@@ -265,7 +276,7 @@ func (n *Server) RenewHubNode(ctx context.Context, request *hubpb.RenewHubNodeRe
 		return nil, status.Error(codes.Unknown, "enrollment failed")
 	}
 
-	err = pgx.BeginFunc(ctx, n.pool, func(tx pgx.Tx) error {
+	err = pgx.BeginFunc(ctx, n.write, func(tx pgx.Tx) error {
 		return UpdateEnrollment(ctx, tx, Enrollment{
 			Name:        en.TargetName,
 			Description: reg.Description,
@@ -344,7 +355,7 @@ func (n *Server) ForgetHubNode(ctx context.Context, request *hubpb.ForgetHubNode
 		return nil, err
 	}
 
-	err = pgx.BeginFunc(ctx, n.pool, func(tx pgx.Tx) error {
+	err = pgx.BeginFunc(ctx, n.write, func(tx pgx.Tx) error {
 		return DeleteEnrollment(ctx, tx, reg.Address)
 	})
 	if err != nil {

--- a/pkg/system/publications/config/root.go
+++ b/pkg/system/publications/config/root.go
@@ -18,5 +18,5 @@ const (
 
 type Storage struct {
 	Type StorageType `json:"type,omitempty"`
-	pgxutil.ConnectConfig
+	pgxutil.RoleConfig
 }

--- a/pkg/system/publications/factory.go
+++ b/pkg/system/publications/factory.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"go.uber.org/zap"
 
-	"github.com/smart-core-os/sc-bos/internal/util/pgxutil"
 	"github.com/smart-core-os/sc-bos/pkg/app/stores"
 	"github.com/smart-core-os/sc-bos/pkg/node"
 	"github.com/smart-core-os/sc-bos/pkg/proto/publicationpb"
@@ -59,18 +57,12 @@ func (s *System) applyConfig(ctx context.Context, cfg config.Root) error {
 	}
 	switch cfg.Storage.Type {
 	case config.StorageTypePostgres:
-		var pool *pgxpool.Pool
-		var err error
-		if cfg.Storage.ConnectConfig.IsZero() {
-			_, _, pool, err = s.stores.Postgres()
-		} else {
-			pool, err = pgxutil.Connect(ctx, cfg.Storage.ConnectConfig)
-		}
+		pools, err := s.stores.PostgresPoolsFor(ctx, cfg.Storage.RoleConfig)
 		if err != nil {
 			return fmt.Errorf("connect: %w", err)
 		}
 
-		server, err := pgxpublications.NewServerFromPool(ctx, pool, pgxpublications.WithLogger(s.logger))
+		server, err := pgxpublications.NewServerFromPools(ctx, pools, pgxpublications.WithLogger(s.logger))
 		if err != nil {
 			return fmt.Errorf("init: %w", err)
 		}

--- a/pkg/system/publications/pgxpublications/pgx.go
+++ b/pkg/system/publications/pgxpublications/pgx.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/smart-core-os/sc-bos/internal/util/pgxutil"
 	"github.com/smart-core-os/sc-bos/internal/util/rpcutil"
 	"github.com/smart-core-os/sc-bos/pkg/proto/publicationpb"
 )
@@ -37,14 +38,23 @@ func NewServer(ctx context.Context, connStr string) (*Server, error) {
 	return NewServerFromPool(ctx, pool)
 }
 
+// NewServerFromPool returns a Server backed by a single pool used for reads,
+// writes, and admin (schema) operations.
 func NewServerFromPool(ctx context.Context, pool *pgxpool.Pool, opts ...Option) (*Server, error) {
-	err := SetupDB(ctx, pool)
+	return NewServerFromPools(ctx, pgxutil.SamePool(pool), opts...)
+}
+
+// NewServerFromPools returns a Server that sets up its schema via pools.Admin
+// and routes reads to pools.Read and writes to pools.Write.
+func NewServerFromPools(ctx context.Context, pools pgxutil.Pools, opts ...Option) (*Server, error) {
+	err := SetupDB(ctx, pools.Admin)
 	if err != nil {
 		return nil, fmt.Errorf("setup %w", err)
 	}
 
 	s := &Server{
-		pool: pool,
+		read:  pools.Read,
+		write: pools.Write,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -56,7 +66,8 @@ type Server struct {
 	publicationpb.UnimplementedPublicationApiServer
 
 	logger *zap.Logger
-	pool   *pgxpool.Pool
+	read   *pgxpool.Pool
+	write  *pgxpool.Pool
 }
 
 func (p *Server) CreatePublication(ctx context.Context, request *publicationpb.CreatePublicationRequest) (*publicationpb.Publication, error) {
@@ -72,7 +83,7 @@ func (p *Server) CreatePublication(ctx context.Context, request *publicationpb.C
 	mediaType := input.GetMediaType()
 
 	var output *publicationpb.Publication
-	err := pgx.BeginFunc(ctx, p.pool, func(tx pgx.Tx) error {
+	err := pgx.BeginFunc(ctx, p.write, func(tx pgx.Tx) error {
 		// Register the publication
 		err := CreatePublication(ctx, tx, pubID, audience)
 		if err != nil {
@@ -120,7 +131,7 @@ func (p *Server) GetPublication(ctx context.Context, request *publicationpb.GetP
 	version := request.GetVersion()
 
 	var output *publicationpb.Publication
-	err := pgx.BeginFunc(ctx, p.pool, func(tx pgx.Tx) error {
+	err := pgx.BeginFunc(ctx, p.read, func(tx pgx.Tx) error {
 		var err error
 		output, err = GetPublication(ctx, tx, id, version)
 		return err
@@ -141,7 +152,7 @@ func (p *Server) UpdatePublication(ctx context.Context, request *publicationpb.U
 	}
 	var updated *publicationpb.Publication
 
-	err := pgx.BeginFunc(ctx, p.pool, func(tx pgx.Tx) error {
+	err := pgx.BeginFunc(ctx, p.write, func(tx pgx.Tx) error {
 		var err error
 		if request.GetVersion() != "" {
 			err = checkLatestVersion(ctx, tx, request.GetPublication().GetId(), request.GetVersion())
@@ -169,7 +180,7 @@ func (p *Server) UpdatePublication(ctx context.Context, request *publicationpb.U
 func (p *Server) DeletePublication(ctx context.Context, request *publicationpb.DeletePublicationRequest) (*publicationpb.Publication, error) {
 	var pub *publicationpb.Publication
 
-	err := pgx.BeginFunc(ctx, p.pool, func(tx pgx.Tx) error {
+	err := pgx.BeginFunc(ctx, p.write, func(tx pgx.Tx) error {
 		var err error
 		// if a version is specified, check that it's the latest version
 		// this helps clients to avoid racing each other
@@ -215,7 +226,7 @@ func (p *Server) ListPublications(ctx context.Context, request *publicationpb.Li
 		publications []*publicationpb.Publication
 		nextToken    string
 	)
-	err := pgx.BeginFunc(ctx, p.pool, func(tx pgx.Tx) error {
+	err := pgx.BeginFunc(ctx, p.read, func(tx pgx.Tx) error {
 		var err error
 		publications, nextToken, err = GetPublicationsPaginated(ctx, tx, request.GetPageToken(), limit)
 		return err
@@ -250,7 +261,7 @@ func (p *Server) AcknowledgePublication(ctx context.Context, request *publicatio
 	}
 
 	var updated *publicationpb.Publication
-	err := pgx.BeginFunc(ctx, p.pool, func(tx pgx.Tx) error {
+	err := pgx.BeginFunc(ctx, p.write, func(tx pgx.Tx) error {
 		err := CreatePublicationAcknowledgement(ctx, tx, request.GetId(), request.GetVersion(), time.Now(), accepted,
 			request.GetReceiptRejectedReason(), request.GetAllowAcknowledged())
 		if err != nil {

--- a/pkg/system/tenants/config/root.go
+++ b/pkg/system/tenants/config/root.go
@@ -19,5 +19,5 @@ const (
 
 type Storage struct {
 	Type StorageType `json:"type,omitempty"`
-	pgxutil.ConnectConfig
+	pgxutil.RoleConfig
 }

--- a/pkg/system/tenants/factory.go
+++ b/pkg/system/tenants/factory.go
@@ -32,7 +32,7 @@ func NewSystem(services system.Services) *System {
 		logger:  services.Logger.Named("tenants"),
 	}
 	s.Service = service.New(
-		s.applyConfig,
+		service.MonoApply(s.applyConfig),
 		service.WithRetry[config.Root](service.RetryWithLogger(func(logContext service.RetryContext) {
 			logContext.LogTo("applyConfig", s.logger)
 		})),

--- a/pkg/system/tenants/factory.go
+++ b/pkg/system/tenants/factory.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"go.uber.org/zap"
 
-	"github.com/smart-core-os/sc-bos/internal/util/pgxutil"
 	"github.com/smart-core-os/sc-bos/pkg/app/stores"
 	"github.com/smart-core-os/sc-bos/pkg/node"
 	"github.com/smart-core-os/sc-bos/pkg/proto/tenantpb"
@@ -76,18 +74,12 @@ func (s *System) applyConfig(ctx context.Context, cfg config.Root) error {
 			return fmt.Errorf("can't create proxied TenantApi service: %w", err)
 		}
 	case config.StorageTypePostgres:
-		var pool *pgxpool.Pool
-		var err error
-		if cfg.Storage.ConnectConfig.IsZero() {
-			_, _, pool, err = s.stores.Postgres()
-		} else {
-			pool, err = pgxutil.Connect(ctx, cfg.Storage.ConnectConfig)
-		}
+		pools, err := s.stores.PostgresPoolsFor(ctx, cfg.Storage.RoleConfig)
 		if err != nil {
 			return fmt.Errorf("connect: %w", err)
 		}
 
-		server, err := pgxtenants.NewServerFromPool(ctx, pool, pgxtenants.WithLogger(s.logger))
+		server, err := pgxtenants.NewServerFromPools(ctx, pools, pgxtenants.WithLogger(s.logger))
 		if err != nil {
 			return fmt.Errorf("init: %w", err)
 		}

--- a/pkg/system/tenants/pgxtenants/pgx.go
+++ b/pkg/system/tenants/pgxtenants/pgx.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/smart-core-os/sc-bos/internal/util/pass"
+	"github.com/smart-core-os/sc-bos/internal/util/pgxutil"
 	"github.com/smart-core-os/sc-bos/internal/util/rpcutil"
 	"github.com/smart-core-os/sc-bos/pkg/proto/tenantpb"
 	"github.com/smart-core-os/sc-bos/pkg/util/masks"
@@ -42,14 +43,23 @@ func NewServer(ctx context.Context, connStr string) (*Server, error) {
 	return NewServerFromPool(ctx, pool)
 }
 
+// NewServerFromPool returns a Server backed by a single pool used for reads,
+// writes, and admin (schema) operations.
 func NewServerFromPool(ctx context.Context, pool *pgxpool.Pool, opts ...Option) (*Server, error) {
-	err := SetupDB(ctx, pool)
+	return NewServerFromPools(ctx, pgxutil.SamePool(pool), opts...)
+}
+
+// NewServerFromPools returns a Server that sets up its schema via pools.Admin
+// and routes reads to pools.Read and writes to pools.Write.
+func NewServerFromPools(ctx context.Context, pools pgxutil.Pools, opts ...Option) (*Server, error) {
+	err := SetupDB(ctx, pools.Admin)
 	if err != nil {
 		return nil, fmt.Errorf("setup %w", err)
 	}
 
 	s := &Server{
-		pool: pool,
+		read:  pools.Read,
+		write: pools.Write,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -64,7 +74,8 @@ var (
 
 type Server struct {
 	tenantpb.UnimplementedTenantApiServer
-	pool   *pgxpool.Pool
+	read   *pgxpool.Pool
+	write  *pgxpool.Pool
 	logger *zap.Logger
 }
 
@@ -72,7 +83,7 @@ func (s *Server) ListTenants(ctx context.Context, request *tenantpb.ListTenantsR
 	logger := rpcutil.ServerLogger(ctx, s.logger)
 
 	var tenants []*tenantpb.Tenant
-	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) (err error) {
+	err := pgx.BeginFunc(ctx, s.read, func(tx pgx.Tx) (err error) {
 		tenants, err = ListTenants(ctx, tx)
 		return
 	})
@@ -102,7 +113,7 @@ func (s *Server) CreateTenant(ctx context.Context, request *tenantpb.CreateTenan
 	logger := rpcutil.ServerLogger(ctx, s.logger)
 
 	var newTenant *tenantpb.Tenant
-	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) (err error) {
+	err := pgx.BeginFunc(ctx, s.write, func(tx pgx.Tx) (err error) {
 		newTenant, err = CreateTenant(ctx, tx, request.Tenant.Title)
 		if err != nil {
 			return
@@ -132,7 +143,7 @@ func (s *Server) GetTenant(ctx context.Context, request *tenantpb.GetTenantReque
 	logger := rpcutil.ServerLogger(ctx, s.logger)
 
 	var tenant *tenantpb.Tenant
-	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+	err := pgx.BeginFunc(ctx, s.read, func(tx pgx.Tx) error {
 		var err error
 		tenant, err = GetTenant(ctx, tx, request.GetId())
 		return err
@@ -162,7 +173,7 @@ func (s *Server) UpdateTenant(ctx context.Context, request *tenantpb.UpdateTenan
 		return nil, err
 	}
 
-	err = pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) (err error) {
+	err = pgx.BeginFunc(ctx, s.write, func(tx pgx.Tx) (err error) {
 		if rpcutil.MaskContains(request.UpdateMask, "title") {
 			err = UpdateTenantTitle(ctx, tx, tenant.Id, tenant.Title)
 			if err != nil {
@@ -194,7 +205,7 @@ func (s *Server) UpdateTenant(ctx context.Context, request *tenantpb.UpdateTenan
 func (s *Server) DeleteTenant(ctx context.Context, request *tenantpb.DeleteTenantRequest) (*tenantpb.DeleteTenantResponse, error) {
 	logger := rpcutil.ServerLogger(ctx, s.logger).With(zap.String("id", request.Id))
 
-	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+	err := pgx.BeginFunc(ctx, s.write, func(tx pgx.Tx) error {
 		return DeleteTenant(ctx, tx, request.Id)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -214,7 +225,7 @@ func (s *Server) PullTenant(request *tenantpb.PullTenantRequest, server tenantpb
 func (s *Server) AddTenantZones(ctx context.Context, request *tenantpb.AddTenantZonesRequest) (*tenantpb.Tenant, error) {
 	logger := rpcutil.ServerLogger(ctx, s.logger)
 
-	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+	err := pgx.BeginFunc(ctx, s.write, func(tx pgx.Tx) error {
 		return AddTenantZones(ctx, tx, request.TenantId, request.AddZoneNames)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -231,7 +242,7 @@ func (s *Server) RemoveTenantZones(ctx context.Context, request *tenantpb.Remove
 	logger := rpcutil.ServerLogger(ctx, s.logger)
 
 	var tenant *tenantpb.Tenant
-	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) (err error) {
+	err := pgx.BeginFunc(ctx, s.write, func(tx pgx.Tx) (err error) {
 		err = RemoveTenantZones(ctx, tx, request.TenantId, request.RemoveZoneNames)
 		if err != nil {
 			return err
@@ -267,7 +278,7 @@ func (s *Server) ListSecrets(ctx context.Context, request *tenantpb.ListSecretsR
 	}
 
 	var secrets []*tenantpb.Secret
-	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) (err error) {
+	err := pgx.BeginFunc(ctx, s.read, func(tx pgx.Tx) (err error) {
 		secrets, err = ListTenantSecrets(ctx, tx, tenantID)
 		return
 	})
@@ -315,7 +326,7 @@ func (s *Server) CreateSecret(ctx context.Context, request *tenantpb.CreateSecre
 		return nil, status.Errorf(codes.Internal, "secret hashing failed: %s", err.Error())
 	}
 
-	err = pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) (err error) {
+	err = pgx.BeginFunc(ctx, s.write, func(tx pgx.Tx) (err error) {
 		secret, err = CreateTenantSecret(ctx, tx, secret)
 		return
 	})
@@ -337,7 +348,7 @@ func (s *Server) VerifySecret(ctx context.Context, request *tenantpb.VerifySecre
 	}
 
 	var secrets []*tenantpb.Secret
-	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) (err error) {
+	err := pgx.BeginFunc(ctx, s.read, func(tx pgx.Tx) (err error) {
 		secrets, err = ListTenantSecrets(ctx, tx, request.TenantId)
 		return
 	})
@@ -358,7 +369,7 @@ func (s *Server) GetSecret(ctx context.Context, request *tenantpb.GetSecretReque
 	logger := rpcutil.ServerLogger(ctx, s.logger).With(zap.String("secret_id", request.GetId()))
 
 	var secret *tenantpb.Secret
-	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) (err error) {
+	err := pgx.BeginFunc(ctx, s.read, func(tx pgx.Tx) (err error) {
 		secret, err = GetTenantSecret(ctx, tx, request.Id)
 		return
 	})
@@ -378,7 +389,7 @@ func (s *Server) UpdateSecret(ctx context.Context, request *tenantpb.UpdateSecre
 
 func (s *Server) DeleteSecret(ctx context.Context, request *tenantpb.DeleteSecretRequest) (*tenantpb.DeleteSecretResponse, error) {
 	logger := rpcutil.ServerLogger(ctx, s.logger)
-	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+	err := pgx.BeginFunc(ctx, s.write, func(tx pgx.Tx) error {
 		return DeleteTenantSecret(ctx, tx, request.Id)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {


### PR DESCRIPTION
[SCB-1038](https://vanti.youtrack.cloud/issue/SCB-1038) Support r, w, admin connection pools for pgx

## Summary

Splits each postgres store's single `*pgxpool.Pool` into three role-scoped pools — **read**, **write**, and **admin** — so a deployment can connect each privilege level as a distinct, least-privilege database user.

- New `pgxutil.RoleConfig` (embeds `ConnectConfig`, plus optional `read`/`write`/`admin` sub-blocks) and `pgxutil.Pools` / `ConnectRoles` helpers in `internal/util/pgxutil/roles.go`.
- `stores.PostgresPoolsFor(ctx, rc)` returns the shared node pools when `rc` is zero, or opens a dedicated set (auto-closed on `ctx` done) otherwise.
- Each postgres query is routed to the minimum-privilege pool it needs:
  - **read** — `SELECT` only
  - **write** — `INSERT`/`UPDATE`/`DELETE` and any transaction that both reads and writes
  - **admin** — schema DDL (`CREATE`/`ALTER`) and maintenance (`VACUUM`)
- Systems updated: `alerts`, `hub`, `tenants`, `publications`, `history`, plus the `history` automation.

Fully backward compatible: `RoleConfig` embeds `ConnectConfig` inline, so an existing `{uri, passwordFile}` config parses unchanged and opens a single shared pool (no behaviour change). Roles with identical configs share one underlying pool.

See the new `pkg/app/stores/README.md` for configuration and suggested grants.

## Notes
- `dataretention` `Compact` now runs `VACUUM` on the admin pool (it requires table ownership / the `MAINTAIN` privilege).
- Dedicated pools are closed automatically when their context is cancelled; the `tenants` factory was switched to `service.MonoApply` so this cleanup fires on config reload like the other factories.

## Test plan
- [ ] `go test ./internal/util/pgxutil/... ./pkg/app/stores/... ./pkg/system/... ./pkg/history/...`
- [ ] Existing single-`uri` deployments open one pool and behave as before.
- [ ] With `read`/`write`/`admin` sub-blocks + least-privilege grants, reads/writes/DDL each succeed on their scoped user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)