### PR TITLE
ui/ops: add issue-type filter to health dashboard (SCB-1377)

### DIFF
--- a/internal/manage/devices/query_test.go
+++ b/internal/manage/devices/query_test.go
@@ -1019,3 +1019,88 @@ func Example_anyOfMatchesAbnormalOrUnreliable() {
 	//   Device02 matches: true
 	//   Device03 matches: true
 }
+
+// Example_issueTypeFilters documents the health dashboard's "Issue Type" filter
+// (SCB-1377). Each option narrows to one kind of issue on a single health check
+// using a nested `matches` condition, so the sub-conditions apply to the same
+// check. Only present / string_in / matches matchers are used so the JS query
+// converter (ui/ops/src/api/ui/devices.js) can build them without change.
+func Example_issueTypeFilters() {
+	present := func(field string) *devicespb.Device_Query_Condition {
+		return &devicespb.Device_Query_Condition{Field: field, Value: &devicespb.Device_Query_Condition_Present{Present: &emptypb.Empty{}}}
+	}
+	stringIn := func(field string, ss ...string) *devicespb.Device_Query_Condition {
+		return &devicespb.Device_Query_Condition{Field: field, Value: &devicespb.Device_Query_Condition_StringIn{StringIn: &devicespb.Device_Query_StringList{Strings: ss}}}
+	}
+	// matchesCheck matches when any single health check satisfies all of conds.
+	matchesCheck := func(conds ...*devicespb.Device_Query_Condition) *devicespb.Device_Query {
+		return &devicespb.Device_Query{Conditions: []*devicespb.Device_Query_Condition{{
+			Field: "health_checks",
+			Value: &devicespb.Device_Query_Condition_Matches{Matches: &devicespb.Device_Query{Conditions: conds}},
+		}}}
+	}
+	abnormal := []string{"ABNORMAL", "HIGH", "LOW"}
+	commsFailures := []string{"UNRELIABLE", "CONN_TRANSIENT_FAILURE", "SEND_FAILURE", "NO_RESPONSE", "BAD_RESPONSE", "NOT_FOUND", "PERMISSION_DENIED"}
+
+	connectivity := matchesCheck(stringIn("reliability.state", commsFailures...))
+	outOfRange := matchesCheck(present("bounds"), stringIn("normality", abnormal...))
+	fault := matchesCheck(present("faults"), stringIn("normality", abnormal...))
+
+	// A healthy device: reliable, in range, no faults.
+	healthy := &devicespb.Device{Name: "Healthy", HealthChecks: []*healthpb.HealthCheck{
+		{Id: "Online", Normality: healthpb.HealthCheck_NORMAL, Reliability: &healthpb.HealthCheck_Reliability{State: healthpb.HealthCheck_Reliability_RELIABLE}},
+		{Id: "Temperature", Normality: healthpb.HealthCheck_NORMAL, Check: &healthpb.HealthCheck_Bounds_{Bounds: &healthpb.HealthCheck_Bounds{DisplayUnit: "°C"}}},
+	}}
+	// A bounds check reading out of range.
+	rangeDev := &devicespb.Device{Name: "Range", HealthChecks: []*healthpb.HealthCheck{
+		{Id: "Temperature", Normality: healthpb.HealthCheck_HIGH, Check: &healthpb.HealthCheck_Bounds_{Bounds: &healthpb.HealthCheck_Bounds{DisplayUnit: "°C"}}},
+	}}
+	// A faults check reporting a current fault (always ABNORMAL per health.proto).
+	faultDev := &devicespb.Device{Name: "Fault", HealthChecks: []*healthpb.HealthCheck{
+		{Id: "Alarms", Normality: healthpb.HealthCheck_ABNORMAL, Check: &healthpb.HealthCheck_Faults_{Faults: &healthpb.HealthCheck_Faults{CurrentFaults: []*healthpb.HealthCheck_Error{{SummaryText: "door stuck"}}}}},
+	}}
+	// Normality is NORMAL, but we can't talk to the device - a comms-only issue.
+	commsDev := &devicespb.Device{Name: "Comms", HealthChecks: []*healthpb.HealthCheck{
+		{Id: "Online", Normality: healthpb.HealthCheck_NORMAL, Reliability: &healthpb.HealthCheck_Reliability{State: healthpb.HealthCheck_Reliability_NO_RESPONSE}},
+	}}
+	// A faults check that currently reports no faults - not an issue, and the
+	// normality clause is what keeps it out of the Fault results.
+	emptyFaultDev := &devicespb.Device{Name: "EmptyFault", HealthChecks: []*healthpb.HealthCheck{
+		{Id: "Alarms", Normality: healthpb.HealthCheck_NORMAL, Check: &healthpb.HealthCheck_Faults_{Faults: &healthpb.HealthCheck_Faults{}}},
+	}}
+
+	devices := []*devicespb.Device{healthy, rangeDev, faultDev, commsDev, emptyFaultDev}
+	for _, tc := range []struct {
+		name  string
+		query *devicespb.Device_Query
+	}{
+		{"Connectivity", connectivity},
+		{"Out of range", outOfRange},
+		{"Fault", fault},
+	} {
+		fmt.Printf("%s:\n", tc.name)
+		for _, device := range devices {
+			fmt.Printf("  %s matches: %v\n", device.Name, deviceMatchesQuery(tc.query, device))
+		}
+	}
+
+	// Output:
+	// Connectivity:
+	//   Healthy matches: false
+	//   Range matches: false
+	//   Fault matches: false
+	//   Comms matches: true
+	//   EmptyFault matches: false
+	// Out of range:
+	//   Healthy matches: false
+	//   Range matches: true
+	//   Fault matches: false
+	//   Comms matches: false
+	//   EmptyFault matches: false
+	// Fault:
+	//   Healthy matches: false
+	//   Range matches: false
+	//   Fault matches: true
+	//   Comms matches: false
+	//   EmptyFault matches: false
+}

