### PR TITLE
audit: exclude noisy RPCs from the audit log (SCB-1380)

### DIFF
--- a/pkg/auth/policy/interceptor.go
+++ b/pkg/auth/policy/interceptor.go
@@ -225,7 +225,7 @@ func (i *Interceptor) checkPolicyGrpc(ctx context.Context, creds *verifiedCreds,
 		)
 	}
 	// Only audit once per RPC, not for every message on an open client/bidirectional stream.
-	if isWriteMethod(method) && !stream.Open {
+	if isWriteMethod(method) && !isAuditExcluded(service, method) && !stream.Open {
 		outcome := "allowed"
 		if err != nil {
 			outcome = "denied"
@@ -443,6 +443,24 @@ func isWriteMethod(method string) bool {
 		}
 	}
 	return true
+}
+
+// auditExcludedMethods are noisy, low-value RPCs that must never appear in the
+// audit log even though isWriteMethod would otherwise classify them as writes.
+// Matched on the short method name (see rpcutil.ServiceMethod).
+var auditExcludedMethods = map[string]bool{
+	"TestHubNode":         true, // hub connectivity check, called frequently
+	"CreateHistoryRecord": true, // telemetry ingest, very noisy
+}
+
+// isAuditExcluded reports whether an RPC should be omitted from the audit log
+// regardless of whether it is a write method.
+func isAuditExcluded(service, method string) bool {
+	// gRPC server reflection (v1 and v1alpha) is not a meaningful audit event.
+	if strings.HasPrefix(service, "grpc.reflection.") {
+		return true
+	}
+	return auditExcludedMethods[method]
 }
 
 func isHTTPWriteMethod(method string) bool {

--- a/pkg/auth/policy/interceptor.go
+++ b/pkg/auth/policy/interceptor.go
@@ -447,10 +447,11 @@ func isWriteMethod(method string) bool {
 
 // auditExcludedMethods are noisy, low-value RPCs that must never appear in the
 // audit log even though isWriteMethod would otherwise classify them as writes.
-// Matched on the short method name (see rpcutil.ServiceMethod).
+// Keyed on the fully-qualified "service/method" name (see rpcutil.ServiceMethod)
+// so an unrelated service reusing one of these method names is not excluded.
 var auditExcludedMethods = map[string]bool{
-	"TestHubNode":         true, // hub connectivity check, called frequently
-	"CreateHistoryRecord": true, // telemetry ingest, very noisy
+	"smartcore.bos.hub.v1.HubApi/TestHubNode":                      true, // hub connectivity check, called frequently
+	"smartcore.bos.history.v1.HistoryAdminApi/CreateHistoryRecord": true, // telemetry ingest, very noisy
 }
 
 // isAuditExcluded reports whether an RPC should be omitted from the audit log
@@ -460,7 +461,7 @@ func isAuditExcluded(service, method string) bool {
 	if strings.HasPrefix(service, "grpc.reflection.") {
 		return true
 	}
-	return auditExcludedMethods[method]
+	return auditExcludedMethods[service+"/"+method]
 }
 
 func isHTTPWriteMethod(method string) bool {

--- a/pkg/auth/policy/interceptor_test.go
+++ b/pkg/auth/policy/interceptor_test.go
@@ -168,6 +168,33 @@ func TestIsWriteMethod(t *testing.T) {
 	}
 }
 
+func TestIsAuditExcluded(t *testing.T) {
+	tests := []struct {
+		name    string
+		service string
+		method  string
+		want    bool
+	}{
+		// noisy RPCs that must be excluded from the audit log
+		{"reflection v1", "grpc.reflection.v1.ServerReflection", "ServerReflectionInfo", true},
+		{"reflection v1alpha", "grpc.reflection.v1alpha.ServerReflection", "ServerReflectionInfo", true},
+		{"hub test", "smartcore.bos.hub.v1.HubApi", "TestHubNode", true},
+		{"history create", "smartcore.bos.history.v1.HistoryAdminApi", "CreateHistoryRecord", true},
+		// legitimately-audited writes that must NOT be excluded
+		{"enrollment test", "smartcore.bos.enrollment.v1.EnrollmentApi", "TestEnrollment", false},
+		{"function test", "smartcore.bos.emergency.v1.EmergencyApi", "StartFunctionTest", false},
+		{"enroll hub node", "smartcore.bos.hub.v1.HubApi", "EnrollHubNode", false},
+		{"access grant", "smartcore.bos.tenants.v1.TenantApi", "CreateAccessGrant", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAuditExcluded(tt.service, tt.method); got != tt.want {
+				t.Errorf("isAuditExcluded(%q, %q) = %v, want %v", tt.service, tt.method, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestInterceptor_AuditSink(t *testing.T) {
 	sink := &captureSink{}
 

--- a/pkg/auth/policy/interceptor_test.go
+++ b/pkg/auth/policy/interceptor_test.go
@@ -185,6 +185,9 @@ func TestIsAuditExcluded(t *testing.T) {
 		{"function test", "smartcore.bos.emergency.v1.EmergencyApi", "StartFunctionTest", false},
 		{"enroll hub node", "smartcore.bos.hub.v1.HubApi", "EnrollHubNode", false},
 		{"access grant", "smartcore.bos.tenants.v1.TenantApi", "CreateAccessGrant", false},
+		// same method name on a different service must NOT be excluded
+		{"other TestHubNode", "example.other.v1.OtherApi", "TestHubNode", false},
+		{"other CreateHistoryRecord", "example.other.v1.OtherApi", "CreateHistoryRecord", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

`ServerReflectionInfo`, `TestHubNode` and `CreateHistoryRecord` are high-frequency, low-value calls that drown out meaningful mutating operations in the audit log ([SCB-1380](https://vanti.youtrack.cloud/issue/SCB-1380)).

- Added `isAuditExcluded(service, method)` in `pkg/auth/policy/interceptor.go` — excludes `grpc.reflection.` services (covers both `v1` and `v1alpha` `ServerReflectionInfo`) plus `TestHubNode` and `CreateHistoryRecord` by exact method name.
- Gated the audit write with `!isAuditExcluded(...)`. Policy evaluation is untouched — only the audit-log side effect is suppressed.
- Added `TestIsAuditExcluded` covering the excluded RPCs plus negative cases (`TestEnrollment`, `StartFunctionTest`, `EnrollHubNode`, `CreateAccessGrant`) to guard against over-matching.

## Test plan

- `go test ./pkg/auth/policy/...` passes
- `go build ./...` succeeds