### PR TITLE
ui/ops: derive meter unit from DescribeMeterReading in MeterDensityCard (SCB-1387)

### DIFF
--- a/ui/ops/src/dynamic/widgets/meter/MeterDensityCard.vue
+++ b/ui/ops/src/dynamic/widgets/meter/MeterDensityCard.vue
@@ -128,7 +128,7 @@ import {useDateScale} from '@/components/charts/date.js';
 import {useRollingValue} from '@/composables/rollingValue.js';
 import {usePeriod} from '@/composables/time.js';
 import {useMaxPeopleCount} from '@/dynamic/widgets/occupancy/occupancy.js';
-import {useMeterReadingAt, usePullMeterReading} from '@/traits/meter/meter.js';
+import {useDescribeMeterReading, useMeterReadingAt, usePullMeterReading} from '@/traits/meter/meter.js';
 import {format} from '@/util/number.js';
 import {formatTrend, getTrendColor, getTrendIcon} from '@/util/trend.js';
 import {isNull} from '@/util/types.js';
@@ -151,7 +151,9 @@ const props = defineProps({
   },
   meterUnit: {
     type: String,
-    default: 'kWh' // TODO(get meter unit from DescribeMeterReading)
+    // Optional override. When unset, the consumption meter's own reported unit is
+    // used (see _meterUnit), falling back to kWh.
+    default: ''
   },
   occupancy: {
     type: [
@@ -187,7 +189,11 @@ const props = defineProps({
   }
 });
 
-const _unit = computed(() => `${props.meterUnit} per person per day`);
+// Prefer an explicitly configured meterUnit; otherwise use the unit the meter
+// reports via MeterInfo.DescribeMeterReading; fall back to kWh when neither is set.
+const {response: meterInfo} = useDescribeMeterReading(() => props.name || null);
+const _meterUnit = computed(() => props.meterUnit || meterInfo.value?.usageUnit || 'kWh');
+const _unit = computed(() => `${_meterUnit.value} per person per day`);
 
 // Gauge max: the last finite threshold, or 2 as a sensible default
 const densityGaugeMax = computed(() => {


### PR DESCRIPTION
The power-density card hardcoded its displayed unit to `kWh`, so meters reporting in other units were mislabelled. It now derives the unit from the consumption meter itself via `MeterInfo.DescribeMeterReading` (`MeterReadingSupport.usage_unit`), reusing the existing `useDescribeMeterReading` composable already consumed by `MeterHistoryCard`, `ConsumptionCard`, and `WithMeter`.

Precedence is `meterUnit` prop (explicit config override) → the meter's reported unit → `kWh` fallback. The prop default changed from `'kWh'` to `''` so an explicitly-configured unit is distinguishable from the default; the fallback chain preserves the previous `kWh` behaviour when a meter reports no unit.

Verified by eslint (clean on the changed file). The rendered flow wasn't driven end-to-end locally (no running ops backend this session; `vite build` can't run on the Windows host due to the rolldown native-binary issue) — build and visual are covered by CI and the shared pattern with the sibling cards.

SCB-1387
