### PR TITLE
udmi: make MQTT QoS configurable

### DIFF
--- a/pkg/auto/udmi/config/root.go
+++ b/pkg/auto/udmi/config/root.go
@@ -20,4 +20,7 @@ type Root struct {
 	// topics are always published unretained so subscribers get real-time telemetry
 	// rather than a replayed stale value.
 	Retained bool `json:"retained,omitempty"`
+	// QoS is the MQTT Quality of Service level (0, 1, or 2) used for both
+	// publishing and subscribing. Defaults to 0 (at-most-once) when unset.
+	QoS byte `json:"qos,omitempty"`
 }

--- a/pkg/auto/udmi/config/root.go
+++ b/pkg/auto/udmi/config/root.go
@@ -20,7 +20,12 @@ type Root struct {
 	// topics are always published unretained so subscribers get real-time telemetry
 	// rather than a replayed stale value.
 	Retained bool `json:"retained,omitempty"`
-	// QoS is the MQTT Quality of Service level (0, 1, or 2) used for both
-	// publishing and subscribing. Defaults to 0 (at-most-once) when unset.
+	// QoS is the MQTT Quality of Service level (0, 1, or 2) used for publishing
+	// telemetry (pointset event topics) and for all subscriptions. Defaults to 0
+	// (at-most-once) when unset.
 	QoS byte `json:"qos,omitempty"`
+	// StateQoS is the MQTT QoS level used for publishing state and metadata topics
+	// (everything that is not an event topic). Defaults to 0 (matching QoS) when
+	// unset, preserving the previous single-QoS behaviour.
+	StateQoS byte `json:"stateQos,omitempty"`
 }

