### PR TITLE
task: return error on duplicate Group.Spawn tag instead of panicking (SCB-1386)

### DIFF
--- a/pkg/task/group.go
+++ b/pkg/task/group.go
@@ -2,18 +2,26 @@ package task
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"sync"
 	"time"
 )
 
+// ErrTagExists is returned by Group.Spawn when the group already contains a task
+// with the requested tag.
+var ErrTagExists = errors.New("tag already present")
+
 type Group struct {
 	m     sync.Mutex
 	tasks map[string]*GroupTask
 }
 
-func (g *Group) Spawn(ctx context.Context, tag string, task Task, options ...Option) *GroupTask {
+// Spawn starts task running under the given tag and tracks it in the group.
+// Tags must be unique within a group: if one is already present, Spawn does
+// nothing and returns an error wrapping ErrTagExists.
+func (g *Group) Spawn(ctx context.Context, tag string, task Task, options ...Option) (*GroupTask, error) {
 	g.m.Lock()
 	defer g.m.Unlock()
 
@@ -22,12 +30,11 @@ func (g *Group) Spawn(ctx context.Context, tag string, task Task, options ...Opt
 	}
 
 	if _, present := g.tasks[tag]; present {
-		// TODO: autogenerate an alternative name
-		panic("tag already present")
+		return nil, fmt.Errorf("spawn %q: %w", tag, ErrTagExists)
 	}
 	gt := spawnGroupTask(tag, ctx, NewRunner(task, options...))
 	g.tasks[tag] = gt
-	return gt
+	return gt, nil
 }
 
 func (g *Group) Tasks() map[string]*GroupTask {

--- a/pkg/task/group_test.go
+++ b/pkg/task/group_test.go
@@ -1,0 +1,56 @@
+package task
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// noopTask runs once and stops without error.
+func noopTask(context.Context) (Next, error) {
+	return StopNow, nil
+}
+
+func TestGroup_Spawn(t *testing.T) {
+	var g Group
+
+	gt, err := g.Spawn(context.Background(), "a", noopTask)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gt == nil {
+		t.Fatal("expected a GroupTask, got nil")
+	}
+	if gt.Tag() != "a" {
+		t.Errorf("unexpected tag %q", gt.Tag())
+	}
+	if _, ok := g.Tasks()["a"]; !ok {
+		t.Error("spawned task not present in group")
+	}
+}
+
+func TestGroup_Spawn_duplicateTag(t *testing.T) {
+	var g Group
+
+	first, err := g.Spawn(context.Background(), "a", noopTask)
+	if err != nil {
+		t.Fatalf("unexpected error on first spawn: %v", err)
+	}
+
+	dup, err := g.Spawn(context.Background(), "a", noopTask)
+	if !errors.Is(err, ErrTagExists) {
+		t.Errorf("expected ErrTagExists, got %v", err)
+	}
+	if dup != nil {
+		t.Error("expected nil GroupTask on duplicate tag")
+	}
+
+	// The original task must be untouched and still the only one tracked.
+	tasks := g.Tasks()
+	if len(tasks) != 1 {
+		t.Errorf("expected 1 tracked task, got %d", len(tasks))
+	}
+	if tasks["a"] != first {
+		t.Error("duplicate spawn replaced the original task")
+	}
+}


### PR DESCRIPTION
`Group.Spawn` panicked with `"tag already present"` whenever a tag collided. Since tags can be caller- or data-driven, a duplicate would crash the whole process rather than failing gracefully — a latent footgun for anyone who starts using `Controller.Tasks` (the field is wired up but not yet called anywhere today).

`Spawn` now returns `(*GroupTask, error)`, yielding an error that wraps the new sentinel `ErrTagExists` on a duplicate and leaving the existing task untouched. Returning an error (rather than auto-renaming the tag or silently returning the existing task) keeps a keyed group's contract explicit; with no current callers the signature change has no blast radius.

Verified by `go build ./...`, `go vet`, `staticcheck`, and `go test ./pkg/task/` (new `TestGroup_Spawn` and `TestGroup_Spawn_duplicateTag` cover the happy path and the duplicate-tag error). Race pass deferred to CI (no local C toolchain).

SCB-1386