--- a/ui/ops/src/traits/health/HealthCheckTable.vue
+++ b/ui/ops/src/traits/health/HealthCheckTable.vue
@@ -92,7 +92,7 @@ import MdText from '@/components/MdText.vue';
 import {useDevices} from '@/composables/devices.js';
 import {useDataTableCollection} from '@/composables/table.js';
 import CheckCountCell from '@/traits/health/CheckCountCell.vue';
-import {countChecks, useHealthCheckFilters} from '@/traits/health/health';
+import {ABNORMAL_NORMALITY_STATES, countChecks, RELIABILITY_FAILURE_STATES, useHealthCheckFilters} from '@/traits/health/health';
 import HealthCheckEnrichedRows from '@/traits/health/HealthCheckEnrichedRows.vue';
 import NormalityLastChangeCell from '@/traits/health/NormalityLastChangeCell.vue';
 import ReliabilityLastChangeCell from '@/traits/health/ReliabilityLastChangeCell.vue';
@@ -102,8 +102,18 @@ import {computed, ref} from 'vue';
 const props = defineProps({
   conditions: {
     type: Array, // of Device.Query.Condition.AsObject
+    // Default to devices that are unhealthy in either dimension: an abnormal check
+    // OR a comms/reliability failure. Normality and reliability are independent
+    // (a device we can't talk to can still read NORMAL), so any_of ORs them so
+    // comms-only issues surface by default. See SCB-1381 for the any_of primitive.
     default: () => ([
-      {'field': 'health_checks.normality', 'stringIn': {'stringsList': ['ABNORMAL', 'HIGH', 'LOW']}}
+      {
+        field: 'health_checks',
+        anyOf: {queriesList: [
+          {conditionsList: [{field: 'normality', stringIn: {stringsList: ABNORMAL_NORMALITY_STATES}}]},
+          {conditionsList: [{field: 'reliability.state', stringIn: {stringsList: RELIABILITY_FAILURE_STATES}}]}
+        ]}
+      }
     ])
   }
 });

