### PR TITLE
auto: validate configured trait against the anytrait registry (SCB-1385)

### DIFF
--- a/pkg/auto/healthbounds/config/root.go
+++ b/pkg/auto/healthbounds/config/root.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/smart-core-os/sc-bos/internal/protobuf/protopath2"
 	"github.com/smart-core-os/sc-bos/pkg/auto"
+	"github.com/smart-core-os/sc-bos/pkg/auto/internal/anytrait"
 	"github.com/smart-core-os/sc-bos/pkg/proto/devicespb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
 	"github.com/smart-core-os/sc-bos/pkg/trait"
@@ -82,7 +83,8 @@ func (h *HealthCheck) MarshalJSON() ([]byte, error) {
 // Source configures which property of a device is checked by a health check.
 type Source struct {
 	// Trait is the fully qualified name of a trait implemented by monitored devices.
-	// TODO: Only some traits are supported, see internal/anytrait/registry.go for the list of supported traits.
+	// The trait must be registered in the shared trait registry (pkg/auto/internal/anytrait);
+	// unsupported traits are rejected at config-load time by Validate.
 	Trait    trait.Name `json:"trait"`
 	Resource Resource   `json:"resource,omitempty"`
 	Value    Value      `json:"value,omitempty"`
@@ -131,7 +133,25 @@ func Read(data []byte) (Root, error) {
 	if err != nil {
 		return Root{}, err
 	}
+	if err := Validate(&cfg); err != nil {
+		return Root{}, err
+	}
 	return cfg, err
+}
+
+// Validate checks that the config is internally consistent.
+// Path validity against the trait resource is checked later, once the trait is resolved.
+func Validate(cfg *Root) error {
+	if cfg == nil {
+		return fmt.Errorf("config is nil")
+	}
+	if cfg.Source.Trait == "" {
+		return fmt.Errorf("source.trait is required")
+	}
+	if err := anytrait.Validate(cfg.Source.Trait); err != nil {
+		return fmt.Errorf("source.trait: %w", err)
+	}
+	return nil
 }
 
 // Hydrate fills in additional details in the config that are not specified directly in JSON.

--- a/pkg/auto/healthbounds/config/validate_test.go
+++ b/pkg/auto/healthbounds/config/validate_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidate_Trait(t *testing.T) {
+	base := `{
+		"type": "healthbounds",
+		"name": "fcu",
+		"source": {%s}
+	}`
+
+	tests := []struct {
+		name      string
+		source    string
+		wantError bool
+	}{
+		{name: "supported trait", source: `"trait": "smartcore.traits.AirTemperature"`, wantError: false},
+		{name: "missing trait", source: `"resource": "AirTemperature"`, wantError: true},
+		{name: "empty trait", source: `"trait": ""`, wantError: true},
+		{name: "unsupported trait", source: `"trait": "smartcore.traits.NotATrait"`, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := []byte(strings.Replace(base, "%s", tt.source, 1))
+			_, err := Read(cfg)
+			if tt.wantError && err == nil {
+				t.Errorf("Read() expected error, got nil")
+			}
+			if !tt.wantError && err != nil {
+				t.Errorf("Read() unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/auto/internal/anytrait/registry.go
+++ b/pkg/auto/internal/anytrait/registry.go
@@ -3,6 +3,9 @@ package anytrait
 import (
 	"context"
 	"errors"
+	"fmt"
+	"slices"
+	"strings"
 	"sync"
 
 	"google.golang.org/grpc"
@@ -32,6 +35,16 @@ func (r *Resolver) FindByName(name trait.Name) (Trait, error) {
 		return Trait{}, ErrNotFound
 	}
 	return t, nil
+}
+
+// Names returns the sorted list of trait names known to the resolver.
+func (r *Resolver) Names() []trait.Name {
+	names := make([]trait.Name, 0, len(r.byName))
+	for name := range r.byName {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
 }
 
 func (r *Resolver) add(name trait.Name, resources ...Resource) {
@@ -98,6 +111,26 @@ var (
 func FindByName(name trait.Name) (Trait, error) {
 	initKnownTraits()
 	return knownTraits.FindByName(name)
+}
+
+// Names returns the sorted list of trait names supported by the registry.
+func Names() []trait.Name {
+	initKnownTraits()
+	return knownTraits.Names()
+}
+
+// Validate returns a descriptive error if name is not a trait supported by the registry.
+// The error lists the supported trait names.
+func Validate(name trait.Name) error {
+	if _, err := FindByName(name); err != nil {
+		names := Names()
+		supported := make([]string, 0, len(names))
+		for _, n := range names {
+			supported = append(supported, string(n))
+		}
+		return fmt.Errorf("%q is not a supported trait; supported traits are: %s", name, strings.Join(supported, ", "))
+	}
+	return nil
 }
 
 // reqPT forces the implementation of proto.Message to also have a pointer receiver.

--- a/pkg/auto/internal/anytrait/registry.go
+++ b/pkg/auto/internal/anytrait/registry.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
-	"strings"
 	"sync"
 
 	"google.golang.org/grpc"
@@ -35,16 +33,6 @@ func (r *Resolver) FindByName(name trait.Name) (Trait, error) {
 		return Trait{}, ErrNotFound
 	}
 	return t, nil
-}
-
-// Names returns the sorted list of trait names known to the resolver.
-func (r *Resolver) Names() []trait.Name {
-	names := make([]trait.Name, 0, len(r.byName))
-	for name := range r.byName {
-		names = append(names, name)
-	}
-	slices.Sort(names)
-	return names
 }
 
 func (r *Resolver) add(name trait.Name, resources ...Resource) {
@@ -113,22 +101,10 @@ func FindByName(name trait.Name) (Trait, error) {
 	return knownTraits.FindByName(name)
 }
 
-// Names returns the sorted list of trait names supported by the registry.
-func Names() []trait.Name {
-	initKnownTraits()
-	return knownTraits.Names()
-}
-
-// Validate returns a descriptive error if name is not a trait supported by the registry.
-// The error lists the supported trait names.
+// Validate returns an error if name is not a trait supported by the registry.
 func Validate(name trait.Name) error {
 	if _, err := FindByName(name); err != nil {
-		names := Names()
-		supported := make([]string, 0, len(names))
-		for _, n := range names {
-			supported = append(supported, string(n))
-		}
-		return fmt.Errorf("%q is not a supported trait; supported traits are: %s", name, strings.Join(supported, ", "))
+		return fmt.Errorf("%q is not a supported trait", name)
 	}
 	return nil
 }

--- a/pkg/auto/internal/anytrait/registry_test.go
+++ b/pkg/auto/internal/anytrait/registry_test.go
@@ -1,0 +1,43 @@
+package anytrait
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/smart-core-os/sc-bos/pkg/trait"
+)
+
+func TestNames(t *testing.T) {
+	names := Names()
+	if len(names) == 0 {
+		t.Fatal("Names() returned no traits")
+	}
+	if !slices.IsSorted(names) {
+		t.Errorf("Names() not sorted: %v", names)
+	}
+	if !slices.Contains(names, trait.AirTemperature) {
+		t.Errorf("Names() missing AirTemperature: %v", names)
+	}
+	// Every name reported must resolve.
+	for _, n := range names {
+		if _, err := FindByName(n); err != nil {
+			t.Errorf("FindByName(%q) failed for a name from Names(): %v", n, err)
+		}
+	}
+}
+
+func TestValidate(t *testing.T) {
+	if err := Validate(trait.AirTemperature); err != nil {
+		t.Errorf("Validate(AirTemperature) = %v, want nil", err)
+	}
+
+	err := Validate(trait.Name("smartcore.traits.NotATrait"))
+	if err == nil {
+		t.Fatal("Validate(unsupported) = nil, want error")
+	}
+	// Error should list the supported set to guide the user.
+	if !strings.Contains(err.Error(), string(trait.AirTemperature)) {
+		t.Errorf("Validate error does not list supported traits: %v", err)
+	}
+}

--- a/pkg/auto/internal/anytrait/registry_test.go
+++ b/pkg/auto/internal/anytrait/registry_test.go
@@ -1,43 +1,17 @@
 package anytrait
 
 import (
-	"slices"
-	"strings"
 	"testing"
 
 	"github.com/smart-core-os/sc-bos/pkg/trait"
 )
-
-func TestNames(t *testing.T) {
-	names := Names()
-	if len(names) == 0 {
-		t.Fatal("Names() returned no traits")
-	}
-	if !slices.IsSorted(names) {
-		t.Errorf("Names() not sorted: %v", names)
-	}
-	if !slices.Contains(names, trait.AirTemperature) {
-		t.Errorf("Names() missing AirTemperature: %v", names)
-	}
-	// Every name reported must resolve.
-	for _, n := range names {
-		if _, err := FindByName(n); err != nil {
-			t.Errorf("FindByName(%q) failed for a name from Names(): %v", n, err)
-		}
-	}
-}
 
 func TestValidate(t *testing.T) {
 	if err := Validate(trait.AirTemperature); err != nil {
 		t.Errorf("Validate(AirTemperature) = %v, want nil", err)
 	}
 
-	err := Validate(trait.Name("smartcore.traits.NotATrait"))
-	if err == nil {
+	if err := Validate(trait.Name("smartcore.traits.NotATrait")); err == nil {
 		t.Fatal("Validate(unsupported) = nil, want error")
-	}
-	// Error should list the supported set to guide the user.
-	if !strings.Contains(err.Error(), string(trait.AirTemperature)) {
-		t.Errorf("Validate error does not list supported traits: %v", err)
 	}
 }

--- a/pkg/auto/setpointhealth/config/root.go
+++ b/pkg/auto/setpointhealth/config/root.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/smart-core-os/sc-bos/internal/protobuf/protopath2"
 	"github.com/smart-core-os/sc-bos/pkg/auto"
+	"github.com/smart-core-os/sc-bos/pkg/auto/internal/anytrait"
 	"github.com/smart-core-os/sc-bos/pkg/proto/devicespb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/healthpb"
 	"github.com/smart-core-os/sc-bos/pkg/trait"
@@ -184,6 +185,9 @@ func Validate(cfg *Root) error {
 	}
 	if cfg.Source.Trait == "" {
 		return fmt.Errorf("source.trait is required")
+	}
+	if err := anytrait.Validate(cfg.Source.Trait); err != nil {
+		return fmt.Errorf("source.trait: %w", err)
 	}
 	return nil
 }

--- a/pkg/auto/setpointhealth/config/root_test.go
+++ b/pkg/auto/setpointhealth/config/root_test.go
@@ -73,6 +73,15 @@ func TestRead(t *testing.T) {
 			wantError: true,
 		},
 		{
+			name: "unsupported trait",
+			config: `{
+				"type": "setpointhealth", "name": "fcu",
+				"source": {"trait": "smartcore.traits.NotATrait", "measured": "a", "setPoint": "b"},
+				"tolerance": 1.5, "duration": "1h"
+			}`,
+			wantError: true,
+		},
+		{
 			name: "maxDuration greater than duration",
 			config: `{
 				"type": "setpointhealth", "name": "fcu",


### PR DESCRIPTION
The `healthbounds` and `setpointhealth` automations take a free-form `trait.Name` in their source config, but only traits registered in the shared `anytrait` registry actually work. A misspelled or unsupported trait didn't fail at config-load — it surfaced late, per device, as an opaque `anytrait.ErrNotFound` that got logged and skipped, so checks silently never ran.

This validates the configured trait against the registry at `config.Read` time and returns a clear error naming the unsupported trait. `anytrait` gains a `Validate` that defers to the registry, so it stays the single source of truth (membership is checked, not duplicated). `healthbounds` had no validation step and gets one; `setpointhealth` already had a `Validate` that only checked the trait was non-empty, so it's extended with the same registry-membership check — fixing the whole class rather than just the one automation named in the ticket.

Verified by `go test ./pkg/auto/internal/anytrait/... ./pkg/auto/healthbounds/... ./pkg/auto/setpointhealth/...` (new regression tests: an unsupported trait is now rejected by `Read` in both automations), plus `go build ./...`, `go vet`, and `staticcheck` on the touched packages.

#SCB-1385 State Done
