### PR TITLE
chore: add grab-ticket, raise-pr, read-pr-feedback skills

### DIFF
--- a/.claude/skills/grab-ticket/SKILL.md
+++ b/.claude/skills/grab-ticket/SKILL.md
@@ -128,10 +128,9 @@ The chosen option will almost always have follow-up details that need pinning do
 
 Branch state was already vetted in the Phase 1 pre-flight, so proceed directly to implementation. Follow the conventions already present in the code you're touching (match the surrounding package's style, error handling, and test patterns).
 
-- **Proto changes.** After editing any `.proto`, regenerate the Go/JS code. `protoc` is not installed on the Windows host — run the generator from WSL (see `.claude/CLAUDE.md`):
-  `wsl.exe -e bash -lc 'cd /mnt/c/Users/DeanRedfern/dev/sc-bos && bash scripts/gen-proto.sh'`
+- **Proto changes.** After editing any `.proto`, regenerate the Go/JS code with `bash scripts/gen-proto.sh` (it runs `go run ./cmd/tools/genproto`), and commit the regenerated output alongside the proto.
 - **Go.** Keep it building as you go: `go build ./...`. Add/adjust tests next to the code.
-- **Ops UI.** Lives under `ui/ops` (Vue 3 + Vuetify, Vite, yarn workspaces rooted at `ui/`). Lint from `ui/` (the workspace root, as CI does): `yarn --cwd ops lint`. On this Windows host the UI deps are WSL-installed, so run lint/build from WSL or via the eslint node-direct fallback — see `.claude/CLAUDE.md` → "Linting / building the ops UI".
+- **Ops UI.** Lives under `ui/ops` (Vue 3 + Vuetify, Vite, yarn workspaces rooted at `ui/`). Lint from `ui/` (the workspace root, as CI does): `yarn --cwd ops lint`.
 
 If the work turns out to be materially different from the chosen option (e.g. you discover a needed proto change mid-edit, or the change implies a new trait/domain that wasn't in the plan), stop and re-engage the user — don't quietly expand the scope. Bigger-than-expected is usually still Workable; only step out to a design pass if what you discovered genuinely crosses into a new product domain.
 
@@ -140,7 +139,7 @@ If the work turns out to be materially different from the chosen option (e.g. yo
 The ticket symptom should be **gone**, and **nothing adjacent should have regressed**. A green build alone is **not** validation — the change needs to be observed working. Consider driving this with the `/verify` skill.
 
 - **Same reproduction as Phase 2.** If you reproduced the bug via a Go test, re-run it. If via the ops UI, re-walk the same screen. The smoke must hit the same surface the ticket complained about.
-- **Adjacent surface.** Mirror what CI will run (see `/raise-pr` for the full gate): `go build ./...`, `go vet -lostcancel=false ./...`, `go test ./...`, and for UI changes `yarn --cwd ops lint:nofix` run from `ui/` (on this host see `.claude/CLAUDE.md` for the WSL/node-direct route). If the fix touched a shared helper, smoke-test the other callers. If it touched UI, click around related screens — visual regressions don't show up in unit tests, so observe the change rendered before claiming success.
+- **Adjacent surface.** Mirror what CI will run (see `/raise-pr` for the full gate): `go build ./...`, `go vet -lostcancel=false ./...`, `go test ./...`, and for UI changes `yarn --cwd ops lint:nofix` run from `ui/`. If the fix touched a shared helper, smoke-test the other callers. If it touched UI, click around related screens — visual regressions don't show up in unit tests, so observe the change rendered before claiming success.
 - **Driver / integration work.** Where the change touches a driver or external integration, exercise it against a mock or a real device as available, and say which you used.
 
 If you genuinely can't validate (no environment, missing hardware), say so explicitly rather than claiming success. Report results back to the user with a short summary: what you tested, what passed, anything you couldn't verify and why.

--- a/.claude/skills/grab-ticket/SKILL.md
+++ b/.claude/skills/grab-ticket/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: grab-ticket
+description: Work a YouTrack ticket end-to-end — fetch it, verify the situation against the actual codebase (don't trust the ticket body), present options with trade-offs, then build and validate the fix. TRIGGER whenever the user opens a prompt with a SCB- ticket reference and an investigate / look-at / work-on / pick-up / grab / read-and-fix intent — e.g. "look at SCB-123", "work SCB-456", "pick up SCB-789", "grab SCB-NNN", "read SCB-123 and tell me how we'd fix it", "investigate SCB-NNN", "what's going on with SCB-XYZ". Covers the full loop from triage through PR handoff and composes with /verify, /code-review, and /raise-pr.
+argument-hint: <SCB-NNN>
+---
+
+# Grab YouTrack ticket: $ARGUMENTS
+
+Work a YouTrack ticket end-to-end — fetch it, verify the situation against the actual codebase, agree the approach with the user, then build and validate the fix.
+
+The skill's core assumption: **tickets are a starting point, not a spec.** The body may be wrong, the proposed solution may be wrong, the scope may be wider than enumerated. Trust the codebase, not the ticket. SCB tickets are "things to pick up" — the body doesn't track product state (code and PRs are the source of truth for that), but the **assignee** and **workflow state** do matter for team coordination, and this skill keeps those in sync as it works.
+
+The YouTrack project is **SCB** (Smart Core BOS) at `https://vanti.youtrack.cloud`. Access it through the `mcp__youtrack__*` MCP tools.
+
+## Phase 1 — Fetch the ticket
+
+### Pre-flight — branch check
+
+Before doing anything else, check the current branch:
+
+```
+git rev-parse --abbrev-ref HEAD
+```
+
+If on `main`, **stop immediately**. Investigation, categorisation, and the option-discussion conversation in Phases 2–4 should happen in the session that's going to do the implementation, on the branch that will hold the work — otherwise the work is wasted or has to be manually transferred.
+
+Tell the user: create a feature branch for this ticket (this repo's convention is `feat/<short-slug>` or `fix/<short-slug>`; some contributors run one worktree per ticket), then re-invoke the skill there. Don't soldier on with a read-only triage pass on `main` — the assign + In-Progress claim later in this phase only makes sense once we're committed to working the ticket from this session.
+
+If on a feature branch (anything other than `main`), proceed. The skill assumes the branch was prepared for this ticket, but doesn't enforce a particular naming convention.
+
+### Determine the ticket ID
+
+- If `$ARGUMENTS` matches `SCB-\d+`, use that.
+- Otherwise check the current branch name (`git rev-parse --abbrev-ref HEAD`) for an embedded ticket ID like `feat/SCB-123-foo`.
+- If still unknown, ask the user.
+
+Fetch the ticket and its context in parallel:
+
+- `mcp__youtrack__get_issue` — title, body, type, status, reporter, assignee
+- `mcp__youtrack__get_issue_comments` — prior triage and discussion
+- Linked issues from the issue payload (`links` field, if any) — duplicates, parents, follow-ups worth fetching too
+
+Surface a short summary back to the user (one paragraph): what the ticket asks for, who reported it, current state, and anything notable in the comments (e.g. "Alice already debugged this and pointed at package X"). **Don't yet say what you think we should do** — that comes after Phase 2. The user can interject if the fetched ticket isn't the one they meant; otherwise proceed straight to claiming it.
+
+### Claim the ticket
+
+Right after the summary, take ownership in YouTrack — deciding what to do with a ticket already counts as working on it, so the state should reflect that immediately:
+
+- **Assign to the current user** via `mcp__youtrack__change_issue_assignee`. Resolve the current user with `mcp__youtrack__get_current_user` if you don't already know their login. Note: the YouTrack MCP can set or change an assignee but cannot clear the field — reassigning to a real person is fine, but unassigning requires the YouTrack UI.
+- **Transition to "In Progress"** via `mcp__youtrack__update_issue`, unless the ticket is already at or past In Progress (don't backstep).
+
+State name discovery: if you don't already know the project's workflow values, call `mcp__youtrack__get_issue_fields_schema` once to learn the valid `State` options for SCB, then pick the closest match to "In Progress" (and later "To Verify"). For reference, SCB's states are: Submitted, To Do, In Progress, Can't Reproduce, Duplicate, Done, Won't fix, Deployed, To Verify, Blocked.
+
+**Edge cases that should stop the skill here**:
+
+- Ticket is already **Done / Deployed / Won't fix / Duplicate** — don't reopen it. Surface the closed state loudly and ask the user whether they actually want to work it (likely the wrong ticket).
+- Ticket is **already assigned to someone else** — don't steal it. Show who has it and ask the user how to proceed.
+- Ticket is an **epic / placeholder / meta** — the workflow assumes a single workable unit. Flag it and ask which child issue to actually pick up.
+
+## Phase 2 — Verify against the codebase
+
+Treat the ticket body and any proposed solution in it as untrusted. For every factual claim the ticket makes — "when X happens, Y is shown", "the API returns Z when called with W", "feature F is missing" — find the corresponding code path and confirm or refute the claim. Read the code, don't theorise about it.
+
+Concretely:
+
+- **Bugs.** Locate the code path, reason through it, and where practical **reproduce the symptom locally**. For Go, write or run a focused test (`go test -run <name> ./pkg/...`) or exercise the relevant binary under `cmd/`. For the ops UI, run the dev server (`yarn dev` in `ui/ops`) and drive the affected screen. Confirm the bug actually exists on the current branch *before* discussing fixes — a fix proposed on a theory often turns out to be aimed at the wrong root cause and wastes a review round.
+- **Missing feature.** Find where it would live and what scaffolding is already in place. Note any partial work (half-built RPC, proto message with no server impl, config field with no UI, etc.) — these change the size of the work materially.
+- **Refactor / cleanup.** Read the cited code and trace its callers; understand what depends on it before proposing changes.
+
+Watch for these specific outcomes, because they change the next step:
+
+- **Already fixed.** Behaviour doesn't reproduce. Maybe it was fixed in a later commit, maybe the reporter's environment was stale. Skip to Phase 3 with category *Invalid*.
+- **Ticket says one thing, code does another.** Ticket asserts X is the bug; code shows Y. Don't silently fix Y under the heading of X — name the divergence so the user can decide what to do with it.
+- **Scope wider than enumerated.** A bug class with multiple sites; a missing field that breaks more than the single example the reporter gave. Default to fixing the **full class**, not just the named case — leaving siblings broken usually just produces a duplicate ticket. But surface it as a choice; sometimes there's a reason to stay narrow (urgency, blast radius, a separate piece of work already planned for the rest).
+- **Multiple plausible root causes.** When two code paths could each produce the reported symptom, instrument or read enough to know which one — don't pick the more convenient candidate.
+
+### When verification stalls — ask the user first
+
+If the repro fails, the symptom doesn't appear, or the ticket's wording leaves you genuinely unsure what behaviour to test, **ask the user before declaring "needs more info"**. They're usually closer to the missing context than either the ticket or the codebase: a recent change on another branch, an env flag the test data needs, a related ticket, a sibling feature that interacts, or just a translation of what the reporter probably meant.
+
+Concrete things to ask for when stuck:
+
+- "I can't reproduce on `main` — do you have a branch / env where it shows up?"
+- "The ticket says X but I see code Y — which behaviour are we treating as the bug?"
+- "I'm seeing two code paths that could produce this symptom — does one of them ring a bell?"
+- "What was the reporter's setup (which site, which driver, which node)?"
+
+Continue Phase 2 with whatever context the user provides. Only escalate to the **Needs more info** category in Phase 3 if the user can't unstick the repro either — at that point the question genuinely belongs with the reporter, and drafting a comment back is the right move.
+
+### Report findings
+
+Once verification settles (with or without help from the user), report findings with a short summary before moving to Phase 3. Frame it as *what you found*, not *what you'd do* — Phase 3 is for the recommendation.
+
+If verification surfaces an issue that's a strict superset of the ticket (a class-wide bug, a missing layer of a feature), say so explicitly. The user expects to be told.
+
+## Phase 3 — Categorise & engage
+
+Based on Phase 2, classify the situation into one of these and tell the user which one fits, with one-sentence reasoning:
+
+| Category | What it means | Next step |
+|---|---|---|
+| **Invalid / already fixed / duplicate** | Cannot reproduce; fixed in a later commit; covered by another ticket | Skill ends. Optionally post a closing comment (Phase 8). |
+| **Needs more info** | Reporter's description isn't enough, codebase doesn't disambiguate, **and** the user couldn't fill the gap when asked in Phase 2 | Skill ends. Draft a "what would help" comment back to the reporter. |
+| **Workable** | A concrete change we can plan and build — bug fix, refactor, new RPC, new config field, new driver capability, even a sizeable addition to an existing area. Most tickets land here. | Continue to Phase 4. |
+| **New product domain** | The ticket asks for a whole new product concept the codebase doesn't already model (a new trait, a new subsystem, a data model invented from scratch). The bar is "we need to invent terminology and a data model", not "this is a bigger change than usual". | Recommend stepping back into a design/plan pass first (write a short design doc under `docs/design/`, or use plan mode) and stop. |
+
+Most non-trivial work is still **Workable** — we don't write a design doc just because the change is medium-sized, touches several packages, or crosses the Go/UI boundary. The design gate is *new domain*, not *non-trivial*. If you find yourself reaching for a design doc, articulate which new domain concept the ticket introduces before recommending it; if you can't name one, the answer is Workable.
+
+Scope decisions (narrow vs full-class) were already discussed in Phase 2 — by Phase 3 you're categorising the **agreed scope**, not re-opening the conversation. A ticket where the user picked a wider scope is still Workable; broader doesn't mean design-shaped.
+
+For categories that end the skill, summarise clearly so the user can act on it (close the ticket themselves, ping the reporter, start a design pass). **For an ended skill, do not update ticket status, fields, or assignee beyond what Phase 1 already did** — leave further changes to the user.
+
+## Phase 4 — Propose options & decide
+
+Present **1–3 viable approaches** with concrete trade-offs: effort, risk, regression surface, reach. Don't jump straight to one — the user's call. A worked option includes:
+
+- What you'd change (which files / which layers — Go packages, proto, ops UI)
+- What the user-facing outcome is
+- The notable trade-off vs. the alternatives (perf, scope creep, blast radius, etc.)
+
+Use `AskUserQuestion` when the options map cleanly onto multi-choice. When the choice is interlinked with other decisions, free-text discussion is fine. Ask one focused question at a time rather than dropping a numbered wall of questions — it's faster to converge that way.
+
+After the user picks, **mirror the chosen plan back** as 2–3 bullet points before writing code.
+
+The chosen option will almost always have follow-up details that need pinning down (naming, config defaults, edge cases, failure modes). Surface those one at a time — the same interview rule applies. Don't dump them as a numbered list of "open questions" and expect the user to reply with a numbered block; that's slower and easier to lose track of. Pick the most consequential open question, ask it on its own, apply the answer, then ask the next. If a couple of small details cluster naturally, batching those two is fine — but the default is one at a time.
+
+## Phase 5 — Implement
+
+Branch state was already vetted in the Phase 1 pre-flight, so proceed directly to implementation. Follow the conventions already present in the code you're touching (match the surrounding package's style, error handling, and test patterns).
+
+- **Proto changes.** After editing any `.proto`, regenerate the Go/JS code. `protoc` is not installed on the Windows host — run the generator from WSL (see `.claude/CLAUDE.md`):
+  `wsl.exe -e bash -lc 'cd /mnt/c/Users/DeanRedfern/dev/sc-bos && bash scripts/gen-proto.sh'`
+- **Go.** Keep it building as you go: `go build ./...`. Add/adjust tests next to the code.
+- **Ops UI.** Lives under `ui/ops` (Vue 3 + Vuetify, Vite, yarn workspaces rooted at `ui/`). Lint from `ui/` (the workspace root, as CI does): `yarn --cwd ops lint`. On this Windows host the UI deps are WSL-installed, so run lint/build from WSL or via the eslint node-direct fallback — see `.claude/CLAUDE.md` → "Linting / building the ops UI".
+
+If the work turns out to be materially different from the chosen option (e.g. you discover a needed proto change mid-edit, or the change implies a new trait/domain that wasn't in the plan), stop and re-engage the user — don't quietly expand the scope. Bigger-than-expected is usually still Workable; only step out to a design pass if what you discovered genuinely crosses into a new product domain.
+
+## Phase 6 — Validate end-to-end
+
+The ticket symptom should be **gone**, and **nothing adjacent should have regressed**. A green build alone is **not** validation — the change needs to be observed working. Consider driving this with the `/verify` skill.
+
+- **Same reproduction as Phase 2.** If you reproduced the bug via a Go test, re-run it. If via the ops UI, re-walk the same screen. The smoke must hit the same surface the ticket complained about.
+- **Adjacent surface.** Mirror what CI will run (see `/raise-pr` for the full gate): `go build ./...`, `go vet -lostcancel=false ./...`, `go test ./...`, and for UI changes `yarn --cwd ops lint:nofix` run from `ui/` (on this host see `.claude/CLAUDE.md` for the WSL/node-direct route). If the fix touched a shared helper, smoke-test the other callers. If it touched UI, click around related screens — visual regressions don't show up in unit tests, so observe the change rendered before claiming success.
+- **Driver / integration work.** Where the change touches a driver or external integration, exercise it against a mock or a real device as available, and say which you used.
+
+If you genuinely can't validate (no environment, missing hardware), say so explicitly rather than claiming success. Report results back to the user with a short summary: what you tested, what passed, anything you couldn't verify and why.
+
+Local validation passing isn't yet a To Verify state — that transition is tied to PR publication, not to a green build on the user's machine. It happens in Phase 8.
+
+## Phase 7 — Self-review (when significant)
+
+Significant changes benefit from a fresh-eyes pass before they reach a teammate's PR queue. Use the built-in **`/code-review`** skill to review the working diff for correctness bugs and cleanups.
+
+**Invoke `/code-review` when the change is significant**, e.g.:
+
+- The diff touches a lot of files, or spans several packages
+- The change lands in heavily-used / load-bearing code — a shared helper, an auth path, a proto/trait definition many drivers consume
+- Cross-cutting impact — a change to `pkg/proto/*`, `pkg/node`, config schemas, anything other features rely on
+- You're not fully confident the implementation lands cleanly
+
+**Skip it for:**
+
+- A CSS / styling tweak in a single Vue component
+- Markdown or other doc updates
+- A small refactor with no behavioural change
+- A one-line bug fix that Phase 6 already exercised end-to-end
+
+When in doubt, lean toward running it — a review round inside this session is cheaper than another round of PR feedback later. Move on to Phase 8 when the review loop settles.
+
+## Phase 8 — Wrap up
+
+### Ticket comment (usually skip)
+
+Default: **no comment.** SCB tickets aren't reliably read again after they're picked up, so a comment is overhead with no audience. Only post one when there's something load-bearing for future readers:
+
+- "Closing as not-a-bug — X is intentional, see <link>"
+- "Surfaced a wider issue while picking this up, tracked as SCB-XYZ"
+- "Partial fix landed; broader rework deferred — see PR #NNN for context"
+- "Cannot reproduce — closing. If it comes back, please attach <Y>"
+- (For the Phase 3 "Needs more info" exit) "Couldn't reproduce — would help to know <X, Y, Z>."
+
+When one of these applies, just write the final wording and post it via `mcp__youtrack__add_issue_comment` — no explicit approval step. The comment is narrow in scope and posted to a ticket the team rarely revisits, so a confirmation gate buys nothing. The substantive call is *whether* to comment at all (gated above); once that's settled, the post is mechanical. Mention what you posted in the end-of-skill summary so the user sees it.
+
+The skill already handled assignee and state transitions in earlier phases — don't touch them again here, and don't change priority, type, sprint, subsystem, or other ticket fields (those stay manual).
+
+### PR handoff
+
+If code changed and the user is happy, recommend they invoke `/raise-pr`. Don't auto-invoke it — that skill has its own pre-flight (validation depth, build gate, branch hygiene) that's better entered fresh. Don't commit during the iteration loop unless the user explicitly asks; iteration on review feedback is faster when changes accumulate uncommitted, and `/raise-pr` owns commit timing at the end.
+
+### Move the ticket to To Verify
+
+The To Verify transition is tied to **PR publication**, not local validation — until the change is on GitHub for a teammate to look at, there's nothing for anyone to verify. Once `/raise-pr` has successfully published the PR (pushed, opened, and marked ready-for-review per that skill's flow), transition the ticket from In Progress to **"To Verify"** via `mcp__youtrack__update_issue`, using the project's exact state name as discovered in Phase 1.
+
+Skip the transition if:
+
+- The user declined `/raise-pr` or `/raise-pr` did not complete (no published PR yet — state stays In Progress).
+- The ticket is already past To Verify (don't backstep).
+- No code change was made (Invalid / Needs more info / New-domain handed to a design pass) — there's nothing to verify, leave the state where it is.
+
+### When there's nothing to PR
+
+If verification ended with no code change (Invalid / Needs more info / New-domain), there's nothing to PR and no To Verify transition — say so and stop.

--- a/.claude/skills/grab-ticket/SKILL.md
+++ b/.claude/skills/grab-ticket/SKILL.md
@@ -190,6 +190,8 @@ If code changed and the user is happy, recommend they invoke `/raise-pr`. Don't 
 
 The To Verify transition is tied to **PR publication**, not local validation — until the change is on GitHub for a teammate to look at, there's nothing for anyone to verify. Once `/raise-pr` has successfully published the PR (pushed, opened, and marked ready-for-review per that skill's flow), transition the ticket from In Progress to **"To Verify"** via `mcp__youtrack__update_issue`, using the project's exact state name as discovered in Phase 1.
 
+To Verify is the *in-review* state; the closing transition happens on **merge**, carried by the `#SCB-NNNN State Done` command `/raise-pr` puts in the PR body (processed by YouTrack's GitHub VCS integration). So don't set Done here — leave the merge to resolve it. If that integration isn't enabled, the ticket stays at To Verify after merge and someone closes it manually.
+
 Skip the transition if:
 
 - The user declined `/raise-pr` or `/raise-pr` did not complete (no published PR yet — state stays In Progress).

--- a/.claude/skills/raise-pr/SKILL.md
+++ b/.claude/skills/raise-pr/SKILL.md
@@ -148,7 +148,7 @@ If push is rejected for "fetch first" — and sanity check didn't already prompt
 Resolve everything before invoking `gh pr create`:
 
 1. **Title** — already decided in Phase 3 (`area: summary (SCB-NNNN)`).
-2. **Body** — prose explaining *why*, not what. The diff explains what. End with a verification line stating how the change was exercised. If the work tracks a ticket, reference it (e.g. a `SCB-NNNN` line, or a link to the YouTrack issue) so reviewers can find it — the `/grab-ticket` flow owns the YouTrack state transition, so the PR body just needs to make the link discoverable.
+2. **Body** — prose explaining *why*, not what. The diff explains what. End with a verification line stating how the change was exercised. If the work tracks a ticket, end with a YouTrack command footer `#SCB-NNNN State Done` — this both links the ticket and, when the PR merges, transitions it to Done via YouTrack's GitHub VCS integration (the merge is the resolving event; a bare `SCB-NNNN` only links). If the integration isn't enabled the footer is harmless text and the ticket stays where `/grab-ticket` left it (To Verify), to be closed manually. Use the project's resolved-state command if it isn't `State Done`.
 3. **Base** — `$ARGUMENTS` or `main`.
 4. **Draft mode** — open as draft. CI still runs on drafts; mergeable status is computed regardless. Opening as draft keeps reviewers out of it until CI is green and the PR is mergeable — the flip and the reviewer request happen together in Phase 7.
 
@@ -171,7 +171,7 @@ Capture the PR number and URL from the output.
 
 Verified by <go test ./pkg/... / exercised cmd/bos with <config> / browser walk-through of <flow> / proto regenerated and built / ...>.
 
-SCB-NNNN
+#SCB-NNNN State Done
 ```
 
 Keep it short. Reviewers can read the diff. The body's job is to communicate intent, confirm the change was witnessed, and link the ticket.

--- a/.claude/skills/raise-pr/SKILL.md
+++ b/.claude/skills/raise-pr/SKILL.md
@@ -45,7 +45,7 @@ Act on the flags before doing anything else:
 - `nothing-to-raise-stop` — no commits ahead **and** no uncommitted work. Nothing to raise. Stop.
 - `rebase` — branch is behind base. Rebase onto `origin/<base>` now, before Phase 1, so confidence assessment and pre-flight operate on the final state (`git rebase origin/<base>`; stash first if there's uncommitted work). Resolve conflicts, then continue.
 - `skip-build` — pre-flight (Phase 2) can skip the Go build/test chain; see that phase for the fast path.
-- `proto-regen` — the diff touches `.proto` files. Confirm the generated code is up to date (regenerate via WSL — see `.claude/CLAUDE.md`) and that the regenerated output is committed, before proceeding.
+- `proto-regen` — the diff touches `.proto` files. Confirm the generated code is up to date (`bash scripts/gen-proto.sh`) and that the regenerated output is committed, before proceeding.
 
 ## Phase 1 — Confidence assessment
 
@@ -102,8 +102,6 @@ CI also runs `staticcheck ./...` (`honnef.co/go/tools/cmd/staticcheck@2026.1`). 
 
 - Run from `ui/` (the yarn workspace root, as CI does): `yarn --cwd ops lint:nofix` — exactly what CI runs per-workspace. (`yarn --cwd ui/ops …` from the repo root does **not** work — the repo root isn't a workspace, so the hoisted binaries don't resolve.)
 - For a build-affecting change, also `yarn --cwd ops build` (from `ui/`).
-
-> **Windows host note:** the ops UI deps are installed under WSL, so `yarn` lint/build fail natively (`'eslint' is not recognized`, rolldown `MODULE_NOT_FOUND`). Run them from WSL, or use the eslint node-direct fallback. See `.claude/CLAUDE.md` → "Linting / building the ops UI".
 
 Note: the `lint` script auto-fixes; `lint:nofix` only checks. If you run `lint` to auto-fix, review the resulting `git status` and include the fixes in the commit, then confirm `lint:nofix` passes.
 

--- a/.claude/skills/raise-pr/SKILL.md
+++ b/.claude/skills/raise-pr/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: raise-pr
+description: Raise a pull request from the current branch — assesses whether the change has been validated to the depth its size warrants, runs the build/test/lint gate that mirrors CI, commits, pushes, opens the PR as draft, watches CI to green, then marks it ready and prompts you for who to request review from (this repo has no CODEOWNERS auto-request). Use when the user signals end-of-task intent ("raise a PR", "open a PR", "ship this", "create the PR", "let's PR this"). Do NOT fire on "review my changes" (that's /code-review) or post-PR feedback (that's /read-pr-feedback).
+argument-hint: [base-branch]
+---
+
+# Raise PR
+
+Take a branch from "implementation done" to "PR open, CI green, review requested". Default base branch is `main` if no argument given. Repo: `github.com/smart-core-os/sc-bos` (use the `gh` CLI).
+
+## Goal
+
+A pull request is the author saying: *"I want this change to land in the product in exactly this shape, and I'm confident enough in it to ask for a second pair of eyes."* The review process is a sanity check on that commitment, not a substitute for it. Quality and confidence are the author's responsibility before raising.
+
+The skill exists to make the commitment honest. Confidence is earned by checking the change outcome against several criteria, weighted by the change's size and impact:
+
+- **Mechanical** — lint, vet, build. Cheap, deterministic, run as a pre-flight.
+- **Correctness** — unit/integration tests, binary/API exercise, proto regenerated. Should have happened *during* the work.
+- **Judgement** — design alignment, UI assessment, review of some form. Proportionate to scope.
+
+The skill verifies these signals; it does not perform the underlying work at PR time. Missing evidence means the change is not yet ready to be committed to — surface the gap rather than paper over it by doing the work last-minute.
+
+The skill makes no assumption about *what* upstream workflow was used. It does not require `/grab-ticket`, `/code-review`, or any specific predecessor; it assesses what's actually in the session and the diff.
+
+## Efficiency rules
+
+- **Single `gh pr create` call** — never fail-then-retry. Resolve title, body, base, and remote tracking *before* invoking. Use `--body-file` (not `--body`) for prose bodies.
+- **Don't ask for confirmation on a clean run** of the mechanical gates. The one interactive step that always happens is choosing reviewers in Phase 7 — that's the point of this skill's variant.
+- **Use parallel tool calls** for independent reads and independent checks (see Phase 2).
+- **Never hot-loop CI checks.** Either stream events via `Monitor` on `gh pr checks <pr> --watch`, or wait at least 30 seconds between polls. CI runs typically take a minute or longer to settle.
+
+## Sanity check
+
+Run `bash .claude/skills/raise-pr/scripts/state.sh [base-branch]` (default base: `main`) to get a structured snapshot of the branch in one call. The script fetches the base and emits key=value lines:
+
+- `branch`, `base`, `ahead`, `behind`, `uncommitted_count`
+- `base_fetch` — `fresh` if the fetch of `origin/<base>` succeeded; `stale` if it failed (likely offline). Stale numbers may be wrong; retry or proceed cautiously.
+- `change_class` — `docs-only` | `code` | `mixed` (heuristic on file paths/extensions; `.go/.proto/.rego/.vue/.js/.ts` count as code)
+- `recommend` — space-separated flags, optionally followed by ` // ` and a human-readable rationale. Flags: `on-base-branch-stop`, `nothing-to-raise-stop`, `rebase`, `skip-build`, `proto-regen`. Ignore everything from ` // ` onward if parsing.
+- Lists of uncommitted and committed-ahead files
+
+Act on the flags before doing anything else:
+
+- `on-base-branch-stop` — the branch is the base. Stop and ask which branch should hold the work.
+- `nothing-to-raise-stop` — no commits ahead **and** no uncommitted work. Nothing to raise. Stop.
+- `rebase` — branch is behind base. Rebase onto `origin/<base>` now, before Phase 1, so confidence assessment and pre-flight operate on the final state (`git rebase origin/<base>`; stash first if there's uncommitted work). Resolve conflicts, then continue.
+- `skip-build` — pre-flight (Phase 2) can skip the Go build/test chain; see that phase for the fast path.
+- `proto-regen` — the diff touches `.proto` files. Confirm the generated code is up to date (regenerate via WSL — see `.claude/CLAUDE.md`) and that the regenerated output is committed, before proceeding.
+
+## Phase 1 — Confidence assessment
+
+Read the session and the diff. Judge whether the evidence supports committing to this change in this shape. The depth required scales with the size and impact of the change.
+
+### Signals to assess
+
+**Session continuity** — Scan the conversation for items raised by the user that were parked, deferred, or forgotten. Phrases like "we'll do X later", "also handle Y", "remind me about Z", or direct asks that drifted out of focus. The change should not leave session-level expectations unmet without an explicit decision to defer them.
+
+**Tests** — Does the diff include tests covering the new behaviour? For a new package/service, expect a `_test.go`. For a bug fix, expect a regression test that would have caught the bug. For a tiny refactor, existing tests may suffice. The signal: would a reviewer reasonably expect tests here, and are they present?
+
+**Binary / API exercise** — If the diff adds or changes an RPC, driver, or command, look for evidence in the session that it was actually run — a `go test` against the new path, the relevant `cmd/` binary exercised, or a gRPC call made.
+
+**Proto regeneration** — If `.proto` files changed, the generated Go (`pkg/proto/...`, `pkg/gen`) and JS (`ui/ui-gen/proto`) must be regenerated and committed. Confirm the generated files are in the diff and consistent with the proto change.
+
+**Frontend functional flow** — If the diff changes ops-UI behaviour, look for evidence the affected flow was driven end-to-end in the session (dev server, navigate, exercise, confirm outcome).
+
+**UI visual signoff** — How much pixel surface did the change move?
+
+- *Small* — a CSS tweak, a copy change, a fix targeted at a specific visual bug. Look for evidence the change was visually confirmed in the session (a screenshot or a browser navigation that loaded the changed surface after the edit). If it went in blind, that's a gap.
+- *Non-trivial* — new views, restyled components, layout shifts, new visual states. Look for evidence the user has engaged with the visual in this session — a shared screenshot, feedback given and addressed, or direct sign-off. If the user hasn't seen it, ask for a walkthrough before raising.
+
+**Design alignment** — If a design doc under `docs/` describes the change, the diff should match it on structure, RPCs, config, fields.
+
+**Review** — Proportionate to size. A two-line fix needs no formal review beyond its own clarity. A new feature should have evidence of *some* review pass: `/code-review`, direct user feedback that was engaged with, or substantive back-and-forth in the session. Absent any review trace on a substantial change, that's a confidence gap.
+
+### On a gap
+
+Stop. Name the gap concretely — which signal is weak, what specifically is missing, what would close it. Pause for the user.
+
+Example:
+
+> The diff adds a new `MeterInfo.DescribeMeterReading` handler and wires it into the mock driver. The session shows a `go build` but no test covering the new handler, and no review trace for a change of this size. Before raising: add the test, or confirm you've reviewed the handler separately.
+
+If the user supplies plausible out-of-session evidence ("I tested it from another terminal", "I reviewed it in another session"), take it at face value and continue. The gate catches genuinely-missed validation, not ceremony. Do not volunteer to *do* the validation yourself — that defeats the gate.
+
+## Phase 2 — Pre-flight gate
+
+Mirror what CI runs so nothing is discovered only after pushing.
+
+If sanity check returned `skip-build` (docs/config-only diff), run only the relevant linters and skip ahead to Phase 3.
+
+### Go (when the diff touches `go.mod`, `cmd/`, `internal/`, or `pkg/`)
+
+Run in parallel (separate Bash calls in one message):
+
+- `go build ./...`
+- `go vet -lostcancel=false ./...`
+- `go test ./...` (CI additionally runs `-short -race ./...` and the `_e2e$` split; run the race pass too for concurrency-touching changes)
+
+CI also runs `staticcheck ./...` (`honnef.co/go/tools/cmd/staticcheck@2026.1`). Run it if available locally; if not installed, note that staticcheck will run in CI and watch it in Phase 6.
+
+### Ops UI (when the diff touches `ui/**`)
+
+- Run from `ui/` (the yarn workspace root, as CI does): `yarn --cwd ops lint:nofix` — exactly what CI runs per-workspace. (`yarn --cwd ui/ops …` from the repo root does **not** work — the repo root isn't a workspace, so the hoisted binaries don't resolve.)
+- For a build-affecting change, also `yarn --cwd ops build` (from `ui/`).
+
+> **Windows host note:** the ops UI deps are installed under WSL, so `yarn` lint/build fail natively (`'eslint' is not recognized`, rolldown `MODULE_NOT_FOUND`). Run them from WSL, or use the eslint node-direct fallback. See `.claude/CLAUDE.md` → "Linting / building the ops UI".
+
+Note: the `lint` script auto-fixes; `lint:nofix` only checks. If you run `lint` to auto-fix, review the resulting `git status` and include the fixes in the commit, then confirm `lint:nofix` passes.
+
+All gates must succeed. If anything fails, fix it locally and rerun — do not push a broken branch and let CI catch it.
+
+## Phase 3 — Commit
+
+Iteration tweaks may have been held uncommitted during review loops. Roll them into one meaningful commit, or a small number of meaningful commits — not per-file noise.
+
+**Title format:** this repo uses `<area>: <summary>` with the ticket ID in parentheses at the end. Real examples from the history:
+
+```
+ui/ops: escape CSV special characters in downloads (SCB-1375)
+node/alltraits: drop status trait from service registry
+auto/history: drop status trait recorder
+```
+
+- `<area>` is the package/path touched (`ui/ops`, `node/alltraits`, `pkg/auto/bms`, `driver/mock`, …).
+- Append ` (SCB-NNNN)` when the work tracks a ticket. Unlike some repos, sc-bos **keeps the ticket ID in the subject line** — don't strip it.
+- Imperative mood, lower-case area, no trailing full stop.
+
+Plain `git commit` — never `--no-verify`.
+
+## Phase 4 — Push
+
+First push to a new remote branch:
+
+```
+git push -u origin <branch>
+```
+
+Subsequent push (history rewritten via amend, rebase, fixup):
+
+```
+git push --force-with-lease --force-if-includes
+```
+
+Never plain `--force` or bare `--force-with-lease` (without `--force-if-includes`) — both can silently overwrite upstream changes.
+
+If push is rejected for "fetch first" — and sanity check didn't already prompt a rebase — rebase onto `origin/<base>` and push again.
+
+## Phase 5 — Create the PR as draft
+
+Resolve everything before invoking `gh pr create`:
+
+1. **Title** — already decided in Phase 3 (`area: summary (SCB-NNNN)`).
+2. **Body** — prose explaining *why*, not what. The diff explains what. End with a verification line stating how the change was exercised. If the work tracks a ticket, reference it (e.g. a `SCB-NNNN` line, or a link to the YouTrack issue) so reviewers can find it — the `/grab-ticket` flow owns the YouTrack state transition, so the PR body just needs to make the link discoverable.
+3. **Base** — `$ARGUMENTS` or `main`.
+4. **Draft mode** — open as draft. CI still runs on drafts; mergeable status is computed regardless. Opening as draft keeps reviewers out of it until CI is green and the PR is mergeable — the flip and the reviewer request happen together in Phase 7.
+
+Write the body to a temp file, then create the PR:
+
+```
+mkdir -p .tmp
+# write the body to .tmp/pr-body.md  (.tmp is gitignored; create it if missing)
+gh pr create --draft --base <base> --title "<title>" --body-file .tmp/pr-body.md
+```
+
+Capture the PR number and URL from the output.
+
+### Body shape
+
+```
+<one short paragraph: why this change exists — the trigger, the user pain. Not "this PR adds X">
+
+<optional second paragraph: non-obvious design choice, trade-off, or scope note>
+
+Verified by <go test ./pkg/... / exercised cmd/bos with <config> / browser walk-through of <flow> / proto regenerated and built / ...>.
+
+SCB-NNNN
+```
+
+Keep it short. Reviewers can read the diff. The body's job is to communicate intent, confirm the change was witnessed, and link the ticket.
+
+## Phase 6 — Watch CI and merge state
+
+Watch the PR through to green without polling tightly. Either:
+
+- Stream events via `Monitor` on `gh pr checks <pr> --watch` (event-driven, no polling), or
+- Poll `gh pr checks <pr>` and `gh pr view <pr> --json mergeable,mergeStateStatus`, waiting at least 30 seconds between polls.
+
+sc-bos CI includes Go Test, Go Lint (vet + staticcheck), Go Security, Rego Test, and UI Lint — each only runs when its paths are touched, so expect a subset relevant to your diff.
+
+### On `mergeable: CONFLICTING`
+
+Rebase onto `origin/<base>`, resolve, then push (`--force-with-lease --force-if-includes`) and resume watching.
+
+### On red CI
+
+Identify the failing run, then pull its failed-step logs:
+
+```
+gh run list --branch <branch> --limit 5 --json databaseId,name,conclusion,headSha
+gh run view <run-id> --log-failed
+```
+
+Classify the failure:
+
+- **Mechanical** — lint/format, vet/staticcheck finding, a test broken by a refactor miss, a missing import. The fix is local and obvious.
+- **Behavioural** — a test failed because the *behaviour* is wrong, or the failure is in code you don't recognise. Stop and escalate: failing job name, log snippet, your hypothesis. Don't guess your way through a real bug.
+
+When CI fails and a fix is needed, the fix is in-session work — witness it the same way you'd witness any change: re-run the failing test locally, exercise the affected path. "It compiles" is mechanical confidence, not enough for a behavioural failure. Apply the matching validation, re-run the Phase 2 pre-flight, then push.
+
+### On green CI and no conflicts
+
+Proceed to Phase 7.
+
+## Phase 7 — Mark ready and request review
+
+This repo has **no CODEOWNERS auto-request**, so reviewers must be named explicitly. Do **not** auto-assign anyone or auto-invoke a review skill — **ask the user who should review.**
+
+1. Flip the PR from draft to ready:
+
+   ```
+   gh pr ready <pr>
+   ```
+
+2. **Prompt the user for the reviewer(s).** Ask who they'd like to request review from. To make the choice easy, offer a short list of candidates from recent history rather than a blank prompt:
+
+   ```
+   git log -n 30 --format='%an' -- <top-level dirs the diff touched> | sort | uniq -c | sort -rn
+   gh api repos/smart-core-os/sc-bos/collaborators --jq '.[].login'   # if permitted
+   ```
+
+   Present a few likely names (recent authors in the touched areas) and let the user pick one or more — or type a different GitHub login. Use `AskUserQuestion` if the candidate list maps cleanly onto options; otherwise a plain free-text ask is fine. Don't proceed by guessing.
+
+3. Once the user names the reviewer(s), request them by GitHub login:
+
+   ```
+   gh pr edit <pr> --add-reviewer <login1>,<login2>
+   ```
+
+Then print:
+
+- PR URL
+- Reviewer(s) requested
+
+Suggest the next move:
+
+> CI is green and `<reviewer(s)>` have been requested. When their review lands, run `/read-pr-feedback`.
+
+Do **not** merge the PR. Merging is the user's decision (or a separate step).
+
+## Tone
+
+You are taking the change from "implementation done" to "PR open, validated, CI green, review requested". Be decisive on mechanical fixes; surface confidence gaps honestly rather than papering over them; treat reviewer time as a cost that earned confidence is the price of. The one deliberate pause is choosing reviewers — that's a human call, so ask. When CI fails, the fix is held to the same confidence bar as the original change — a red CI doesn't lower the standard, it just triggers another round of it.

--- a/.claude/skills/raise-pr/scripts/state.sh
+++ b/.claude/skills/raise-pr/scripts/state.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# state.sh — emit a structured snapshot of the branch state for /raise-pr.
+# Usage: scripts/state.sh [base-branch]   default base: main
+#
+# Output is key=value lines (one per metric) followed by a `---` separator and
+# `uncommitted_files:` / `committed_files:` blocks with two-space indented paths.
+# The skill body reads this output instead of issuing several ad-hoc git calls.
+set -eo pipefail
+
+BASE="${1:-main}"
+BRANCH="$(git branch --show-current)"
+
+# Fetch makes ahead/behind accurate; if offline, fall through with stale data
+# and surface that via base_fetch so the caller can decide whether to retry.
+if git fetch --quiet origin "$BASE" 2>/dev/null; then
+  BASE_FETCH="fresh"
+else
+  BASE_FETCH="stale"
+fi
+
+AHEAD="$(git rev-list --count "origin/$BASE..HEAD")"
+BEHIND="$(git rev-list --count "HEAD..origin/$BASE")"
+
+# Uncommitted: tracked changes (staged + unstaged) from porcelain — `ls-files
+# --modified` alone misses staged additions — plus untracked files from
+# `ls-files --others` (which doesn't directory-collapse like porcelain does).
+TRACKED_CHANGES="$(git status --porcelain --untracked-files=no | sed -E 's/^.{2} //' | sed -E 's/.* -> //')"
+UNTRACKED="$(git ls-files --others --exclude-standard)"
+UNCOMMITTED_FILES="$(printf '%s\n%s\n' "$TRACKED_CHANGES" "$UNTRACKED" | grep -v '^$' | sort -u || true)"
+UNCOMMITTED_COUNT="$(printf '%s\n' "$UNCOMMITTED_FILES" | grep -c . || true)"
+
+# Triple-dot: changes from merge-base(origin/BASE, HEAD) to HEAD — i.e. only
+# what this branch added. Double-dot would include changes that landed on BASE.
+COMMITTED_FILES="$(git diff --name-only "origin/$BASE...HEAD")"
+
+ALL_FILES="$(printf '%s\n%s\n' "$COMMITTED_FILES" "$UNCOMMITTED_FILES" | grep -v '^$' | sort -u || true)"
+
+docs_only=true
+has_code=false
+has_proto=false
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    # vendored / installed / build-output dirs are never our change — skip so a
+    # stray file inside them (e.g. an untracked node_modules) can't skew the class.
+    */node_modules/*|node_modules/*|*/vendor/*|vendor/*|*/dist/*|dist/*) continue ;;
+    *.md) ;;
+    .github/*) ;;
+    .claude/*) ;;
+    .gitignore) ;;
+    *.proto)
+      has_code=true; has_proto=true; docs_only=false ;;
+    *.go|*.rego|*.ts|*.tsx|*.vue|*.js|*.jsx|*.mjs|*.cjs)
+      has_code=true; docs_only=false ;;
+    *)
+      docs_only=false ;;
+  esac
+done <<< "$ALL_FILES"
+
+if $docs_only; then
+  CHANGE_CLASS="docs-only"
+elif $has_code; then
+  CHANGE_CLASS="code"
+else
+  CHANGE_CLASS="mixed"
+fi
+
+RECS=""
+REASONS=""
+add_rec() {
+  RECS="${RECS}${RECS:+ }$1"
+  REASONS="${REASONS}${REASONS:+; }$2"
+}
+plural() { [ "$1" -eq 1 ] && echo "" || echo "s"; }
+
+[ "$BRANCH" = "$BASE" ] && add_rec "on-base-branch-stop" "current branch is the base branch"
+[ "$AHEAD" -eq 0 ] && [ "$UNCOMMITTED_COUNT" -eq 0 ] && add_rec "nothing-to-raise-stop" "no commits ahead and no uncommitted work"
+[ "$BEHIND" -gt 0 ] && add_rec "rebase" "behind $BASE by $BEHIND commit$(plural "$BEHIND")"
+[ "$CHANGE_CLASS" = "docs-only" ] && add_rec "skip-build" "diff is docs/config only"
+$has_proto && add_rec "proto-regen" "diff touches .proto files — regenerate before raising"
+
+if [ -z "$RECS" ]; then
+  RECS="none"
+  REASONS="no action needed"
+fi
+
+echo "branch=$BRANCH"
+echo "base=$BASE"
+echo "base_fetch=$BASE_FETCH"
+echo "ahead=$AHEAD"
+echo "behind=$BEHIND"
+echo "uncommitted_count=$UNCOMMITTED_COUNT"
+echo "change_class=$CHANGE_CLASS"
+echo "recommend=$RECS  // $REASONS"
+echo "---"
+echo "uncommitted_files:"
+if [ -n "$UNCOMMITTED_FILES" ]; then
+  printf '%s\n' "$UNCOMMITTED_FILES" | sed 's/^/  /'
+fi
+echo "committed_files:"
+if [ -n "$COMMITTED_FILES" ]; then
+  printf '%s\n' "$COMMITTED_FILES" | sed 's/^/  /'
+fi

--- a/.claude/skills/read-pr-feedback/SKILL.md
+++ b/.claude/skills/read-pr-feedback/SKILL.md
@@ -76,8 +76,8 @@ Skip empty categories silently. If the user declines a whole category (e.g., "sk
 
 ### Applying fixes
 
-- If a fix touches `.proto` files, regenerate the Go/JS afterwards (via WSL — see `.claude/CLAUDE.md`) and include the regenerated output.
-- Keep the change building as you go (`go build ./...`); UI changes should still pass `yarn --cwd ops lint:nofix` (run from `ui/`; on this host see `.claude/CLAUDE.md` for the WSL/node-direct route).
+- If a fix touches `.proto` files, regenerate the Go/JS afterwards (`bash scripts/gen-proto.sh`) and include the regenerated output.
+- Keep the change building as you go (`go build ./...`); UI changes should still pass `yarn --cwd ops lint:nofix` (run from `ui/`).
 
 ### Reply to threads
 
@@ -115,7 +115,7 @@ If any code changes were made, re-run the relevant pre-flight gate (mirrors CI):
 
 ```
 go build ./... && go vet -lostcancel=false ./... && go test ./...
-# for UI changes (run from ui/; see .claude/CLAUDE.md for the host's WSL/node-direct route):
+# for UI changes (run from ui/):
 (cd ui && yarn --cwd ops lint:nofix)
 ```
 

--- a/.claude/skills/read-pr-feedback/SKILL.md
+++ b/.claude/skills/read-pr-feedback/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: read-pr-feedback
+description: Process review feedback on your PR — resolve comments, apply fixes, and reply to reviewers systematically. Use after a reviewer has left comments on a PR you raised (e.g. "read the PR feedback", "address the review comments", "work through the PR review"). Do NOT fire on "raise a PR" (that's /raise-pr) or "review my changes" (that's /code-review).
+argument-hint: [pr-number]
+---
+
+# Process PR feedback $ARGUMENTS
+
+Systematically work through review comments on your PR, resolving each thread by applying fixes, replying to reviewers, or discussing trade-offs. Repo: `github.com/smart-core-os/sc-bos` (use the `gh` CLI).
+
+## Phase 1 — Detect PR
+
+If no PR number argument given, detect from current branch:
+
+```
+gh pr view --json number,title,url
+```
+
+If a PR number is given, use it directly. Confirm the PR exists and show the title.
+
+## Phase 2 — Fetch reviews & comments
+
+Fetch all review data:
+
+```
+gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate
+gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate
+gh api repos/{owner}/{repo}/issues/<number>/comments --paginate
+```
+
+Check thread resolution status via GraphQL (uses this skill's bundled query file to avoid permission prompts):
+
+```
+gh api graphql -F query=@.claude/skills/read-pr-feedback/graphql/review-threads.graphql -F owner=smart-core-os -F repo=sc-bos -F number=NUMBER
+```
+
+The thread `id` (node ID like `PRRT_...`) is used in Phase 6 to resolve threads. The comment `databaseId` is the numeric ID used for `in_reply_to` in REST API replies.
+
+Filter out resolved threads. Note which reviewer authored each comment — this is needed in Phase 6 to determine per-reviewer re-request eligibility.
+
+## Phase 3 — Present summary
+
+Show:
+
+- Number of reviewers with open comments
+- Open comment count per reviewer
+- Review verdicts (approved, changes requested, commented)
+
+## Phase 4 — Triage comments
+
+Read the code at each comment's location and classify every open comment into one of these categories based on what action is needed:
+
+1. **Already addressed** — the current code already fixes the feedback (e.g., from a previous commit). Just needs a reply confirming.
+2. **Observation / no change requested** — the reviewer is flagging context, asking a question, or confirming an intentional choice ("no action needed if intentional", "just flagging for later"). Needs a reply acknowledging the observation; no code change. Do not silently resolve these — a reply closes the loop.
+3. **Straightforward fixes** — the reviewer's suggestion is correct and there is no genuine trade-off to decide. This includes but is not limited to typos, naming, imports, nil checks, added validation, error-wrapping tweaks, small refactors, or test coverage. The test is *"is there a real design choice the author should make?"*, not *"is this smaller than one line?"*.
+4. **Needs author input** — multiple valid approaches or a trade-off the author should decide. Present options.
+5. **Push-back candidates** — the current approach is deliberately chosen and the reviewer's suggestion would regress it or change scope. Flag the concrete reason (not vibes) so the author can decide whether to push back or accept. Pushback is a valid outcome — don't steer away from it when the existing code is right.
+6. **Scope expansion** — addressing the comment would require work in areas the PR *did not already touch*: other packages, other drivers, unrelated concerns, or broad refactoring across untouched files. The test is *surface area*, not *size*. If the PR introduced a package, RPC, proto message, or pattern, then adding a sibling method, filling in a missing field, or completing the surface the PR itself defined is **not** scope expansion — it's finishing the work. Default to tackling it in this PR unless the added work genuinely reaches into unrelated code.
+
+Present the triage as a numbered list per category, with each comment showing: reviewer, file:line, and a one-line summary of the feedback.
+
+If all comments fall into categories 1–3 (already addressed, observations, and straightforward fixes), skip confirmation and proceed directly — there are no decisions for the user to make. Otherwise, wait for the user to confirm or adjust the categorisation before proceeding.
+
+## Phase 5 — Process categories
+
+Work through the categories in the order listed above. For each category, ask the user for a batch decision before proceeding:
+
+- **Already addressed** — reply to these confirming they're fixed. No user confirmation needed.
+- **Observation / no change requested** — reply acknowledging. If the observation flagged an intentional choice, state the rationale in one line. No user confirmation needed.
+- **Straightforward fixes** — apply all changes and show a summary of what was done. No user confirmation needed.
+- **Needs author input** — present each comment (or sub-group of related comments) with the options and trade-offs. Wait for the user's choice, then apply.
+- **Push-back candidates** — for each, state the concrete reason the current approach is right (e.g. "scope is intentional — tracked in SCB-XXX", "the previous semantics were the bug"). Ask whether to push back or accept.
+- **Scope expansion** — for each, state which untouched areas the work reaches into and why that makes it out-of-scope. If the work stays inside the surface the PR introduced or modified, reclassify as *Straightforward fixes* or *Needs author input* instead of deferring. Ask whether to tackle it in this PR, defer with a follow-up ticket, or push back.
+
+Skip empty categories silently. If the user declines a whole category (e.g., "skip the scope expansion ones"), mark those comments as deferred.
+
+### Applying fixes
+
+- If a fix touches `.proto` files, regenerate the Go/JS afterwards (via WSL — see `.claude/CLAUDE.md`) and include the regenerated output.
+- Keep the change building as you go (`go build ./...`); UI changes should still pass `yarn --cwd ops lint:nofix` (run from `ui/`; on this host see `.claude/CLAUDE.md` for the WSL/node-direct route).
+
+### Reply to threads
+
+After each category is processed, reply to the threads in that category.
+
+**For code-level review comments** (comments attached to a file/line in the diff), reply inline using `in_reply_to` so the response appears in the same thread:
+
+```
+gh api repos/{owner}/{repo}/pulls/<number>/comments -f body="Reply text" -F in_reply_to=COMMENT_ID
+```
+
+The `COMMENT_ID` is the `id` of the review comment being replied to (from the `/pulls/<number>/comments` endpoint, not the `/issues/<number>/comments` endpoint).
+
+**For general PR-level comments** (comments on the PR description, not attached to code), reply as an issue comment:
+
+```
+gh api repos/{owner}/{repo}/issues/<number>/comments -f body="Reply text"
+```
+
+Keep replies concise: what was done (with commit ref if applicable), or why the current approach is preferred.
+
+## Phase 5b — Integration pass
+
+Before wrapping up, re-read each file you changed **cold** — the whole region, not just the changed lines — and integrate the fixes so they read as if always part of the code, not bolted on in response to comments. The diff and your thread replies are the trace; the code itself must not narrate that it was revised (no "changed to address review" comments, no awkward seams around the edit). For a substantial or prose-heavy round a self-read won't catch this reliably — you carry the same focus that produced the bolt-on — so run the check through a fresh context (`/code-review`, or a `code-reviewer` subagent) instead.
+
+## Phase 6 — Wrap up
+
+Summarise:
+
+- Comments addressed with code changes
+- Comments replied to without code changes
+- Comments deferred or skipped
+
+If any code changes were made, re-run the relevant pre-flight gate (mirrors CI):
+
+```
+go build ./... && go vet -lostcancel=false ./... && go test ./...
+# for UI changes (run from ui/; see .claude/CLAUDE.md for the host's WSL/node-direct route):
+(cd ui && yarn --cwd ops lint:nofix)
+```
+
+Report results. If everything passes, offer to commit the changes. Follow the repo's commit convention — `<area>: <summary>` with the ticket in parens when applicable, e.g.:
+
+```
+<area>: address review feedback (SCB-NNNN)
+```
+
+List the specific items addressed in the commit body.
+
+### Refresh the PR description
+
+Before resolving threads, check whether the changes invalidate anything in the PR description. The diff and inline replies tell most of the story, but reviewers read the description to find context that isn't in the code — and a stale description sends them down wrong paths.
+
+Re-fetch the description with `gh pr view <number> --json body --jq .body` and scan for any of these signals:
+
+- **New manual setup steps surfaced by feedback.** A "you also need to..." piece of config that lives outside the diff: a node config key, an env var, a driver setting, a one-time command. If the reviewer flagged it and the fix accepts the addition, the description needs the step.
+- **Architecture or scope claims now wrong.** The description's "what changes" / "out of scope" notes sometimes describe choices the review revised. A defaulting change, a moved boundary, a renamed file or extracted helper: surface it.
+- **Verification line invalidated.** A step that references a behaviour the fix removed, or a flow that now needs additional verification.
+- **Sequencing or blocker notes the author wants surfaced.** If a fix turns out to depend on another PR landing first, add a callout at the top of the description.
+
+Update the description with `gh pr edit <number> --body-file <file>`. Bundle changes into one edit rather than several. If you're unsure whether a tweak rises to "needs updating", err on the side of asking the user — small adds are fine, but rewriting a section the author wrote deliberately is a different decision.
+
+If nothing in the description needs to change, say so explicitly and move on. Don't edit it just to feel busy.
+
+### Resolve addressed threads
+
+After committing (or if no code changes were needed) and the PR description is current, resolve threads that have been fully addressed:
+
+```
+gh api graphql -F query=@.claude/skills/read-pr-feedback/graphql/resolve-thread.graphql -f threadId=THREAD_NODE_ID
+```
+
+Thread node IDs come from the GraphQL query in Phase 2. Only resolve threads where:
+
+- A code change was made that addresses the feedback, or
+- The reply explains why no change is needed and the user approved the response
+
+Do **not** resolve threads that were deferred or skipped.
+
+### Re-request reviews
+
+For each reviewer, check whether **all** of their open comments were addressed (by code change or approved reply). Re-request review from a reviewer when:
+
+- **All** of their comments were addressed — none deferred or skipped
+- Their most recent verdict was **"changes requested"** or **"commented"**
+
+Treat a `"commented"` verdict the same as `"changes requested"` — if the PR needs an explicit approval to merge, a bare comment blocks it just as much, so re-request the reviewer once their feedback is addressed.
+
+Do not re-request review when:
+
+- Any of the reviewer's threads were deferred or skipped
+- The reviewer already **approved** and the changes made were trivial — e.g. typos, formatting, or directly applying the reviewer's own one-line suggestion. If the changes were substantive (even if the reviewer approved), re-request so they can re-verify.
+
+```
+gh pr edit <number> --add-reviewer <login1>,<login2>
+```
+
+This repo has no CODEOWNERS auto-request, so the reviewers are whoever was requested when the PR was raised (see `/raise-pr` Phase 7). If it's unclear who should re-review, ask the user rather than guessing.

--- a/.claude/skills/read-pr-feedback/graphql/resolve-thread.graphql
+++ b/.claude/skills/read-pr-feedback/graphql/resolve-thread.graphql
@@ -1,0 +1,5 @@
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { isResolved }
+  }
+}

--- a/.claude/skills/read-pr-feedback/graphql/review-threads.graphql
+++ b/.claude/skills/read-pr-feedback/graphql/review-threads.graphql
@@ -1,0 +1,23 @@
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 10) {
+            nodes {
+              id
+              databaseId
+              body
+              path
+              line
+              author { login }
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ podman-build-secret*
 .bin
 demo/vanti-ugs/.env
 
+# Node dependencies (e.g. scripts/ proto-gen tooling)
+node_modules/
+
 # sccexporter local demo artifacts (throwaway certs, broker config, generated DBO)
 example/config/vanti-ugs/scc-certs/
 /mosquitto.conf

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ demo/vanti-ugs/.env
 # Node dependencies (e.g. scripts/ proto-gen tooling)
 node_modules/
 
+# Throwaway scratch dir (e.g. raise-pr / read-pr-feedback skill bodies)
+.tmp/
+
 # sccexporter local demo artifacts (throwaway certs, broker config, generated DBO)
 example/config/vanti-ugs/scc-certs/
 /mosquitto.conf


### PR DESCRIPTION
Adds three Claude Code skills for the ticket → PR workflow, adapted from our smart-core-connect set for this repo:

- **`grab-ticket`** — work an SCB YouTrack ticket end-to-end: fetch + claim (assign / In Progress via the YouTrack MCP), verify the situation against the actual code (not the ticket body), agree an approach, implement, validate against the sc-bos gates, hand off.
- **`raise-pr`** — take a branch to an open, CI-green PR. Runs the build/test/lint gate that mirrors our CI, commits with the `area: summary (SCB-NNNN)` convention, pushes, opens a draft, watches CI, then **prompts for a reviewer** (this repo has no CODEOWNERS auto-request) — it deliberately does not auto-assign.
- **`read-pr-feedback`** — work through review comments systematically (triage, fix, reply, resolve threads, re-request). Bundles its own GraphQL queries so it's self-contained.

Also ignores `node_modules/` (the `scripts/` proto-gen tooling was showing up untracked) and `.tmp/` (the scratch dir the skills write PR bodies to).

Notes for reviewers:
- sc-bos adaptations vs the SCC originals: SCB YouTrack via MCP, Go + ops-UI (`ui/`-rooted `yarn --cwd ops lint:nofix`) gates, and the reviewer-prompt behaviour in `raise-pr`.
- `raise-pr/scripts/state.sh` is a branch-state snapshot helper (treats `.go/.proto/.rego/.vue/.js` as code, ignores vendor dirs).
- Machine-specific host caveats (WSL-installed `ui/node_modules`, etc.) live in `.claude/CLAUDE.md`, which is intentionally git-excluded, so they're not part of this PR.

These were each dry-run on real tickets before raising (SCB-1386, SCB-1387).