--- a/ui/ops/src/traits/health/health.js
+++ b/ui/ops/src/traits/health/health.js
@@ -14,6 +14,25 @@ const NO_ZONE = '< no zone >';
 const NO_SUBSYSTEM = '< no subsystem >';
 
 /**
+ * Normality enum names that indicate an abnormal (unhealthy) check.
+ * Any Normality greater than NORMAL is abnormal; see health.proto.
+ *
+ * @type {string[]}
+ */
+export const ABNORMAL_NORMALITY_STATES = ['ABNORMAL', 'HIGH', 'LOW'];
+
+/**
+ * Reliability.State enum names that indicate a connectivity (comms) issue.
+ * Everything except STATE_UNSPECIFIED (not reported) and RELIABLE (healthy).
+ *
+ * @type {string[]}
+ */
+export const RELIABILITY_FAILURE_STATES = [
+  'UNRELIABLE', 'CONN_TRANSIENT_FAILURE', 'SEND_FAILURE',
+  'NO_RESPONSE', 'BAD_RESPONSE', 'NOT_FOUND', 'PERMISSION_DENIED'
+];
+
+/**
  * Convert a protobuf enum numeric value to its string name.
  *
  * @param {Object} enumObj - The enum object (e.g., HealthCheck.OccupantImpact)
@@ -216,6 +235,20 @@ export function useHealthCheckFilters(forcedFilters) {
       }
     }
 
+    if (!Object.hasOwn(forced, 'health_checks.issue_type')) {
+      filters.push({
+        key: 'health_checks.issue_type',
+        icon: 'mdi-alert-outline',
+        title: 'Issue Type',
+        type: 'list',
+        items: [
+          {title: 'Connectivity', value: 'connectivity'},
+          {title: 'Out of range', value: 'range'},
+          {title: 'Fault', value: 'fault'}
+        ]
+      });
+    }
+
     if (!Object.hasOwn(forced, 'health_checks.occupant_impact')) {
       filters.push({
         key: 'health_checks.occupant_impact',
@@ -261,6 +294,43 @@ export function useHealthCheckFilters(forcedFilters) {
         return {field: 'metadata.location.zone', stringEqualFold: value === NO_ZONE ? '' : value};
       case 'metadata.membership.subsystem':
         return {field: 'metadata.membership.subsystem', stringEqualFold: value === NO_SUBSYSTEM ? '' : value};
+      case 'health_checks.issue_type': {
+        // Each option narrows to a single kind of issue on a single health check.
+        // A nested `matches` (matcher ANY) applies the sub-conditions to the same
+        // check, so e.g. "Fault" means the same check both is a faults check and is
+        // currently abnormal. Only converter-supported matchers are used here
+        // (present / string_in / matches); see ui/api/ui/devices.js.
+        const token = value?.value ?? value;
+        switch (token) {
+          case 'connectivity':
+            return {
+              field: 'health_checks',
+              matches: {conditionsList: [
+                {field: 'reliability.state', stringIn: {stringsList: RELIABILITY_FAILURE_STATES}}
+              ]}
+            };
+          case 'range':
+            return {
+              field: 'health_checks',
+              matches: {conditionsList: [
+                {field: 'bounds', present: {}},
+                {field: 'normality', stringIn: {stringsList: ABNORMAL_NORMALITY_STATES}}
+              ]}
+            };
+          case 'fault':
+            // Faults present always implies ABNORMAL (health.proto), so the normality
+            // clause simply excludes a faults check whose fault list is currently empty.
+            return {
+              field: 'health_checks',
+              matches: {conditionsList: [
+                {field: 'faults', present: {}},
+                {field: 'normality', stringIn: {stringsList: ABNORMAL_NORMALITY_STATES}}
+              ]}
+            };
+          default:
+            return null;
+        }
+      }
       case 'health_checks.occupant_impact': {
         const numVal = value?.value ?? value;
         const enumName = enumValueToName(HealthCheck.OccupantImpact, numVal);

--- a/ui/ops/src/traits/health/impactBreakdown.js
+++ b/ui/ops/src/traits/health/impactBreakdown.js
@@ -1,4 +1,5 @@
 import {usePullDevicesMetadata} from '@/composables/devices.js';
+import {ABNORMAL_NORMALITY_STATES} from '@/traits/health/health.js';
 import {useRollingHistory} from '@/traits/health/rollingHistory.js';
 import {computed, toValue} from 'vue';
 
@@ -121,7 +122,7 @@ function useImpactTable(conditions, opts) {
             // devices with health checks that are both abnormal and have the specified impact
             field: 'health_checks', matches: {
               conditionsList: [
-                {field: 'normality', stringIn: {stringsList: ['ABNORMAL', 'HIGH', 'LOW']}},
+                {field: 'normality', stringIn: {stringsList: ABNORMAL_NORMALITY_STATES}},
                 {field: opts.impactField, stringIn: {stringsList: opts.fields.map(f => f.key)}}
               ]
             }


### PR DESCRIPTION
Operators reported that the health dashboard (`health/HealthCheckTable`) is hard to triage: it lumps every kind of problem together, and — because normality and reliability are independent dimensions — devices we simply can't reach (reliable-looking checks, no comms) were missed entirely by the normality-only default filter.

This adds an **Issue Type** filter (Connectivity / Out of range / Fault) so operators can narrow to one kind of issue, and broadens the dashboard's default condition to an `any_of` (abnormal **OR** unreliable) so comms-only devices surface by default. Each issue-type option maps to a nested `matches` condition on a single health check, using only matchers the JS query converter already supports (`present` / `string_in` / `matches`), so no converter change was needed — the Fault case leans on `health.proto`'s guarantee that a present fault is always ABNORMAL rather than needing `string_not_equal`. Depends on the `any_of` primitive added in SCB-1381. The abnormal and reliability-failure state lists are now shared exports, reused by `impactBreakdown`.

Note: the "Issue Count" column still counts by normality only, so a comms-only device can appear with a 0 count — left as intended here and tracked separately in SCB-1394.

Verified by `go test ./internal/manage/devices/` — a new `Example_issueTypeFilters` proves each filter and the broadened default select exactly the intended devices against the query engine — plus `go build`/`go vet ./...` and `yarn --cwd ops lint:nofix`. The ops UI was not driven live (no backend in this environment); the condition semantics are covered by the Go example test instead.

#SCB-1377 State Done
