### PR TITLE
opsui/system: add audit logs page (SCB-1379)

### DIFF
--- a/ui/ops/public/ac-config.json
+++ b/ui/ops/public/ac-config.json
@@ -21,7 +21,9 @@
     },
     "system": {
       "drivers": true,
-      "features": true
+      "features": true,
+      "logs": true,
+      "audit": true
     }
   },
   "config": {

--- a/ui/ops/public/bc-config.json
+++ b/ui/ops/public/bc-config.json
@@ -19,7 +19,9 @@
     "system": {
       "drivers": true,
       "features": true,
-      "components": true
+      "components": true,
+      "logs": true,
+      "audit": true
     }
   },
   "config": {

--- a/ui/ops/src/api/ui/log.js
+++ b/ui/ops/src/api/ui/log.js
@@ -4,6 +4,7 @@ import {LogApiPromiseClient} from '@smart-core-os/sc-bos-ui-gen/proto/smartcore/
 import {
   GetDownloadLogUrlRequest,
   GetLogLevelRequest,
+  GetLogMetadataRequest,
   LogLevel,
   PullLogLevelRequest,
   PullLogMessagesRequest,
@@ -113,6 +114,23 @@ export function updateLogLevel(request, tracker) {
       req.setLogLevel(ll);
     }
     return api.updateLogLevel(req);
+  });
+}
+
+/**
+ * Fetches the current log metadata once (unary). Useful for probing whether a
+ * device exposes the Log trait (e.g. a per-node audit-log device).
+ *
+ * @param {Partial<import('@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/log/v1/log_pb').GetLogMetadataRequest.AsObject>} request
+ * @param {Object} [tracker]
+ * @return {Promise<import('@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/log/v1/log_pb').LogMetadata.AsObject>}
+ */
+export function getLogMetadata(request, tracker) {
+  return trackAction('Log.getLogMetadata', tracker ?? {}, endpoint => {
+    const api = apiClient(endpoint);
+    const req = new GetLogMetadataRequest();
+    if (request?.name) req.setName(request.name);
+    return api.getLogMetadata(req);
   });
 }
 

--- a/ui/ops/src/assets/roleToPermissions.js
+++ b/ui/ops/src/assets/roleToPermissions.js
@@ -47,6 +47,7 @@ export const roleToPermissions = {
       '/system/features',
       '/system/components',
       '/system/logs',
+      '/system/audit',
       '/signage'
     ],
     limitedAccess: [],
@@ -82,7 +83,8 @@ export const roleToPermissions = {
       '/auth',
       '/auth/users',
       '/auth/third-party',
-      '/system/logs'
+      '/system/logs',
+      '/system/audit'
     ]
   },
   operator: {
@@ -116,7 +118,8 @@ export const roleToPermissions = {
     ],
     blockedAccess: [
       '/auth/users',
-      '/system/logs'
+      '/system/logs',
+      '/system/audit'
     ]
   },
   signage: {
@@ -149,7 +152,8 @@ export const roleToPermissions = {
       '/system/drivers',
       '/system/features',
       '/system/components',
-      '/system/logs'
+      '/system/logs',
+      '/system/audit'
     ]
   },
   superAdmin: {
@@ -179,6 +183,7 @@ export const roleToPermissions = {
       '/system/features',
       '/system/components',
       '/system/logs',
+      '/system/audit',
       '/signage'
     ],
     limitedAccess: [],
@@ -215,7 +220,8 @@ export const roleToPermissions = {
       '/system/components'
     ],
     blockedAccess: [
-      '/system/logs'
+      '/system/logs',
+      '/system/audit'
     ]
   }
 };

--- a/ui/ops/src/routes/system/SystemNav.vue
+++ b/ui/ops/src/routes/system/SystemNav.vue
@@ -49,6 +49,11 @@ const menuItems = [
     title: 'Logs',
     icon: 'mdi-text-box-outline',
     link: {path: '/system/logs'}
+  },
+  {
+    title: 'Audit Logs',
+    icon: 'mdi-clipboard-text-clock-outline',
+    link: {path: '/system/audit'}
   }
 ];
 