--- a/pkg/auto/udmi/mqtt.go
+++ b/pkg/auto/udmi/mqtt.go
@@ -27,9 +27,17 @@ func newMqttClient(cfg config.Root) (mqtt.Client, error) {
 // immediately on connect. retainAll (the auto's "retained" config) forces the
 // retained flag on for every topic, preserving the legacy retain-everything
 // behaviour.
-func mqttPublisher(client mqtt.Client, qos byte, retainAll bool) Publisher {
+//
+// QoS is decided by the same split: event topics publish at eventQoS (telemetry,
+// typically at-most-once) while state/metadata topics publish at stateQoS.
+func mqttPublisher(client mqtt.Client, eventQoS, stateQoS byte, retainAll bool) Publisher {
 	return PublisherFunc(func(ctx context.Context, topic string, payload any) error {
-		retained := retainAll || !isEventTopic(topic)
+		event := isEventTopic(topic)
+		qos := eventQoS
+		if !event {
+			qos = stateQoS
+		}
+		retained := retainAll || !event
 		token := client.Publish(topic, qos, retained, payload)
 		select {
 		case <-ctx.Done():

--- a/pkg/auto/udmi/mqtt_test.go
+++ b/pkg/auto/udmi/mqtt_test.go
@@ -1,6 +1,62 @@
 package udmi
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+// capturingClient embeds mqtt.Client so only Publish is implemented; it records
+// the qos and retained flags passed to the most recent Publish call. Any other
+// method call panics, which is fine as mqttPublisher only calls Publish.
+type capturingClient struct {
+	mqtt.Client
+	qos      byte
+	retained bool
+}
+
+func (c *capturingClient) Publish(_ string, qos byte, retained bool, _ any) mqtt.Token {
+	c.qos = qos
+	c.retained = retained
+	return doneToken{}
+}
+
+// doneToken is an already-completed mqtt.Token with no error.
+type doneToken struct{}
+
+func (doneToken) Wait() bool                     { return true }
+func (doneToken) WaitTimeout(time.Duration) bool { return true }
+func (doneToken) Error() error                   { return nil }
+func (doneToken) Done() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+func TestMqttPublisher_QoSByTopic(t *testing.T) {
+	const eventQoS, stateQoS = 0, 1
+	tests := map[string]byte{
+		// telemetry (event topics) publish at eventQoS
+		"client/site-01/HVAC/PICV-12345/event/pointset/points": eventQoS,
+		"client/site-01/HVAC/PICV-12345/events/pointset":       eventQoS,
+		// state and metadata publish at stateQoS
+		"client/site-01/HVAC/PICV-12345/state":         stateQoS,
+		"client/site-01/HVAC/PICV-12345/metadata.json": stateQoS,
+		"client/site-01/HVAC/PICV-12345/metadata":      stateQoS,
+	}
+	for topic, wantQoS := range tests {
+		client := &capturingClient{}
+		pub := mqttPublisher(client, eventQoS, stateQoS, false)
+		if err := pub.Publish(context.Background(), topic, "payload"); err != nil {
+			t.Fatalf("Publish(%q) returned error: %v", topic, err)
+		}
+		if client.qos != wantQoS {
+			t.Errorf("Publish(%q) used qos %d, want %d", topic, client.qos, wantQoS)
+		}
+	}
+}
 
 func TestIsEventTopic(t *testing.T) {
 	tests := map[string]bool{

--- a/pkg/auto/udmi/udmi.go
+++ b/pkg/auto/udmi/udmi.go
@@ -51,6 +51,9 @@ func (e *udmiAuto) applyConfig(ctx context.Context, cfg config.Root) error {
 	if cfg.QoS > 2 {
 		return fmt.Errorf("invalid qos %d: must be 0, 1, or 2", cfg.QoS)
 	}
+	if cfg.StateQoS > 2 {
+		return fmt.Errorf("invalid stateQos %d: must be 0, 1, or 2", cfg.StateQoS)
+	}
 
 	udmiClient := udmipb.NewUdmiServiceClient(e.services.Node.ClientConn())
 
@@ -60,7 +63,7 @@ func (e *udmiAuto) applyConfig(ctx context.Context, cfg config.Root) error {
 	}
 
 	pubSub := &PubSub{
-		Publisher:  mqttPublisher(client, cfg.QoS, cfg.Retained),
+		Publisher:  mqttPublisher(client, cfg.QoS, cfg.StateQoS, cfg.Retained),
 		Subscriber: mqttSubscriber(client, cfg.QoS),
 	}
 

--- a/pkg/auto/udmi/udmi.go
+++ b/pkg/auto/udmi/udmi.go
@@ -3,6 +3,7 @@ package udmi
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -47,6 +48,10 @@ type udmiAuto struct {
 }
 
 func (e *udmiAuto) applyConfig(ctx context.Context, cfg config.Root) error {
+	if cfg.QoS > 2 {
+		return fmt.Errorf("invalid qos %d: must be 0, 1, or 2", cfg.QoS)
+	}
+
 	udmiClient := udmipb.NewUdmiServiceClient(e.services.Node.ClientConn())
 
 	client, err := newMqttClient(cfg)
@@ -55,8 +60,8 @@ func (e *udmiAuto) applyConfig(ctx context.Context, cfg config.Root) error {
 	}
 
 	pubSub := &PubSub{
-		Publisher:  mqttPublisher(client, 0, cfg.Retained),
-		Subscriber: mqttSubscriber(client, 0),
+		Publisher:  mqttPublisher(client, cfg.QoS, cfg.Retained),
+		Subscriber: mqttSubscriber(client, cfg.QoS),
 	}
 
 	connected := client.Connect()


### PR DESCRIPTION
The QoS level was hardcoded to 0 for both publishing and subscribing. This PR makes it configurable and splits telemetry from state/metadata reliability.

## `qos`
Expose the MQTT QoS as a `qos` config field (default 0), applied to the publisher and subscriber, and reject out-of-range values at config apply.

## `stateQos`
Telemetry (pointset **event** topics) is high-frequency and fine at QoS 0, but **state** and **metadata** describe last-known device status/model and benefit from at-least-once delivery.

Add a `stateQos` config field and select the *publish* QoS per topic using the existing `isEventTopic` split already used for retention:

- event topics (e.g. `.../events/pointset`) publish at `qos`
- everything else (`.../state`, `.../metadata.json`) publishes at `stateQos`

`stateQos` defaults to 0 (matching `qos`), preserving the previous single-QoS behaviour. Subscriptions remain on `qos`. Out-of-range `stateQos` is rejected at config apply.

## Testing
- `TestMqttPublisher_QoSByTopic` asserts event topics use the event QoS and state/metadata topics use the state QoS.
- Existing `TestIsEventTopic` unchanged.