### PR TITLE
auto/bms: add exponential backoff to write retries (SCB-1384)

### DIFF
--- a/pkg/auto/bms/config/root.go
+++ b/pkg/auto/bms/config/root.go
@@ -37,7 +37,7 @@ type Root struct {
 	WriteCacheExpiry *jsontypes.Duration `json:"writeCacheExpiry,omitempty"` // Defaults to no expiry.
 	// If processing fails, how long to wait before trying again.
 	// This is the base delay; consecutive failures back off exponentially (with jitter) up to WriteRetryMaxDelay.
-	WriteRetryDelay *jsontypes.Duration `json:"WriteRetryDelay,omitempty"` // Defaults to 1m.
+	WriteRetryDelay *jsontypes.Duration `json:"writeRetryDelay,omitempty"` // Defaults to 1m.
 	// The maximum delay between retries when processing keeps failing.
 	// Backoff grows from WriteRetryDelay and is capped at this value.
 	WriteRetryMaxDelay *jsontypes.Duration `json:"writeRetryMaxDelay,omitempty"` // Defaults to 15m.

--- a/pkg/auto/bms/config/root.go
+++ b/pkg/auto/bms/config/root.go
@@ -36,7 +36,11 @@ type Root struct {
 	// How long should a past write affect future writes.
 	WriteCacheExpiry *jsontypes.Duration `json:"writeCacheExpiry,omitempty"` // Defaults to no expiry.
 	// If processing fails, how long to wait before trying again.
+	// This is the base delay; consecutive failures back off exponentially (with jitter) up to WriteRetryMaxDelay.
 	WriteRetryDelay *jsontypes.Duration `json:"WriteRetryDelay,omitempty"` // Defaults to 1m.
+	// The maximum delay between retries when processing keeps failing.
+	// Backoff grows from WriteRetryDelay and is capped at this value.
+	WriteRetryMaxDelay *jsontypes.Duration `json:"writeRetryMaxDelay,omitempty"` // Defaults to 15m.
 	// Reprocess state at least this often.
 	WriteEvery *jsontypes.Duration `json:"writeEvery,omitempty"` // Defaults to never.
 	// How long do we allow for writes to be picked up as reads.
@@ -88,6 +92,7 @@ var (
 	DefaultDeadbandModeTarget   = SwitchMode{Key: "deadband", On: "comfort", Off: "eco"}
 	DefaultWriteCacheExpiry     = 0 * time.Second
 	DefaultWriteRetryDelay      = time.Minute
+	DefaultWriteRetryMaxDelay   = 15 * time.Minute
 	DefaultWriteEvery           = 0 * time.Second
 	DefaultWriteReadPropagation = 5 * time.Second
 	DefaultUnoccupiedDelay      = 15 * time.Minute

--- a/pkg/auto/bms/factory.go
+++ b/pkg/auto/bms/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -55,6 +56,7 @@ type Auto struct {
 	clientActions func(clientConner node.ClientConner) Actions
 	newTimer      func(duration time.Duration) (<-chan time.Time, func() bool)
 	processDone   func(readState *ReadState, writeState *WriteState, ttl time.Duration, err error)
+	randFloat     func() float64 // returns a value in [0.0,1.0), used to jitter retry backoff
 }
 
 func (a *Auto) applyConfig(ctx context.Context, cfg config.Root) error {
@@ -138,17 +140,17 @@ func (a *Auto) processReadStates(ctx context.Context, readStates <-chan *ReadSta
 	var ttlExpired <-chan time.Time
 	cancelTtlTimer := func() bool { return false }
 
-	var retryFailedProcessing <-chan time.Time
-	cancelRetryTimer := func() bool { return false }
-
 	// writeState is only accessed from this go routine.
 	writeState := NewWriteState()
 	writeState.Now = a.now
 
+	// consecutiveFailures counts how many times processing has failed in a row.
+	// It grows the retry backoff and resets to 0 on the next successful process.
+	var consecutiveFailures int
+
 	var lastProcessedState *ReadState
 	processStateFn := func(readState *ReadState) error {
 		cancelTtlTimer()
-		cancelRetryTimer()
 		logger := a.logger.With(zap.String("auto", readState.Config.Name))
 
 		if readState.Config.LogReads {
@@ -176,12 +178,20 @@ func (a *Auto) processReadStates(ctx context.Context, readStates <-chan *ReadSta
 		case ctx.Err() != nil:
 			return ctx.Err()
 		case err != nil:
-			// TODO: add backoff etc.
-			ttl = readState.Config.WriteRetryDelay.Or(config.DefaultWriteRetryDelay)
-		case refreshEvery > 0 && (ttl <= 0 || ttl > refreshEvery):
-			// ensure it's not too long before we wake up,
-			// so external changes don't stick around forever
-			ttl = refreshEvery
+			// Back off exponentially (with jitter) while processing keeps failing,
+			// so an unreachable device isn't hammered at a constant rate.
+			consecutiveFailures++
+			base := readState.Config.WriteRetryDelay.Or(config.DefaultWriteRetryDelay)
+			maxDelay := readState.Config.WriteRetryMaxDelay.Or(config.DefaultWriteRetryMaxDelay)
+			ttl = nextRetryDelay(base, maxDelay, consecutiveFailures, a.randFloat())
+		default:
+			// processing succeeded, reset the backoff
+			consecutiveFailures = 0
+			if refreshEvery > 0 && (ttl <= 0 || ttl > refreshEvery) {
+				// ensure it's not too long before we wake up,
+				// so external changes don't stick around forever
+				ttl = refreshEvery
+			}
 		}
 
 		// Setup ttl for the transformed model.
@@ -216,13 +226,44 @@ func (a *Auto) processReadStates(ctx context.Context, readStates <-chan *ReadSta
 			if err != nil {
 				return err
 			}
-		case <-retryFailedProcessing:
-			err := processStateFn(lastReadState)
-			if err != nil {
-				return err
-			}
 		}
 	}
+}
+
+// nextRetryDelay computes the delay before the next retry after attempt consecutive failures.
+// The delay grows exponentially from base (attempt 1 == base, attempt 2 == 2*base, ...),
+// is capped at max, and then has "equal jitter" applied: the returned value lies in
+// [d/2, d) where d is the capped exponential delay. jitter must be in [0.0,1.0).
+func nextRetryDelay(base, maxDelay time.Duration, attempt int, jitter float64) time.Duration {
+	if base <= 0 {
+		base = config.DefaultWriteRetryDelay
+	}
+	if attempt < 1 {
+		attempt = 1
+	}
+
+	d := base
+	for i := 1; i < attempt; i++ {
+		if maxDelay > 0 && d >= maxDelay {
+			d = maxDelay
+			break
+		}
+		d *= 2
+		if d <= 0 { // overflow, treat as unbounded and clamp below
+			d = maxDelay
+			break
+		}
+	}
+	if maxDelay > 0 && d > maxDelay {
+		d = maxDelay
+	}
+	if d <= 0 {
+		d = base
+	}
+
+	// equal jitter: keep half the delay fixed, randomise the other half.
+	half := d / 2
+	return half + time.Duration(jitter*float64(half))
 }
 
 func (a *Auto) setTestHelperFuncs() {
@@ -241,5 +282,8 @@ func (a *Auto) setTestHelperFuncs() {
 	if a.processDone == nil {
 		a.processDone = func(readState *ReadState, writeState *WriteState, ttl time.Duration, err error) {
 		}
+	}
+	if a.randFloat == nil {
+		a.randFloat = rand.Float64
 	}
 }

--- a/pkg/auto/bms/factory_test.go
+++ b/pkg/auto/bms/factory_test.go
@@ -1,0 +1,194 @@
+package bms
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/smart-core-os/sc-bos/pkg/auto/bms/config"
+	"github.com/smart-core-os/sc-bos/pkg/proto/airtemperaturepb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/modepb"
+	"github.com/smart-core-os/sc-bos/pkg/util/jsontypes"
+)
+
+func TestNextRetryDelay(t *testing.T) {
+	const base = time.Minute
+	const max = 15 * time.Minute
+
+	t.Run("grows exponentially with zero jitter", func(t *testing.T) {
+		// jitter 0 => result is exactly half the capped exponential delay.
+		cases := []struct {
+			attempt int
+			wantD   time.Duration // capped exponential delay before jitter
+		}{
+			{1, 1 * time.Minute},
+			{2, 2 * time.Minute},
+			{3, 4 * time.Minute},
+			{4, 8 * time.Minute},
+			{5, 15 * time.Minute}, // 16m capped to 15m
+			{6, 15 * time.Minute}, // stays capped
+			{20, 15 * time.Minute},
+		}
+		for _, c := range cases {
+			got := nextRetryDelay(base, max, c.attempt, 0)
+			if want := c.wantD / 2; got != want {
+				t.Errorf("attempt %d: got %v, want %v", c.attempt, got, want)
+			}
+		}
+	})
+
+	t.Run("jitter stays within [d/2, d)", func(t *testing.T) {
+		for attempt := 1; attempt <= 6; attempt++ {
+			d := nextRetryDelay(base, max, attempt, 0) * 2 // full capped delay
+			for _, j := range []float64{0, 0.25, 0.5, 0.75, 0.999999} {
+				got := nextRetryDelay(base, max, attempt, j)
+				if got < d/2 || got >= d {
+					t.Errorf("attempt %d jitter %v: got %v, want in [%v, %v)", attempt, j, got, d/2, d)
+				}
+			}
+		}
+	})
+
+	t.Run("attempt below one is treated as one", func(t *testing.T) {
+		want := nextRetryDelay(base, max, 1, 0)
+		for _, attempt := range []int{0, -1, -100} {
+			if got := nextRetryDelay(base, max, attempt, 0); got != want {
+				t.Errorf("attempt %d: got %v, want %v", attempt, got, want)
+			}
+		}
+	})
+
+	t.Run("non-positive base falls back to default", func(t *testing.T) {
+		got := nextRetryDelay(0, max, 1, 0)
+		if want := config.DefaultWriteRetryDelay / 2; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("extreme attempt does not overflow", func(t *testing.T) {
+		// a huge attempt count must not panic or wrap to a negative/zero delay.
+		got := nextRetryDelay(base, max, 1_000_000, 0)
+		if got != max/2 {
+			t.Errorf("got %v, want %v", got, max/2)
+		}
+	})
+}
+
+// failToggleActions is an Actions whose writes fail while fail is set, and succeed otherwise.
+type failToggleActions struct {
+	fail atomic.Bool
+}
+
+func (a *failToggleActions) UpdateAirTemperature(context.Context, *airtemperaturepb.UpdateAirTemperatureRequest, *WriteState) error {
+	if a.fail.Load() {
+		return errors.New("boom")
+	}
+	return nil
+}
+
+func (a *failToggleActions) UpdateModeValues(context.Context, *modepb.UpdateModeValuesRequest, *WriteState) error {
+	if a.fail.Load() {
+		return errors.New("boom")
+	}
+	return nil
+}
+
+// TestProcessReadStates_Backoff drives the processing loop with a failing write and asserts
+// the retry TTL backs off on consecutive failures and resets to the base delay after a success.
+func TestProcessReadStates_Backoff(t *testing.T) {
+	acts := &failToggleActions{}
+	acts.fail.Store(true)
+
+	type doneEvent struct {
+		ttl time.Duration
+		err error
+	}
+	done := make(chan doneEvent, 1)
+
+	var mu sync.Mutex
+	var curTimer chan time.Time // the most recently created ttl timer
+
+	a := &Auto{
+		logger: zap.NewNop(),
+		now:    time.Now,
+		newTimer: func(time.Duration) (<-chan time.Time, func() bool) {
+			ch := make(chan time.Time, 1)
+			mu.Lock()
+			curTimer = ch
+			mu.Unlock()
+			return ch, func() bool { return false }
+		},
+		processDone: func(_ *ReadState, _ *WriteState, ttl time.Duration, err error) {
+			done <- doneEvent{ttl: ttl, err: err}
+		},
+		randFloat: func() float64 { return 0 }, // deterministic: ttl == half the exponential delay
+	}
+
+	// a read state that turns occupancy on, forcing mode writes (which fail while acts.fail is set).
+	lt := newLogicTester(t)
+	lt.controlsOccupancy()
+	lt.setOccupied("sensor1")
+	// a non-zero WriteEvery guarantees a timer is created on success, so we can drive the next iteration.
+	lt.rs.Config.WriteEvery = &jsontypes.Duration{Duration: 30 * time.Minute}
+	rs := lt.rs
+
+	readStates := make(chan *ReadState)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errc := make(chan error, 1)
+	go func() { errc <- a.processReadStates(ctx, readStates, acts) }()
+
+	// fireTimer triggers the ttlExpired path, causing the loop to reprocess the last read state.
+	fireTimer := func() {
+		mu.Lock()
+		ch := curTimer
+		mu.Unlock()
+		ch <- time.Time{}
+	}
+
+	// initial process: fails (attempt 1).
+	readStates <- rs
+	e1 := <-done
+	if e1.err == nil {
+		t.Fatalf("expected first process to fail")
+	}
+
+	// two more failures, TTL should grow each time.
+	fireTimer()
+	e2 := <-done
+	fireTimer()
+	e3 := <-done
+	if !(e1.ttl < e2.ttl && e2.ttl < e3.ttl) {
+		t.Errorf("expected backoff to grow, got %v, %v, %v", e1.ttl, e2.ttl, e3.ttl)
+	}
+
+	// a success resets the backoff.
+	acts.fail.Store(false)
+	fireTimer()
+	e4 := <-done
+	if e4.err != nil {
+		t.Fatalf("expected success, got %v", e4.err)
+	}
+
+	// the next failure should be back at the base delay (same as the very first failure).
+	acts.fail.Store(true)
+	fireTimer()
+	e5 := <-done
+	if e5.err == nil {
+		t.Fatalf("expected failure after reset")
+	}
+	if e5.ttl != e1.ttl {
+		t.Errorf("expected backoff to reset to %v, got %v", e1.ttl, e5.ttl)
+	}
+
+	cancel()
+	if err := <-errc; err != nil && !errors.Is(err, context.Canceled) {
+		t.Errorf("unexpected loop error: %v", err)
+	}
+}


### PR DESCRIPTION
A BMS automation that fails to write to a device was retried at a fixed
rate (`WriteRetryDelay`, default 1m). Against a persistently failing or
unreachable device this adds needless load and log noise, with no relief
under sustained failure.

Retries now back off exponentially from `WriteRetryDelay`, capped at a new
`WriteRetryMaxDelay` (default 15m), and reset to the base after the next
successful process. Equal jitter is applied so devices sharing an
upstream gateway don't retry in lockstep when it recovers; because of
the jitter each retry lands in `[delay/2, delay)`, so `WriteRetryDelay`
acts as an upper bound on the wait rather than an exact delay. Existing
config keys still apply unchanged. The never-wired
`retryFailedProcessing` scaffolding in the processing loop was removed
while here.

Verified by `go test ./pkg/auto/bms/...`: a unit test for the backoff
maths (growth, cap, jitter bounds, edges) and an integration test that
drives the real processing loop, asserting the retry TTL grows across
consecutive failures and resets after a success.

#SCB-1384 State Done
