### PR TITLE
ui/ops: escape CSV special characters in downloads (SCB-1375)

### DIFF
--- a/ui/ops/src/util/downloadCSV.js
+++ b/ui/ops/src/util/downloadCSV.js
@@ -6,14 +6,20 @@ import {toValue} from 'vue';
  * quotes when it contains a comma, double-quote, CR or LF, doubling any
  * embedded double-quotes. Nullish values become an empty field.
  *
- * Note: no spreadsheet formula-injection guard (prefixing =/+/-/@) is applied,
- * as that would silently alter legitimate negative numeric values in exports.
+ * Non-numeric values beginning with =, +, -, @, tab or CR are prefixed with a
+ * single quote to neutralise spreadsheet formula injection (e.g. `=HYPERLINK(…)`,
+ * `=cmd|…`) when the export is opened in Excel/Sheets. Numeric values such as
+ * `-5` are recognised and left intact, so numeric/timestamp exports are
+ * unaffected.
  *
  * @param {*} field
  * @return {string}
  */
 function escapeCSVField(field) {
-  const str = field === null || field === undefined ? '' : String(field);
+  let str = field === null || field === undefined ? '' : String(field);
+  if (/^[=+\-@\t\r]/.test(str) && isNaN(Number(str))) {
+    str = `'${str}`;
+  }
   if (/[",\r\n]/.test(str)) {
     return `"${str.replace(/"/g, '""')}"`;
   }

--- a/ui/ops/src/util/downloadCSV.js
+++ b/ui/ops/src/util/downloadCSV.js
@@ -2,6 +2,25 @@ import {camelToSentence} from '@/util/string';
 import {toValue} from 'vue';
 
 /**
+ * Escapes a single field for RFC 4180 CSV output. Wraps the value in double
+ * quotes when it contains a comma, double-quote, CR or LF, doubling any
+ * embedded double-quotes. Nullish values become an empty field.
+ *
+ * Note: no spreadsheet formula-injection guard (prefixing =/+/-/@) is applied,
+ * as that would silently alter legitimate negative numeric values in exports.
+ *
+ * @param {*} field
+ * @return {string}
+ */
+function escapeCSVField(field) {
+  const str = field === null || field === undefined ? '' : String(field);
+  if (/[",\r\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
  * Generates a function to download records as a CSV file based on specified properties.
  *
  * @template T
@@ -70,11 +89,11 @@ export const csvDownload = async (params) => {
 
     // Generate the data rows
     const rows = flattenedRecords.map(record =>
-      Object.keys(headerMap).map(key => record[key]).join(',')
+      Object.keys(headerMap).map(key => escapeCSVField(record[key])).join(',')
     );
 
     // Return the CSV string
-    return [header.join(',')].concat(rows).join('\n');
+    return [header.map(escapeCSVField).join(',')].concat(rows).join('\n');
   };
 
 
@@ -137,8 +156,7 @@ export const csvDownload = async (params) => {
  * @param {string[][]} data
  */
 export function downloadCSVRows(filename, data) {
-  // todo: escape ',' and '"' in data
-  const csvContent = data.map(e => e.join(',')).join('\n') + '\n';
+  const csvContent = data.map(e => e.map(escapeCSVField).join(',')).join('\n') + '\n';
   download(filename, csvContent, 'text/csv;charset=utf-8;');
 }
 


### PR DESCRIPTION
## Summary

Hardens the CSV download helpers in `ui/ops/src/util/downloadCSV.js` to escape special characters and neutralise spreadsheet formula injection, resolving [SCB-1375](https://vanti.youtrack.cloud/issue/SCB-1375).

`downloadCSVRows` and `csvDownload`'s `processRecordsForCSV` built CSV output by naively `join(',')`-ing each field (with a standing `// todo: escape ',' and '"' in data`). Any cell containing a comma, double-quote or newline corrupted the output — fields split across columns, broken rows, or CSV injection when opened in a spreadsheet.

This was already a latent bug, not purely theoretical: the helper has **five callers**, and the Notifications export (`routes/ops/notifications/export.js`) already emits free-text fields (`Source`, `Floor`, `Zone`, `Description`) that can contain these characters.

## Changes

- Add an `escapeCSVField` helper implementing RFC 4180 quoting: wrap a field in double quotes when it contains `,`, `"`, CR or LF, doubling any embedded `"`. Nullish values become an empty field (matching the previous `join` behaviour).
- Guard against spreadsheet formula injection: a non-numeric value beginning with `=`, `+`, `-`, `@`, tab or CR is prefixed with a single quote, so `=cmd|…`/`=HYPERLINK(…)` are neutralised in Excel/Sheets. The guard is scoped to non-numeric values (`isNaN(Number(str))`), so genuine numeric fields such as `-5` and ISO-8601 timestamps are left intact — no regression for numeric exports.
- Apply escaping in both `downloadCSVRows` and `processRecordsForCSV` (header + data rows).
- Remove the `// todo` comment.

## Testing

- eslint clean on the changed file.
- Round-trip smoke test against the **real** `downloadCSVRows` with realistic alert rows (comma in `AHU-1, North`, quotes in `Zone "A"`, embedded comma+newline in a description): the emitted CSV re-parses byte-for-byte back to the original rows via a strict RFC 4180 parser. Timestamp/integer fields stay unquoted (no regression).
- Formula-injection guard verified case-by-case: `=HYPERLINK(…)`/`=cmd|…`/`@handle`/tab-prefixed → prefixed with `'`; `-5`, `-5.5`, ISO-8601 timestamps and plain text → unchanged.

> **Note:** `ui/ops` has no unit-test harness today (no vitest/jest, no `test` script, CI only lints/builds). A dedicated unit test for `escapeCSVField` is tracked in [SCB-1400](https://vanti.youtrack.cloud/issue/SCB-1400) (stand up vitest + CI wiring), kept out of this security fix to avoid bootstrapping test infra on a patch.

## Acceptance criteria

- [x] Fields containing commas, quotes, and newlines round-trip correctly on re-import.
- [x] Existing People Count exports unchanged (no regression for timestamp/integer data).
- [x] Spreadsheet formula injection via free-text fields neutralised (optional criterion in the ticket).