--- a/ui/ops/src/routes/system/components/pages/AuditLogsPage.vue
+++ b/ui/ops/src/routes/system/components/pages/AuditLogsPage.vue
@@ -1,0 +1,216 @@
+<template>
+  <div class="audit-logs-page d-flex flex-column fill-height">
+    <v-row class="flex-grow-0 ma-0 pa-4 align-center" dense>
+      <h3 class="text-h3">Audit Logs</h3>
+      <v-spacer/>
+      <v-select
+          v-model="selectedNode"
+          :items="nodeItems"
+          density="compact"
+          hide-details
+          label="Node"
+          style="max-width: 300px"
+          @update:model-value="onNodeChange"/>
+    </v-row>
+
+    <v-row class="flex-grow-0 ma-0 px-4 pb-2 align-center" dense>
+      <v-spacer/>
+      <span v-if="metadata" class="text-body-2 text-medium-emphasis mr-4">
+        {{ metadata.fileCount }} {{ metadata.fileCount === 1 ? 'file' : 'files' }} · {{ formatBytes(metadata.totalSizeBytes) }}
+      </span>
+      <v-chip v-if="downloadError" class="mr-2" color="error" size="small">{{ downloadError }}</v-chip>
+      <v-btn
+          :disabled="!selectedNode || blockSystemEdit"
+          class="mr-2"
+          prepend-icon="mdi-download"
+          size="small"
+          variant="tonal"
+          @click="downloadCurrent">
+        Download Current
+      </v-btn>
+      <v-btn
+          :disabled="!selectedNode || blockSystemEdit"
+          prepend-icon="mdi-download-multiple"
+          size="small"
+          variant="tonal"
+          @click="downloadAll">
+        Download All
+      </v-btn>
+    </v-row>
+
+    <v-row class="flex-grow-0 ma-0 px-4 pb-2" dense>
+      <v-text-field
+          v-model="search"
+          clearable
+          density="compact"
+          hide-details
+          placeholder="Search audit log…"
+          prepend-inner-icon="mdi-magnify"
+          style="max-width: 500px"/>
+      <v-btn class="ml-2" size="small" variant="tonal" @click="clearMessages">Clear</v-btn>
+      <v-chip v-if="streamError" class="ml-2" color="error" size="small">{{ streamError.message }}</v-chip>
+    </v-row>
+
+    <log-viewport :messages="filteredMessages" class="flex-grow-1 mx-4 mb-4"/>
+  </div>
+</template>
+
+<script setup>
+import {getDownloadLogUrl, getLogMetadata, pullLogMessages, pullLogMetadata} from '@/api/ui/log.js';
+import {closeResource, newResourceValue} from '@/api/resource.js';
+import {triggerDownloadFromUrl} from '@/components/download/download.js';
+import useAuthSetup from '@/composables/useAuthSetup.js';
+import LogViewport from '@/routes/system/components/log/LogViewport.vue';
+import {levelName} from '@/routes/system/components/log/format.js';
+import {useLogBuffer} from '@/routes/system/components/log/useLogBuffer.js';
+import {useCohortStore} from '@/stores/cohort.js';
+import {storeToRefs} from 'pinia';
+import {computed, onUnmounted, reactive, ref, watch} from 'vue';
+import {useRoute, useRouter} from 'vue-router';
+
+const route = useRoute();
+const router = useRouter();
+const {blockSystemEdit} = useAuthSetup();
+
+const {cohortNodes} = storeToRefs(useCohortStore());
+
+// The audit log is exposed via the standard Log trait on a per-node device named
+// "<node>/audit-log" (see setupAuditLog in pkg/app/controller.go). All requests
+// route to that device by name against the connected server endpoint.
+const auditName = (node) => `${node}/audit-log`;
+
+// Only show nodes that expose an audit-log device. Audit is not a system service,
+// so we probe the device directly and keep the nodes whose metadata resolves.
+const nodesWithAudit = ref(new Set());
+watch(cohortNodes, async (nodes) => {
+  const results = await Promise.all(
+      nodes.map(n => n.name
+          ? getLogMetadata({name: auditName(n.name)}).then(() => n.name).catch(() => null)
+          : null
+      )
+  );
+  nodesWithAudit.value = new Set(results.filter(Boolean));
+}, {immediate: true});
+
+const nodeNames = computed(() =>
+    cohortNodes.value.map(n => n.name).filter(n => n && nodesWithAudit.value.has(n))
+);
+
+const nodeItems = computed(() => nodeNames.value.map(n => ({title: n, value: n})));
+
+const selectedNode = ref(route.query.node ?? null);
+
+const search = ref('');
+const streamError = ref(null);
+const metadata = ref(null);
+const downloadError = ref(null);
+const messagesResource = reactive(newResourceValue());
+const metadataResource = reactive(newResourceValue());
+
+const {messages, clear: clearMessages} = useLogBuffer(messagesResource, {max: 2000});
+
+const filteredMessages = computed(() => {
+  if (!search.value) return messages.value;
+  const q = search.value.toLowerCase();
+  return messages.value.filter(m =>
+      m.message?.toLowerCase().includes(q) ||
+      m.logger?.toLowerCase().includes(q) ||
+      m.source?.toLowerCase().includes(q) ||
+      levelName[m.level]?.toLowerCase().includes(q)
+  );
+});
+
+/**
+ * @param {number|null} bytes
+ * @return {string}
+ */
+function formatBytes(bytes) {
+  if (bytes == null) return '';
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+  return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+}
+
+/**
+ * @param {string} node
+ * @return {Promise<void>}
+ */
+async function startStreams(node) {
+  cancelStreams();
+  clearMessages();
+  streamError.value = null;
+  metadata.value = null;
+
+  const name = auditName(node);
+  pullLogMessages({name, initialCount: 200}, messagesResource);
+  pullLogMetadata({name}, metadataResource);
+}
+
+/**
+ * Cancels all active gRPC streams.
+ */
+function cancelStreams() {
+  closeResource(messagesResource);
+  closeResource(metadataResource);
+}
+
+watch(() => messagesResource.streamError, err => { streamError.value = err?.error ?? null; });
+
+watch(() => metadataResource.value, md => { if (md) metadata.value = md; });
+
+watch(selectedNode, (name) => {
+  if (name) {
+    startStreams(name);
+  } else {
+    cancelStreams();
+  }
+}, {immediate: true});
+
+/**
+ * @param {string|null} name
+ */
+function onNodeChange(name) {
+  router.replace({query: name ? {node: name} : {}});
+}
+
+/**
+ * @return {Promise<void>}
+ */
+async function downloadCurrent() {
+  if (!selectedNode.value) return;
+  downloadError.value = null;
+  try {
+    const res = await getDownloadLogUrl({name: auditName(selectedNode.value), includeRotated: false});
+    for (const file of res.filesList ?? []) {
+      triggerDownloadFromUrl(file.url, file.filename);
+    }
+  } catch (e) {
+    downloadError.value = e.message ?? 'Download failed';
+  }
+}
+
+/**
+ * @return {Promise<void>}
+ */
+async function downloadAll() {
+  if (!selectedNode.value) return;
+  downloadError.value = null;
+  try {
+    const res = await getDownloadLogUrl({name: auditName(selectedNode.value), includeRotated: true});
+    for (const file of res.filesList ?? []) {
+      triggerDownloadFromUrl(file.url, file.filename);
+    }
+  } catch (e) {
+    downloadError.value = e.message ?? 'Download failed';
+  }
+}
+
+onUnmounted(() => cancelStreams());
+</script>
+
+<style scoped>
+.audit-logs-page {
+  height: 100%;
+  overflow: hidden;
+}
+</style>

