### PR TITLE
ops: add aggregated chart-data CSV export to PeopleCountHistoryCard

### DIFF
--- a/ui/ops/src/components/download/download.js
+++ b/ui/ops/src/components/download/download.js
@@ -72,7 +72,7 @@ export function useDownloadLink(query, history = null) {
  * @param {Period.AsObject | {startTime: Date, endTime: Date} | null | undefined} period
  * @return {string}
  */
-function datePeriodString(period) {
+export function datePeriodString(period) {
   const toStr = (n) => n.toString().padStart(2, '0');
   if (period) {
     const start = timestampToDate(period.startTime);

--- a/ui/ops/src/dynamic/widgets/occupancy/PeopleCountHistoryCard.vue
+++ b/ui/ops/src/dynamic/widgets/occupancy/PeopleCountHistoryCard.vue
@@ -27,6 +27,7 @@
               <v-list-subheader title="Data"/>
               <period-chooser-rows v-model:start="_start" v-model:end="_end" v-model:offset="_offset"/>
               <v-list-item title="Export chart data (CSV)..."
+                           :disabled="!canExport"
                            @click="onDownloadAggregatedClick"
                            v-tooltip:bottom="'Download the aggregated data shown on the chart'"/>
               <v-list-item title="Export raw data (CSV)..."
@@ -132,6 +133,12 @@ const {summaryPct} = useOccupancyNormalized(
 
 const chartRef = ref(null);
 
+// Slug used for download filenames; collapse whitespace runs to single dashes.
+const titleSlug = computed(() => (props.title?.trim() || 'people-count').toLowerCase().replace(/\s+/g, '-'));
+
+// Whether the chart currently has any data worth exporting.
+const canExport = computed(() => Boolean(chartRef.value?.hasData));
+
 const currentColor = vColors.blue.base;
 
 const priorPeriodTooltip = computed(() => {
@@ -147,16 +154,16 @@ const onDownloadAggregatedClick = () => {
   if (!chart) return;
 
   const {rows, tickUnit} = chart.buildExportRows();
-  const slug = props.title?.toLowerCase()?.replace(' ', '-') ?? 'people-count';
+  if (rows.length <= 1) return; // header only, nothing to export
   const dateString = datePeriodString({startTime: startDate.value, endTime: endDate.value});
-  const filename = `${slug}-chart-${tickUnit}-${dateString}.csv`;
+  const filename = `${titleSlug.value}-chart-${tickUnit}-${dateString}.csv`;
   downloadCSVRows(filename, rows);
 };
 
 const onDownloadClick = async () => {
   if (!props.downloadEnterLeave) {
     await triggerDownload(
-        props.title?.toLowerCase()?.replace(' ', '-') ?? 'people-count',
+        titleSlug.value,
         {conditionsList: [{field: 'name', stringEqual: props.totalOccupancyName}]},
         {startTime: startDate.value, endTime: endDate.value},
         {
@@ -173,7 +180,7 @@ const onDownloadClick = async () => {
   }
 
   await triggerDownload(
-      props.title?.toLowerCase()?.replace(' ', '-') ?? 'people-count-enter-leave',
+      titleSlug.value,
       {conditionsList: [{field: 'name', stringEqual: props.totalOccupancyName}]},
       {startTime: startDate.value, endTime: endDate.value},
       {

--- a/ui/ops/src/dynamic/widgets/occupancy/PeopleCountHistoryCard.vue
+++ b/ui/ops/src/dynamic/widgets/occupancy/PeopleCountHistoryCard.vue
@@ -26,16 +26,19 @@
             <v-list density="compact">
               <v-list-subheader title="Data"/>
               <period-chooser-rows v-model:start="_start" v-model:end="_end" v-model:offset="_offset"/>
-              <v-list-item title="Export CSV..."
+              <v-list-item title="Export chart data (CSV)..."
+                           @click="onDownloadAggregatedClick"
+                           v-tooltip:bottom="'Download the aggregated data shown on the chart'"/>
+              <v-list-item title="Export raw data (CSV)..."
                            @click="onDownloadClick"
-                           v-tooltip:bottom="'Download a CSV of the chart data'"/>
+                           v-tooltip:bottom="'Download a CSV of the raw device readings'"/>
             </v-list>
           </v-card>
         </v-menu>
       </v-btn>
     </v-toolbar>
     <v-card-text class="flex-grow-1 d-flex pt-0">
-      <people-count-history-chart class="flex-grow-1 ma-n2" v-bind="$attrs" :total-occupancy-name="totalOccupancyName"
+      <people-count-history-chart ref="chartRef" class="flex-grow-1 ma-n2" v-bind="$attrs" :total-occupancy-name="totalOccupancyName"
                                   :start="_start" :end="_end" :offset="_offset"
                                   :show-baseline="props.showBaseline" :baseline-shift="baselineShift"
                                   :chart-type="_chartType"/>
@@ -55,12 +58,13 @@
 
 <script setup>
 import {useDateScale} from '@/components/charts/date.js';
-import {triggerDownload} from '@/components/download/download.js';
+import {datePeriodString, triggerDownload} from '@/components/download/download.js';
 import PeriodChooserRows from '@/components/PeriodChooserRows.vue';
 import {useOccupancyNormalized, shiftFnFromStr} from '@/dynamic/widgets/occupancy/baseline.js';
 import PeopleCountHistoryChart from '@/dynamic/widgets/occupancy/PeopleCountHistoryChart.vue';
+import {downloadCSVRows} from '@/util/downloadCSV.js';
 import {useLocalProp} from '@/util/vue.js';
-import {computed, toRef} from 'vue';
+import {computed, ref, toRef} from 'vue';
 import * as vColors from 'vuetify/util/colors';
 
 const props = defineProps({
@@ -126,6 +130,8 @@ const {summaryPct} = useOccupancyNormalized(
   shiftFn
 );
 
+const chartRef = ref(null);
+
 const currentColor = vColors.blue.base;
 
 const priorPeriodTooltip = computed(() => {
@@ -133,6 +139,19 @@ const priorPeriodTooltip = computed(() => {
   const label = labels[props.baselineShift] ?? 'the prior period';
   return `Compared to ${label}`;
 });
+
+// Downloads the aggregated series currently shown on the chart (max people count
+// per auto-sized bucket) as a CSV, rather than the raw device readings.
+const onDownloadAggregatedClick = () => {
+  const chart = chartRef.value;
+  if (!chart) return;
+
+  const {rows, tickUnit} = chart.buildExportRows();
+  const slug = props.title?.toLowerCase()?.replace(' ', '-') ?? 'people-count';
+  const dateString = datePeriodString({startTime: startDate.value, endTime: endDate.value});
+  const filename = `${slug}-chart-${tickUnit}-${dateString}.csv`;
+  downloadCSVRows(filename, rows);
+};
 
 const onDownloadClick = async () => {
   if (!props.downloadEnterLeave) {

--- a/ui/ops/src/dynamic/widgets/occupancy/PeopleCountHistoryChart.vue
+++ b/ui/ops/src/dynamic/widgets/occupancy/PeopleCountHistoryChart.vue
@@ -232,6 +232,36 @@ watch(chartData, (data) => {
 }, {immediate: true});
 
 const showNoData = computed(() => !hasData.value && hasLoadedData.value);
+
+/**
+ * Builds CSV rows (header + one row per bucket) for the aggregated series that
+ * is currently displayed on the chart. Used by the parent card's "Export chart
+ * data" action so the CSV matches the graph exactly.
+ *
+ * @return {{rows: string[][], tickUnit: string}}
+ */
+function buildExportRows() {
+  const totals = totalOccupancyCounts.value;
+  const baseline = baselineCounts.value;
+  const includeBaseline = props.showBaseline;
+
+  const header = ['Time', 'People Count'];
+  if (includeBaseline) header.push('Prior Period People Count');
+
+  const fmt = (v) => (v === null || v === undefined) ? '' : String(v);
+
+  const rows = [header];
+  for (let i = 0; i < totals.length; i++) {
+    const t = totals[i];
+    const time = t.x instanceof Date ? t.x : new Date(t.x);
+    const row = [time.toISOString(), fmt(t.y)];
+    if (includeBaseline) row.push(fmt(baseline[i]?.y));
+    rows.push(row);
+  }
+  return {rows, tickUnit: tickUnit.value};
+}
+
+defineExpose({buildExportRows});
 </script>
 
 <style scoped lang="scss">

--- a/ui/ops/src/dynamic/widgets/occupancy/PeopleCountHistoryChart.vue
+++ b/ui/ops/src/dynamic/widgets/occupancy/PeopleCountHistoryChart.vue
@@ -261,7 +261,7 @@ function buildExportRows() {
   return {rows, tickUnit: tickUnit.value};
 }
 
-defineExpose({buildExportRows});
+defineExpose({buildExportRows, hasData});
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
The existing export downloaded only raw device readings, not the aggregated max-per-bucket series shown on the graph. Add a second "Export chart data (CSV)..." action that serialises exactly what the chart displays.

PeopleCountHistoryChart exposes buildExportRows() so the card can reuse the already-computed series (no extra fetch, CSV matches the graph), including the prior-period baseline column when the overlay is shown. Bucket granularity follows the chart tickUnit automatically. Reuses the existing downloadCSVRows helper; datePeriodString is now exported for consistent filename dating.

I am just adding this only to the PeopleCountHistoryCard for now as it can from a client request to be able to do this.