### PR TITLE
lightingtest: deprecate LightingTestApi in favour of EmergencyLightApi (SCB-1391)

### DIFF
--- a/pkg/proto/lightingtestpb/lighting_test.pb.go
+++ b/pkg/proto/lightingtestpb/lighting_test.pb.go
@@ -439,7 +439,7 @@ func (x *ListLightHealthResponse) GetNextPageToken() string {
 type ListLightEventsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	PageSize      int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
-	PageToken     string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"` // TODO: add filtering support
+	PageToken     string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -823,12 +823,12 @@ const file_smartcore_bos_lightingtest_v1_lighting_test_proto_rawDesc = "" +
 	"\n" +
 	"LAMP_FAULT\x10\x04\x12\x19\n" +
 	"\x15COMMUNICATION_FAILURE\x10\x05\x12\x0f\n" +
-	"\vOTHER_FAULT\x10\x062\xf9\x03\n" +
+	"\vOTHER_FAULT\x10\x062\xfe\x03\n" +
 	"\x0fLightingTestApi\x12r\n" +
 	"\x0eGetLightHealth\x124.smartcore.bos.lightingtest.v1.GetLightHealthRequest\x1a*.smartcore.bos.lightingtest.v1.LightHealth\x12\x80\x01\n" +
 	"\x0fListLightHealth\x125.smartcore.bos.lightingtest.v1.ListLightHealthRequest\x1a6.smartcore.bos.lightingtest.v1.ListLightHealthResponse\x12\x80\x01\n" +
 	"\x0fListLightEvents\x125.smartcore.bos.lightingtest.v1.ListLightEventsRequest\x1a6.smartcore.bos.lightingtest.v1.ListLightEventsResponse\x12l\n" +
-	"\fGetReportCSV\x122.smartcore.bos.lightingtest.v1.GetReportCSVRequest\x1a(.smartcore.bos.lightingtest.v1.ReportCSVB:Z8github.com/smart-core-os/sc-bos/pkg/proto/lightingtestpbb\x06proto3"
+	"\fGetReportCSV\x122.smartcore.bos.lightingtest.v1.GetReportCSVRequest\x1a(.smartcore.bos.lightingtest.v1.ReportCSV\x1a\x03\x88\x02\x01B:Z8github.com/smart-core-os/sc-bos/pkg/proto/lightingtestpbb\x06proto3"
 
 var (
 	file_smartcore_bos_lightingtest_v1_lighting_test_proto_rawDescOnce sync.Once

--- a/pkg/proto/lightingtestpb/lighting_test_grpc.pb.go
+++ b/pkg/proto/lightingtestpb/lighting_test_grpc.pb.go
@@ -28,6 +28,11 @@ const (
 // LightingTestApiClient is the client API for LightingTestApi service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// Deprecated: LightingTestApi is deprecated; implement EmergencyLightApi instead.
+// It will be removed once downstream projects have migrated. See SCB-1391.
+//
+// Deprecated: Do not use.
 type LightingTestApiClient interface {
 	GetLightHealth(ctx context.Context, in *GetLightHealthRequest, opts ...grpc.CallOption) (*LightHealth, error)
 	ListLightHealth(ctx context.Context, in *ListLightHealthRequest, opts ...grpc.CallOption) (*ListLightHealthResponse, error)
@@ -39,6 +44,7 @@ type lightingTestApiClient struct {
 	cc grpc.ClientConnInterface
 }
 
+// Deprecated: Do not use.
 func NewLightingTestApiClient(cc grpc.ClientConnInterface) LightingTestApiClient {
 	return &lightingTestApiClient{cc}
 }
@@ -86,6 +92,11 @@ func (c *lightingTestApiClient) GetReportCSV(ctx context.Context, in *GetReportC
 // LightingTestApiServer is the server API for LightingTestApi service.
 // All implementations must embed UnimplementedLightingTestApiServer
 // for forward compatibility.
+//
+// Deprecated: LightingTestApi is deprecated; implement EmergencyLightApi instead.
+// It will be removed once downstream projects have migrated. See SCB-1391.
+//
+// Deprecated: Do not use.
 type LightingTestApiServer interface {
 	GetLightHealth(context.Context, *GetLightHealthRequest) (*LightHealth, error)
 	ListLightHealth(context.Context, *ListLightHealthRequest) (*ListLightHealthResponse, error)
@@ -123,6 +134,7 @@ type UnsafeLightingTestApiServer interface {
 	mustEmbedUnimplementedLightingTestApiServer()
 }
 
+// Deprecated: Do not use.
 func RegisterLightingTestApiServer(s grpc.ServiceRegistrar, srv LightingTestApiServer) {
 	// If the following call pancis, it indicates UnimplementedLightingTestApiServer was
 	// embedded by pointer and is nil.  This will cause panics if an

--- a/proto/smartcore/bos/lightingtest/v1/lighting_test.proto
+++ b/proto/smartcore/bos/lightingtest/v1/lighting_test.proto
@@ -7,7 +7,11 @@ option go_package = "github.com/smart-core-os/sc-bos/pkg/proto/lightingtestpb";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
+// Deprecated: LightingTestApi is deprecated; implement EmergencyLightApi instead.
+// It will be removed once downstream projects have migrated. See SCB-1391.
 service LightingTestApi {
+  option deprecated = true;
+
   rpc GetLightHealth(GetLightHealthRequest) returns (LightHealth);
   rpc ListLightHealth(ListLightHealthRequest) returns (ListLightHealthResponse);
 
@@ -83,7 +87,6 @@ message ListLightHealthResponse {
 message ListLightEventsRequest {
   int32 page_size = 1;
   string page_token = 2;
-  // TODO: add filtering support
 }
 message ListLightEventsResponse {
   repeated LightingEvent events = 1;


### PR DESCRIPTION
`LightingTestApi` (`smartcore.bos.lightingtest.v1`) is being retired in favour of the live `EmergencyLightApi` trait. It isn't wired into any sc-bos node — its only implementation is a pass-through `Holder` proxy that is never filled, it's absent from the trait registry, and `ListLightEvents` has no in-repo producer or consumer.

This marks the service deprecated (`option deprecated = true`) so the generated Go carries `// Deprecated:` markers, signalling downstream projects to implement `EmergencyLightApi` instead. The service itself will be removed in a follow-up once downstream projects have migrated (tracked in SCB-1391). Also removes the now-moot `// TODO: add filtering support` on `ListLightEventsRequest` — filtering won't be added to a deprecated API (SCB-1388, closed won't-fix).

Verified by regenerating via the WSL protoc toolchain and `go build ./...` / `go vet` / `staticcheck ./pkg/proto/lightingtestpb/...` (no deprecated-usage warnings, since nothing in-repo consumes the API).

SCB-1391