--- a/ui/ops/src/routes/system/route.js
+++ b/ui/ops/src/routes/system/route.js
@@ -82,6 +82,17 @@ export default [
             rolesRequired: ['admin', 'superAdmin']
           }
         }
+      },
+      {
+        path: 'audit',
+        components: {
+          default: () => import('./components/pages/AuditLogsPage.vue')
+        },
+        meta: {
+          authentication: {
+            rolesRequired: ['admin', 'superAdmin']
+          }
+        }
       }
     ],
     meta: {


### PR DESCRIPTION
## What

Adds a System-area **Audit Logs** page to the Ops UI to view and download the audit log, modelled on the existing **Logs** page.

Resolves [SCB-1379](https://vanti.youtrack.cloud/issue/SCB-1379).

## Background

The backend audit log is **already exposed over gRPC** via the existing `LogApi` trait, announced as a per-node device `<node>/audit-log` (see `setupAuditLog` in `pkg/app/controller.go`), with file download wired through the shared signed-URL router (`DownloadType = "audit-log"`). So **no new proto / gRPC service / codegen** is required — this reuses the existing `LogApi` client pointed at that device.

## Changes

- **`AuditLogsPage.vue`** (new): view, client-side search, and **Download Current** / **Download All** (incl. rotated files), targeting `<node>/audit-log`. Node picker lists only nodes that expose an audit-log device (probed via `getLogMetadata`). No log-level or "All nodes" aggregate controls (not applicable to audit).
- **`log.js`**: add a `getLogMetadata` unary wrapper for per-node audit probing.
- **`route.js` / `SystemNav.vue`**: register `/system/audit` and its nav item.
- **`roleToPermissions.js`**: gate `/system/audit` to admin/superAdmin, mirroring `/system/logs`.
- **`bc-config.json` / `ac-config.json`**: enable `logs` + `audit` under `features.system`.

## Acceptance criteria

- [x] Admins can view recent audit entries (who/what/when) for a selected node.
- [x] Entries can be filtered/searched.
- [x] Audit log can be downloaded, including rotated files.
- [x] Access role-gated consistently with `/system/logs` (admin / super admin).

## Notes for reviewer

- The audit page is **distinct** from the Notifications page (alerts API) as required by the ticket.
- **Deployment**: the live per-site `ui-config.json` must include `audit` under `features.system` for the nav item to appear (in-repo samples updated; `eg-config.json` already uses the `"system": true` wildcard).
- **Backend policy**: worth confirming the policy grants admin/superAdmin access to `LogApi` on the `<node>/audit-log` device.

## Testing

- `eslint` passes on all changed files.
- Full `vite build` could not be run locally (missing `@rolldown/binding-win32-x64-msvc` native module on the Windows box — unrelated to these changes); needs a build/dev-run in a working environment to confirm.
