### PR TITLE
health: bucket range-check deviation and add dashboard filter (SCB-1382)

### DIFF
--- a/pkg/proto/healthpb/bounds.go
+++ b/pkg/proto/healthpb/bounds.go
@@ -4,8 +4,18 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"math"
 
 	"google.golang.org/protobuf/proto"
+)
+
+// Deviation buckets are assigned by how far a measured value sits outside its
+// expected range, as a fraction of the range width (or of the crossed bound's
+// magnitude for open-ended ranges). A value at or above deviationMajorRatio is
+// MAJOR, at or above deviationModerateRatio is MODERATE, otherwise MINOR.
+const (
+	deviationModerateRatio = 0.10
+	deviationMajorRatio    = 0.25
 )
 
 // ValidateValueRange checks that a value range is well-formed.
@@ -157,6 +167,7 @@ func (c *BoundsCheck) writeValue(dst *HealthCheck, v *HealthCheck_Value) {
 	oldState := dst.GetNormality()
 	newState := c.checker.valueToState(v, dst)
 	dst.Normality = newState
+	dst.Deviation = c.checker.valueToDeviation(v, newState)
 	out.CurrentValue = v
 	updateStateTimes(dst, oldState, newState)
 }
@@ -184,6 +195,10 @@ func (c *BoundsCheck) prepareChecker(b *HealthCheck_Bounds) (boundsChecker, erro
 // boundsChecker compares a value against a normal state, returning the appropriate check state.
 type boundsChecker interface {
 	valueToState(v *HealthCheck_Value, current *HealthCheck) HealthCheck_Normality
+	// valueToDeviation buckets how far v sits outside the expected bounds, given
+	// the state just computed by valueToState. Checks without a meaningful
+	// magnitude (equality and value-set checks) return DEVIATION_UNSPECIFIED.
+	valueToDeviation(v *HealthCheck_Value, state HealthCheck_Normality) HealthCheck_Deviation
 }
 
 func newNormalValueCheck(v, nv *HealthCheck_Value) (*valueCheck, error) {
@@ -215,6 +230,12 @@ func (c *valueCheck) valueToState(v *HealthCheck_Value, _ *HealthCheck) HealthCh
 	return c.neq
 }
 
+// valueToDeviation always returns DEVIATION_UNSPECIFIED: equality checks are
+// either equal or not, with no magnitude to bucket.
+func (c *valueCheck) valueToDeviation(_ *HealthCheck_Value, _ HealthCheck_Normality) HealthCheck_Deviation {
+	return HealthCheck_DEVIATION_UNSPECIFIED
+}
+
 func newNormalRangeCheck(v *HealthCheck_Value, r *HealthCheck_ValueRange) (*normalRangeCheck, error) {
 	if err := ValidateValueRange(r); err != nil {
 		return nil, err
@@ -236,6 +257,71 @@ type normalRangeCheck struct {
 
 func (c *normalRangeCheck) valueToState(v *HealthCheck_Value, current *HealthCheck) HealthCheck_Normality {
 	return checkRangeState(c.bounds, v, current.GetNormality())
+}
+
+// valueToDeviation buckets how far v sits below low (state LOW) or above high
+// (state HIGH), as a fraction of the range width. For open-ended ranges (only
+// one bound set) it falls back to the magnitude of the crossed bound. Non-numeric
+// values, and states other than LOW/HIGH, yield DEVIATION_UNSPECIFIED. A value
+// that has returned within the bounds while the state is held out of NORMAL by
+// deadband hysteresis also yields DEVIATION_UNSPECIFIED: there is no excursion.
+func (c *normalRangeCheck) valueToDeviation(v *HealthCheck_Value, state HealthCheck_Normality) HealthCheck_Deviation {
+	var bound *HealthCheck_Value
+	switch state {
+	case HealthCheck_LOW:
+		bound = c.bounds.GetLow()
+	case HealthCheck_HIGH:
+		bound = c.bounds.GetHigh()
+	default:
+		return HealthCheck_DEVIATION_UNSPECIFIED
+	}
+	val, okV := valueAsFloat(v)
+	boundF, okB := valueAsFloat(bound)
+	if !okV || !okB {
+		return HealthCheck_DEVIATION_UNSPECIFIED
+	}
+	// Measure the excursion in the direction the state implies. The state can be
+	// held out of NORMAL by deadband hysteresis while v has already returned
+	// inside the range, so a non-positive overshoot means there is nothing to
+	// bucket.
+	overshoot := val - boundF // HIGH: positive when v is above the high bound
+	if state == HealthCheck_LOW {
+		overshoot = -overshoot // LOW: positive when v is below the low bound
+	}
+	if overshoot <= 0 {
+		return HealthCheck_DEVIATION_UNSPECIFIED
+	}
+
+	// Prefer the range width as the denominator; fall back to the crossed bound's
+	// magnitude for open-ended ranges. If neither yields a positive scale there is
+	// no meaningful ratio to bucket.
+	denom := 0.0
+	if low, high := c.bounds.GetLow(), c.bounds.GetHigh(); low != nil && high != nil {
+		lf, okL := valueAsFloat(low)
+		hf, okH := valueAsFloat(high)
+		if okL && okH {
+			denom = math.Abs(hf - lf)
+		}
+	}
+	if denom == 0 && !isTimestampValue(bound) {
+		// Fall back to the crossed bound's magnitude, but only where that magnitude
+		// is a meaningful scale. Timestamps are measured from an arbitrary epoch, so
+		// |bound| (Unix nanoseconds) is not usable: an open-ended timestamp range has
+		// no width and no natural scale, so it stays unbucketed.
+		denom = math.Abs(boundF)
+	}
+	if denom == 0 {
+		return HealthCheck_DEVIATION_UNSPECIFIED
+	}
+
+	switch ratio := overshoot / denom; {
+	case ratio >= deviationMajorRatio:
+		return HealthCheck_MAJOR
+	case ratio >= deviationModerateRatio:
+		return HealthCheck_MODERATE
+	default:
+		return HealthCheck_MINOR
+	}
 }
 
 func newNormalValuesCheck(v *HealthCheck_Value, vs []*HealthCheck_Value) (*valuesCheck, error) {
@@ -260,6 +346,12 @@ type valuesCheck struct {
 
 func (c *valuesCheck) valueToState(v *HealthCheck_Value, _ *HealthCheck) HealthCheck_Normality {
 	return valuesToState(v, c.values, c.in, c.nin)
+}
+
+// valueToDeviation always returns DEVIATION_UNSPECIFIED: value-set checks are
+// membership tests, with no magnitude to bucket.
+func (c *valuesCheck) valueToDeviation(_ *HealthCheck_Value, _ HealthCheck_Normality) HealthCheck_Deviation {
+	return HealthCheck_DEVIATION_UNSPECIFIED
 }
 
 // validateValuesCheck returns an error if any value in vs is inconsistent with the others, and with v (if set).

--- a/pkg/proto/healthpb/bounds_test.go
+++ b/pkg/proto/healthpb/bounds_test.go
@@ -138,6 +138,80 @@ func TestCheckRangeState(t *testing.T) {
 	}
 }
 
+func TestNormalRangeCheck_valueToDeviation(t *testing.T) {
+	tsBase := time.Unix(1_700_000_000, 0)
+	tests := []struct {
+		name  string
+		r     *HealthCheck_ValueRange
+		v     *HealthCheck_Value
+		state HealthCheck_Normality
+		want  HealthCheck_Deviation
+	}{
+		// closed range [30,60], width 30 -> ratio = overshoot/30
+		{"high tiny -> minor", &HealthCheck_ValueRange{Low: FloatValue(30), High: FloatValue(60)}, FloatValue(60.2), HealthCheck_HIGH, HealthCheck_MINOR},
+		{"high 10% -> moderate", &HealthCheck_ValueRange{Low: FloatValue(30), High: FloatValue(60)}, FloatValue(63), HealthCheck_HIGH, HealthCheck_MODERATE},
+		{"high 25% -> major", &HealthCheck_ValueRange{Low: FloatValue(30), High: FloatValue(60)}, FloatValue(67.5), HealthCheck_HIGH, HealthCheck_MAJOR},
+		{"low 10% -> moderate", &HealthCheck_ValueRange{Low: FloatValue(30), High: FloatValue(60)}, FloatValue(27), HealthCheck_LOW, HealthCheck_MODERATE},
+		{"low 25% -> major", &HealthCheck_ValueRange{Low: FloatValue(30), High: FloatValue(60)}, FloatValue(22.5), HealthCheck_LOW, HealthCheck_MAJOR},
+
+		// bucket boundaries on [10,20], width 10
+		{"just under 10% -> minor", &HealthCheck_ValueRange{Low: IntValue(10), High: IntValue(20)}, FloatValue(20.9), HealthCheck_HIGH, HealthCheck_MINOR},
+		{"exactly 10% -> moderate", &HealthCheck_ValueRange{Low: FloatValue(10), High: FloatValue(20)}, FloatValue(21), HealthCheck_HIGH, HealthCheck_MODERATE},
+		{"just under 25% -> moderate", &HealthCheck_ValueRange{Low: FloatValue(10), High: FloatValue(20)}, FloatValue(22.4), HealthCheck_HIGH, HealthCheck_MODERATE},
+		{"exactly 25% -> major", &HealthCheck_ValueRange{Low: FloatValue(10), High: FloatValue(20)}, FloatValue(22.5), HealthCheck_HIGH, HealthCheck_MAJOR},
+
+		// int values
+		{"int major", &HealthCheck_ValueRange{Low: IntValue(10), High: IntValue(20)}, IntValue(25), HealthCheck_HIGH, HealthCheck_MAJOR},
+
+		// duration range [10s,20s], width 10s
+		{"duration major", &HealthCheck_ValueRange{Low: DurationValue(10 * time.Second), High: DurationValue(20 * time.Second)}, DurationValue(25 * time.Second), HealthCheck_HIGH, HealthCheck_MAJOR},
+
+		// closed timestamp range [t0, t0+10s], width 10s -> 3s over = 30% -> major
+		{"timestamp closed major", &HealthCheck_ValueRange{Low: TimestampValue(tsBase), High: TimestampValue(tsBase.Add(10 * time.Second))}, TimestampValue(tsBase.Add(13 * time.Second)), HealthCheck_HIGH, HealthCheck_MAJOR},
+		// open-ended timestamp range has no meaningful scale (arbitrary epoch) -> unspecified
+		{"timestamp open-ended -> unspecified", &HealthCheck_ValueRange{High: TimestampValue(tsBase)}, TimestampValue(tsBase.Add(time.Hour)), HealthCheck_HIGH, HealthCheck_DEVIATION_UNSPECIFIED},
+
+		// open-ended ranges fall back to |crossed bound|
+		{"high-only minor", &HealthCheck_ValueRange{High: FloatValue(20)}, FloatValue(21), HealthCheck_HIGH, HealthCheck_MINOR},
+		{"high-only major", &HealthCheck_ValueRange{High: FloatValue(20)}, FloatValue(25), HealthCheck_HIGH, HealthCheck_MAJOR},
+		{"low-only moderate", &HealthCheck_ValueRange{Low: FloatValue(100)}, FloatValue(80), HealthCheck_LOW, HealthCheck_MODERATE},
+
+		// zero-width closed range falls back to |bound|
+		{"zero width", &HealthCheck_ValueRange{Low: FloatValue(5), High: FloatValue(5)}, FloatValue(6), HealthCheck_HIGH, HealthCheck_MODERATE},
+
+		// state held out of NORMAL by deadband hysteresis while the value is back
+		// inside the range -> no excursion -> unspecified
+		{"high held by deadband, value in range", &HealthCheck_ValueRange{Low: FloatValue(30), High: FloatValue(60)}, FloatValue(58), HealthCheck_HIGH, HealthCheck_DEVIATION_UNSPECIFIED},
+		{"high state, value at bound", &HealthCheck_ValueRange{Low: FloatValue(30), High: FloatValue(60)}, FloatValue(60), HealthCheck_HIGH, HealthCheck_DEVIATION_UNSPECIFIED},
+		{"low held by deadband, value in range", &HealthCheck_ValueRange{Low: FloatValue(30), High: FloatValue(60)}, FloatValue(35), HealthCheck_LOW, HealthCheck_DEVIATION_UNSPECIFIED},
+
+		// no meaningful scale / magnitude -> unspecified
+		{"zero bound open-ended", &HealthCheck_ValueRange{High: FloatValue(0)}, FloatValue(5), HealthCheck_HIGH, HealthCheck_DEVIATION_UNSPECIFIED},
+		{"string bounds", &HealthCheck_ValueRange{Low: StringValue("a"), High: StringValue("z")}, StringValue("~"), HealthCheck_HIGH, HealthCheck_DEVIATION_UNSPECIFIED},
+		{"normal -> unspecified", &HealthCheck_ValueRange{Low: FloatValue(30), High: FloatValue(60)}, FloatValue(45), HealthCheck_NORMAL, HealthCheck_DEVIATION_UNSPECIFIED},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &normalRangeCheck{bounds: tt.r}
+			if got := c.valueToDeviation(tt.v, tt.state); got != tt.want {
+				t.Errorf("valueToDeviation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValueCheck_valueToDeviation(t *testing.T) {
+	// equality and value-set checks have no magnitude -> always unspecified
+	vc := &valueCheck{value: IntValue(1), eq: HealthCheck_NORMAL, neq: HealthCheck_ABNORMAL}
+	if got := vc.valueToDeviation(IntValue(99), HealthCheck_ABNORMAL); got != HealthCheck_DEVIATION_UNSPECIFIED {
+		t.Errorf("valueCheck.valueToDeviation() = %v, want DEVIATION_UNSPECIFIED", got)
+	}
+	vsc := &valuesCheck{values: []*HealthCheck_Value{IntValue(1)}, in: HealthCheck_NORMAL, nin: HealthCheck_ABNORMAL}
+	if got := vsc.valueToDeviation(IntValue(99), HealthCheck_ABNORMAL); got != HealthCheck_DEVIATION_UNSPECIFIED {
+		t.Errorf("valuesCheck.valueToDeviation() = %v, want DEVIATION_UNSPECIFIED", got)
+	}
+}
+
 func Test_less(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/proto/healthpb/health.pb.go
+++ b/pkg/proto/healthpb/health.pb.go
@@ -216,6 +216,66 @@ func (HealthCheck_Normality) EnumDescriptor() ([]byte, []int) {
 	return file_smartcore_bos_health_v1_health_proto_rawDescGZIP(), []int{0, 2}
 }
 
+// Deviation describes how far a measured value is from its expected range,
+// bucketed so it can be filtered without exposing the measured value itself.
+// It is only meaningful for range (normal_range) bounds checks; it is
+// DEVIATION_UNSPECIFIED when the value is within range, or for equality and
+// value-set checks, which have no magnitude.
+type HealthCheck_Deviation int32
+
+const (
+	HealthCheck_DEVIATION_UNSPECIFIED HealthCheck_Deviation = 0
+	// The value is only slightly outside its expected range.
+	HealthCheck_MINOR HealthCheck_Deviation = 1
+	// The value is moderately outside its expected range.
+	HealthCheck_MODERATE HealthCheck_Deviation = 2
+	// The value is far outside its expected range.
+	HealthCheck_MAJOR HealthCheck_Deviation = 3
+)
+
+// Enum value maps for HealthCheck_Deviation.
+var (
+	HealthCheck_Deviation_name = map[int32]string{
+		0: "DEVIATION_UNSPECIFIED",
+		1: "MINOR",
+		2: "MODERATE",
+		3: "MAJOR",
+	}
+	HealthCheck_Deviation_value = map[string]int32{
+		"DEVIATION_UNSPECIFIED": 0,
+		"MINOR":                 1,
+		"MODERATE":              2,
+		"MAJOR":                 3,
+	}
+)
+
+func (x HealthCheck_Deviation) Enum() *HealthCheck_Deviation {
+	p := new(HealthCheck_Deviation)
+	*p = x
+	return p
+}
+
+func (x HealthCheck_Deviation) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (HealthCheck_Deviation) Descriptor() protoreflect.EnumDescriptor {
+	return file_smartcore_bos_health_v1_health_proto_enumTypes[3].Descriptor()
+}
+
+func (HealthCheck_Deviation) Type() protoreflect.EnumType {
+	return &file_smartcore_bos_health_v1_health_proto_enumTypes[3]
+}
+
+func (x HealthCheck_Deviation) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use HealthCheck_Deviation.Descriptor instead.
+func (HealthCheck_Deviation) EnumDescriptor() ([]byte, []int) {
+	return file_smartcore_bos_health_v1_health_proto_rawDescGZIP(), []int{0, 3}
+}
+
 // Contribution describes how this check contributes to compliance with the standard.
 type HealthCheck_ComplianceImpact_Contribution int32
 
@@ -261,11 +321,11 @@ func (x HealthCheck_ComplianceImpact_Contribution) String() string {
 }
 
 func (HealthCheck_ComplianceImpact_Contribution) Descriptor() protoreflect.EnumDescriptor {
-	return file_smartcore_bos_health_v1_health_proto_enumTypes[3].Descriptor()
+	return file_smartcore_bos_health_v1_health_proto_enumTypes[4].Descriptor()
 }
 
 func (HealthCheck_ComplianceImpact_Contribution) Type() protoreflect.EnumType {
-	return &file_smartcore_bos_health_v1_health_proto_enumTypes[3]
+	return &file_smartcore_bos_health_v1_health_proto_enumTypes[4]
 }
 
 func (x HealthCheck_ComplianceImpact_Contribution) Number() protoreflect.EnumNumber {
@@ -340,11 +400,11 @@ func (x HealthCheck_Reliability_State) String() string {
 }
 
 func (HealthCheck_Reliability_State) Descriptor() protoreflect.EnumDescriptor {
-	return file_smartcore_bos_health_v1_health_proto_enumTypes[4].Descriptor()
+	return file_smartcore_bos_health_v1_health_proto_enumTypes[5].Descriptor()
 }
 
 func (HealthCheck_Reliability_State) Type() protoreflect.EnumType {
-	return &file_smartcore_bos_health_v1_health_proto_enumTypes[4]
+	return &file_smartcore_bos_health_v1_health_proto_enumTypes[5]
 }
 
 func (x HealthCheck_Reliability_State) Number() protoreflect.EnumNumber {
@@ -410,6 +470,8 @@ type HealthCheck struct {
 	NormalTime *timestamppb.Timestamp `protobuf:"bytes,22,opt,name=normal_time,json=normalTime,proto3" json:"normal_time,omitempty"`
 	// The time when normality last entered a non-NORMAL state.
 	AbnormalTime *timestamppb.Timestamp `protobuf:"bytes,23,opt,name=abnormal_time,json=abnormalTime,proto3" json:"abnormal_time,omitempty"`
+	// Deviation is the bucketed magnitude of a range-check excursion.
+	Deviation HealthCheck_Deviation `protobuf:"varint,24,opt,name=deviation,proto3,enum=smartcore.bos.health.v1.HealthCheck_Deviation" json:"deviation,omitempty"`
 	// Details about the check being performed.
 	// Optional, but strongly recommended.
 	// HealthChecks should not change their type of check after creation.
@@ -528,6 +590,13 @@ func (x *HealthCheck) GetAbnormalTime() *timestamppb.Timestamp {
 		return x.AbnormalTime
 	}
 	return nil
+}
+
+func (x *HealthCheck) GetDeviation() HealthCheck_Deviation {
+	if x != nil {
+		return x.Deviation
+	}
+	return HealthCheck_DEVIATION_UNSPECIFIED
 }
 
 func (x *HealthCheck) GetCheck() isHealthCheck_Check {
@@ -2123,7 +2192,7 @@ var File_smartcore_bos_health_v1_health_proto protoreflect.FileDescriptor
 
 const file_smartcore_bos_health_v1_health_proto_rawDesc = "" +
 	"\n" +
-	"$smartcore/bos/health/v1/health.proto\x12\x17smartcore.bos.health.v1\x1a\x1egoogle/protobuf/duration.proto\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#smartcore/bos/types/v1/change.proto\"\x90\x1f\n" +
+	"$smartcore/bos/health/v1/health.proto\x12\x17smartcore.bos.health.v1\x1a\x1egoogle/protobuf/duration.proto\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#smartcore/bos/types/v1/change.proto\"\xaa \n" +
 	"\vHealthCheck\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12!\n" +
 	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12 \n" +
@@ -2138,7 +2207,8 @@ const file_smartcore_bos_health_v1_health_proto_rawDesc = "" +
 	"\tnormality\x18\x15 \x01(\x0e2..smartcore.bos.health.v1.HealthCheck.NormalityR\tnormality\x12;\n" +
 	"\vnormal_time\x18\x16 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"normalTime\x12?\n" +
-	"\rabnormal_time\x18\x17 \x01(\v2\x1a.google.protobuf.TimestampR\fabnormalTime\x12E\n" +
+	"\rabnormal_time\x18\x17 \x01(\v2\x1a.google.protobuf.TimestampR\fabnormalTime\x12L\n" +
+	"\tdeviation\x18\x18 \x01(\x0e2..smartcore.bos.health.v1.HealthCheck.DeviationR\tdeviation\x12E\n" +
 	"\x06bounds\x18\x1e \x01(\v2+.smartcore.bos.health.v1.HealthCheck.BoundsH\x00R\x06bounds\x12E\n" +
 	"\x06faults\x18\x1f \x01(\v2+.smartcore.bos.health.v1.HealthCheck.FaultsH\x00R\x06faults\x1a\xdb\x03\n" +
 	"\x10ComplianceImpact\x12Z\n" +
@@ -2240,7 +2310,12 @@ const file_smartcore_bos_health_v1_health_proto_rawDesc = "" +
 	"\x06NORMAL\x10\x01\x12\f\n" +
 	"\bABNORMAL\x10\x02\x12\a\n" +
 	"\x03LOW\x10\x03\x12\b\n" +
-	"\x04HIGH\x10\x04B\a\n" +
+	"\x04HIGH\x10\x04\"J\n" +
+	"\tDeviation\x12\x19\n" +
+	"\x15DEVIATION_UNSPECIFIED\x10\x00\x12\t\n" +
+	"\x05MINOR\x10\x01\x12\f\n" +
+	"\bMODERATE\x10\x02\x12\t\n" +
+	"\x05MAJOR\x10\x03B\a\n" +
 	"\x05check\"\xa2\x01\n" +
 	"\x17ListHealthChecksRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x127\n" +
@@ -2300,101 +2375,103 @@ func file_smartcore_bos_health_v1_health_proto_rawDescGZIP() []byte {
 	return file_smartcore_bos_health_v1_health_proto_rawDescData
 }
 
-var file_smartcore_bos_health_v1_health_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_smartcore_bos_health_v1_health_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
 var file_smartcore_bos_health_v1_health_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_smartcore_bos_health_v1_health_proto_goTypes = []any{
 	(HealthCheck_OccupantImpact)(0),                // 0: smartcore.bos.health.v1.HealthCheck.OccupantImpact
 	(HealthCheck_EquipmentImpact)(0),               // 1: smartcore.bos.health.v1.HealthCheck.EquipmentImpact
 	(HealthCheck_Normality)(0),                     // 2: smartcore.bos.health.v1.HealthCheck.Normality
-	(HealthCheck_ComplianceImpact_Contribution)(0), // 3: smartcore.bos.health.v1.HealthCheck.ComplianceImpact.Contribution
-	(HealthCheck_Reliability_State)(0),             // 4: smartcore.bos.health.v1.HealthCheck.Reliability.State
-	(*HealthCheck)(nil),                            // 5: smartcore.bos.health.v1.HealthCheck
-	(*ListHealthChecksRequest)(nil),                // 6: smartcore.bos.health.v1.ListHealthChecksRequest
-	(*ListHealthChecksResponse)(nil),               // 7: smartcore.bos.health.v1.ListHealthChecksResponse
-	(*PullHealthChecksRequest)(nil),                // 8: smartcore.bos.health.v1.PullHealthChecksRequest
-	(*PullHealthChecksResponse)(nil),               // 9: smartcore.bos.health.v1.PullHealthChecksResponse
-	(*GetHealthCheckRequest)(nil),                  // 10: smartcore.bos.health.v1.GetHealthCheckRequest
-	(*PullHealthCheckRequest)(nil),                 // 11: smartcore.bos.health.v1.PullHealthCheckRequest
-	(*PullHealthCheckResponse)(nil),                // 12: smartcore.bos.health.v1.PullHealthCheckResponse
-	(*HealthCheck_ComplianceImpact)(nil),           // 13: smartcore.bos.health.v1.HealthCheck.ComplianceImpact
-	(*HealthCheck_Error)(nil),                      // 14: smartcore.bos.health.v1.HealthCheck.Error
-	(*HealthCheck_Reliability)(nil),                // 15: smartcore.bos.health.v1.HealthCheck.Reliability
-	(*HealthCheck_Value)(nil),                      // 16: smartcore.bos.health.v1.HealthCheck.Value
-	(*HealthCheck_ValueRange)(nil),                 // 17: smartcore.bos.health.v1.HealthCheck.ValueRange
-	(*HealthCheck_Values)(nil),                     // 18: smartcore.bos.health.v1.HealthCheck.Values
-	(*HealthCheck_Bounds)(nil),                     // 19: smartcore.bos.health.v1.HealthCheck.Bounds
-	(*HealthCheck_Faults)(nil),                     // 20: smartcore.bos.health.v1.HealthCheck.Faults
-	(*HealthCheck_ComplianceImpact_Standard)(nil),  // 21: smartcore.bos.health.v1.HealthCheck.ComplianceImpact.Standard
-	(*HealthCheck_Error_Code)(nil),                 // 22: smartcore.bos.health.v1.HealthCheck.Error.Code
-	(*HealthCheck_Reliability_Cause)(nil),          // 23: smartcore.bos.health.v1.HealthCheck.Reliability.Cause
-	(*HealthCheck_Reliability_Effects)(nil),        // 24: smartcore.bos.health.v1.HealthCheck.Reliability.Effects
-	(*PullHealthChecksResponse_Change)(nil),        // 25: smartcore.bos.health.v1.PullHealthChecksResponse.Change
-	(*PullHealthCheckResponse_Change)(nil),         // 26: smartcore.bos.health.v1.PullHealthCheckResponse.Change
-	(*timestamppb.Timestamp)(nil),                  // 27: google.protobuf.Timestamp
-	(*fieldmaskpb.FieldMask)(nil),                  // 28: google.protobuf.FieldMask
-	(*durationpb.Duration)(nil),                    // 29: google.protobuf.Duration
-	(typespb.ChangeType)(0),                        // 30: smartcore.bos.types.v1.ChangeType
+	(HealthCheck_Deviation)(0),                     // 3: smartcore.bos.health.v1.HealthCheck.Deviation
+	(HealthCheck_ComplianceImpact_Contribution)(0), // 4: smartcore.bos.health.v1.HealthCheck.ComplianceImpact.Contribution
+	(HealthCheck_Reliability_State)(0),             // 5: smartcore.bos.health.v1.HealthCheck.Reliability.State
+	(*HealthCheck)(nil),                            // 6: smartcore.bos.health.v1.HealthCheck
+	(*ListHealthChecksRequest)(nil),                // 7: smartcore.bos.health.v1.ListHealthChecksRequest
+	(*ListHealthChecksResponse)(nil),               // 8: smartcore.bos.health.v1.ListHealthChecksResponse
+	(*PullHealthChecksRequest)(nil),                // 9: smartcore.bos.health.v1.PullHealthChecksRequest
+	(*PullHealthChecksResponse)(nil),               // 10: smartcore.bos.health.v1.PullHealthChecksResponse
+	(*GetHealthCheckRequest)(nil),                  // 11: smartcore.bos.health.v1.GetHealthCheckRequest
+	(*PullHealthCheckRequest)(nil),                 // 12: smartcore.bos.health.v1.PullHealthCheckRequest
+	(*PullHealthCheckResponse)(nil),                // 13: smartcore.bos.health.v1.PullHealthCheckResponse
+	(*HealthCheck_ComplianceImpact)(nil),           // 14: smartcore.bos.health.v1.HealthCheck.ComplianceImpact
+	(*HealthCheck_Error)(nil),                      // 15: smartcore.bos.health.v1.HealthCheck.Error
+	(*HealthCheck_Reliability)(nil),                // 16: smartcore.bos.health.v1.HealthCheck.Reliability
+	(*HealthCheck_Value)(nil),                      // 17: smartcore.bos.health.v1.HealthCheck.Value
+	(*HealthCheck_ValueRange)(nil),                 // 18: smartcore.bos.health.v1.HealthCheck.ValueRange
+	(*HealthCheck_Values)(nil),                     // 19: smartcore.bos.health.v1.HealthCheck.Values
+	(*HealthCheck_Bounds)(nil),                     // 20: smartcore.bos.health.v1.HealthCheck.Bounds
+	(*HealthCheck_Faults)(nil),                     // 21: smartcore.bos.health.v1.HealthCheck.Faults
+	(*HealthCheck_ComplianceImpact_Standard)(nil),  // 22: smartcore.bos.health.v1.HealthCheck.ComplianceImpact.Standard
+	(*HealthCheck_Error_Code)(nil),                 // 23: smartcore.bos.health.v1.HealthCheck.Error.Code
+	(*HealthCheck_Reliability_Cause)(nil),          // 24: smartcore.bos.health.v1.HealthCheck.Reliability.Cause
+	(*HealthCheck_Reliability_Effects)(nil),        // 25: smartcore.bos.health.v1.HealthCheck.Reliability.Effects
+	(*PullHealthChecksResponse_Change)(nil),        // 26: smartcore.bos.health.v1.PullHealthChecksResponse.Change
+	(*PullHealthCheckResponse_Change)(nil),         // 27: smartcore.bos.health.v1.PullHealthCheckResponse.Change
+	(*timestamppb.Timestamp)(nil),                  // 28: google.protobuf.Timestamp
+	(*fieldmaskpb.FieldMask)(nil),                  // 29: google.protobuf.FieldMask
+	(*durationpb.Duration)(nil),                    // 30: google.protobuf.Duration
+	(typespb.ChangeType)(0),                        // 31: smartcore.bos.types.v1.ChangeType
 }
 var file_smartcore_bos_health_v1_health_proto_depIdxs = []int32{
-	27, // 0: smartcore.bos.health.v1.HealthCheck.create_time:type_name -> google.protobuf.Timestamp
+	28, // 0: smartcore.bos.health.v1.HealthCheck.create_time:type_name -> google.protobuf.Timestamp
 	0,  // 1: smartcore.bos.health.v1.HealthCheck.occupant_impact:type_name -> smartcore.bos.health.v1.HealthCheck.OccupantImpact
 	1,  // 2: smartcore.bos.health.v1.HealthCheck.equipment_impact:type_name -> smartcore.bos.health.v1.HealthCheck.EquipmentImpact
-	13, // 3: smartcore.bos.health.v1.HealthCheck.compliance_impacts:type_name -> smartcore.bos.health.v1.HealthCheck.ComplianceImpact
-	15, // 4: smartcore.bos.health.v1.HealthCheck.reliability:type_name -> smartcore.bos.health.v1.HealthCheck.Reliability
+	14, // 3: smartcore.bos.health.v1.HealthCheck.compliance_impacts:type_name -> smartcore.bos.health.v1.HealthCheck.ComplianceImpact
+	16, // 4: smartcore.bos.health.v1.HealthCheck.reliability:type_name -> smartcore.bos.health.v1.HealthCheck.Reliability
 	2,  // 5: smartcore.bos.health.v1.HealthCheck.normality:type_name -> smartcore.bos.health.v1.HealthCheck.Normality
-	27, // 6: smartcore.bos.health.v1.HealthCheck.normal_time:type_name -> google.protobuf.Timestamp
-	27, // 7: smartcore.bos.health.v1.HealthCheck.abnormal_time:type_name -> google.protobuf.Timestamp
-	19, // 8: smartcore.bos.health.v1.HealthCheck.bounds:type_name -> smartcore.bos.health.v1.HealthCheck.Bounds
-	20, // 9: smartcore.bos.health.v1.HealthCheck.faults:type_name -> smartcore.bos.health.v1.HealthCheck.Faults
-	28, // 10: smartcore.bos.health.v1.ListHealthChecksRequest.read_mask:type_name -> google.protobuf.FieldMask
-	5,  // 11: smartcore.bos.health.v1.ListHealthChecksResponse.health_checks:type_name -> smartcore.bos.health.v1.HealthCheck
-	28, // 12: smartcore.bos.health.v1.PullHealthChecksRequest.read_mask:type_name -> google.protobuf.FieldMask
-	25, // 13: smartcore.bos.health.v1.PullHealthChecksResponse.changes:type_name -> smartcore.bos.health.v1.PullHealthChecksResponse.Change
-	28, // 14: smartcore.bos.health.v1.GetHealthCheckRequest.read_mask:type_name -> google.protobuf.FieldMask
-	28, // 15: smartcore.bos.health.v1.PullHealthCheckRequest.read_mask:type_name -> google.protobuf.FieldMask
-	26, // 16: smartcore.bos.health.v1.PullHealthCheckResponse.changes:type_name -> smartcore.bos.health.v1.PullHealthCheckResponse.Change
-	21, // 17: smartcore.bos.health.v1.HealthCheck.ComplianceImpact.standard:type_name -> smartcore.bos.health.v1.HealthCheck.ComplianceImpact.Standard
-	3,  // 18: smartcore.bos.health.v1.HealthCheck.ComplianceImpact.contribution:type_name -> smartcore.bos.health.v1.HealthCheck.ComplianceImpact.Contribution
-	22, // 19: smartcore.bos.health.v1.HealthCheck.Error.code:type_name -> smartcore.bos.health.v1.HealthCheck.Error.Code
-	4,  // 20: smartcore.bos.health.v1.HealthCheck.Reliability.state:type_name -> smartcore.bos.health.v1.HealthCheck.Reliability.State
-	27, // 21: smartcore.bos.health.v1.HealthCheck.Reliability.reliable_time:type_name -> google.protobuf.Timestamp
-	27, // 22: smartcore.bos.health.v1.HealthCheck.Reliability.unreliable_time:type_name -> google.protobuf.Timestamp
-	14, // 23: smartcore.bos.health.v1.HealthCheck.Reliability.last_error:type_name -> smartcore.bos.health.v1.HealthCheck.Error
-	23, // 24: smartcore.bos.health.v1.HealthCheck.Reliability.cause:type_name -> smartcore.bos.health.v1.HealthCheck.Reliability.Cause
-	24, // 25: smartcore.bos.health.v1.HealthCheck.Reliability.effects:type_name -> smartcore.bos.health.v1.HealthCheck.Reliability.Effects
-	27, // 26: smartcore.bos.health.v1.HealthCheck.Value.timestamp_value:type_name -> google.protobuf.Timestamp
-	29, // 27: smartcore.bos.health.v1.HealthCheck.Value.duration_value:type_name -> google.protobuf.Duration
-	16, // 28: smartcore.bos.health.v1.HealthCheck.ValueRange.low:type_name -> smartcore.bos.health.v1.HealthCheck.Value
-	16, // 29: smartcore.bos.health.v1.HealthCheck.ValueRange.high:type_name -> smartcore.bos.health.v1.HealthCheck.Value
-	16, // 30: smartcore.bos.health.v1.HealthCheck.ValueRange.deadband:type_name -> smartcore.bos.health.v1.HealthCheck.Value
-	16, // 31: smartcore.bos.health.v1.HealthCheck.Values.values:type_name -> smartcore.bos.health.v1.HealthCheck.Value
-	16, // 32: smartcore.bos.health.v1.HealthCheck.Bounds.current_value:type_name -> smartcore.bos.health.v1.HealthCheck.Value
-	16, // 33: smartcore.bos.health.v1.HealthCheck.Bounds.normal_value:type_name -> smartcore.bos.health.v1.HealthCheck.Value
-	16, // 34: smartcore.bos.health.v1.HealthCheck.Bounds.abnormal_value:type_name -> smartcore.bos.health.v1.HealthCheck.Value
-	17, // 35: smartcore.bos.health.v1.HealthCheck.Bounds.normal_range:type_name -> smartcore.bos.health.v1.HealthCheck.ValueRange
-	18, // 36: smartcore.bos.health.v1.HealthCheck.Bounds.normal_values:type_name -> smartcore.bos.health.v1.HealthCheck.Values
-	18, // 37: smartcore.bos.health.v1.HealthCheck.Bounds.abnormal_values:type_name -> smartcore.bos.health.v1.HealthCheck.Values
-	14, // 38: smartcore.bos.health.v1.HealthCheck.Faults.current_faults:type_name -> smartcore.bos.health.v1.HealthCheck.Error
-	14, // 39: smartcore.bos.health.v1.HealthCheck.Reliability.Cause.error:type_name -> smartcore.bos.health.v1.HealthCheck.Error
-	30, // 40: smartcore.bos.health.v1.PullHealthChecksResponse.Change.type:type_name -> smartcore.bos.types.v1.ChangeType
-	5,  // 41: smartcore.bos.health.v1.PullHealthChecksResponse.Change.new_value:type_name -> smartcore.bos.health.v1.HealthCheck
-	5,  // 42: smartcore.bos.health.v1.PullHealthChecksResponse.Change.old_value:type_name -> smartcore.bos.health.v1.HealthCheck
-	27, // 43: smartcore.bos.health.v1.PullHealthChecksResponse.Change.change_time:type_name -> google.protobuf.Timestamp
-	5,  // 44: smartcore.bos.health.v1.PullHealthCheckResponse.Change.health_check:type_name -> smartcore.bos.health.v1.HealthCheck
-	27, // 45: smartcore.bos.health.v1.PullHealthCheckResponse.Change.change_time:type_name -> google.protobuf.Timestamp
-	6,  // 46: smartcore.bos.health.v1.HealthApi.ListHealthChecks:input_type -> smartcore.bos.health.v1.ListHealthChecksRequest
-	8,  // 47: smartcore.bos.health.v1.HealthApi.PullHealthChecks:input_type -> smartcore.bos.health.v1.PullHealthChecksRequest
-	10, // 48: smartcore.bos.health.v1.HealthApi.GetHealthCheck:input_type -> smartcore.bos.health.v1.GetHealthCheckRequest
-	11, // 49: smartcore.bos.health.v1.HealthApi.PullHealthCheck:input_type -> smartcore.bos.health.v1.PullHealthCheckRequest
-	7,  // 50: smartcore.bos.health.v1.HealthApi.ListHealthChecks:output_type -> smartcore.bos.health.v1.ListHealthChecksResponse
-	9,  // 51: smartcore.bos.health.v1.HealthApi.PullHealthChecks:output_type -> smartcore.bos.health.v1.PullHealthChecksResponse
-	5,  // 52: smartcore.bos.health.v1.HealthApi.GetHealthCheck:output_type -> smartcore.bos.health.v1.HealthCheck
-	12, // 53: smartcore.bos.health.v1.HealthApi.PullHealthCheck:output_type -> smartcore.bos.health.v1.PullHealthCheckResponse
-	50, // [50:54] is the sub-list for method output_type
-	46, // [46:50] is the sub-list for method input_type
-	46, // [46:46] is the sub-list for extension type_name
-	46, // [46:46] is the sub-list for extension extendee
-	0,  // [0:46] is the sub-list for field type_name
+	28, // 6: smartcore.bos.health.v1.HealthCheck.normal_time:type_name -> google.protobuf.Timestamp
+	28, // 7: smartcore.bos.health.v1.HealthCheck.abnormal_time:type_name -> google.protobuf.Timestamp
+	3,  // 8: smartcore.bos.health.v1.HealthCheck.deviation:type_name -> smartcore.bos.health.v1.HealthCheck.Deviation
+	20, // 9: smartcore.bos.health.v1.HealthCheck.bounds:type_name -> smartcore.bos.health.v1.HealthCheck.Bounds
+	21, // 10: smartcore.bos.health.v1.HealthCheck.faults:type_name -> smartcore.bos.health.v1.HealthCheck.Faults
+	29, // 11: smartcore.bos.health.v1.ListHealthChecksRequest.read_mask:type_name -> google.protobuf.FieldMask
+	6,  // 12: smartcore.bos.health.v1.ListHealthChecksResponse.health_checks:type_name -> smartcore.bos.health.v1.HealthCheck
+	29, // 13: smartcore.bos.health.v1.PullHealthChecksRequest.read_mask:type_name -> google.protobuf.FieldMask
+	26, // 14: smartcore.bos.health.v1.PullHealthChecksResponse.changes:type_name -> smartcore.bos.health.v1.PullHealthChecksResponse.Change
+	29, // 15: smartcore.bos.health.v1.GetHealthCheckRequest.read_mask:type_name -> google.protobuf.FieldMask
+	29, // 16: smartcore.bos.health.v1.PullHealthCheckRequest.read_mask:type_name -> google.protobuf.FieldMask
+	27, // 17: smartcore.bos.health.v1.PullHealthCheckResponse.changes:type_name -> smartcore.bos.health.v1.PullHealthCheckResponse.Change
+	22, // 18: smartcore.bos.health.v1.HealthCheck.ComplianceImpact.standard:type_name -> smartcore.bos.health.v1.HealthCheck.ComplianceImpact.Standard
+	4,  // 19: smartcore.bos.health.v1.HealthCheck.ComplianceImpact.contribution:type_name -> smartcore.bos.health.v1.HealthCheck.ComplianceImpact.Contribution
+	23, // 20: smartcore.bos.health.v1.HealthCheck.Error.code:type_name -> smartcore.bos.health.v1.HealthCheck.Error.Code
+	5,  // 21: smartcore.bos.health.v1.HealthCheck.Reliability.state:type_name -> smartcore.bos.health.v1.HealthCheck.Reliability.State
+	28, // 22: smartcore.bos.health.v1.HealthCheck.Reliability.reliable_time:type_name -> google.protobuf.Timestamp
+	28, // 23: smartcore.bos.health.v1.HealthCheck.Reliability.unreliable_time:type_name -> google.protobuf.Timestamp
+	15, // 24: smartcore.bos.health.v1.HealthCheck.Reliability.last_error:type_name -> smartcore.bos.health.v1.HealthCheck.Error
+	24, // 25: smartcore.bos.health.v1.HealthCheck.Reliability.cause:type_name -> smartcore.bos.health.v1.HealthCheck.Reliability.Cause
+	25, // 26: smartcore.bos.health.v1.HealthCheck.Reliability.effects:type_name -> smartcore.bos.health.v1.HealthCheck.Reliability.Effects
+	28, // 27: smartcore.bos.health.v1.HealthCheck.Value.timestamp_value:type_name -> google.protobuf.Timestamp
+	30, // 28: smartcore.bos.health.v1.HealthCheck.Value.duration_value:type_name -> google.protobuf.Duration
+	17, // 29: smartcore.bos.health.v1.HealthCheck.ValueRange.low:type_name -> smartcore.bos.health.v1.HealthCheck.Value
+	17, // 30: smartcore.bos.health.v1.HealthCheck.ValueRange.high:type_name -> smartcore.bos.health.v1.HealthCheck.Value
+	17, // 31: smartcore.bos.health.v1.HealthCheck.ValueRange.deadband:type_name -> smartcore.bos.health.v1.HealthCheck.Value
+	17, // 32: smartcore.bos.health.v1.HealthCheck.Values.values:type_name -> smartcore.bos.health.v1.HealthCheck.Value
+	17, // 33: smartcore.bos.health.v1.HealthCheck.Bounds.current_value:type_name -> smartcore.bos.health.v1.HealthCheck.Value
+	17, // 34: smartcore.bos.health.v1.HealthCheck.Bounds.normal_value:type_name -> smartcore.bos.health.v1.HealthCheck.Value
+	17, // 35: smartcore.bos.health.v1.HealthCheck.Bounds.abnormal_value:type_name -> smartcore.bos.health.v1.HealthCheck.Value
+	18, // 36: smartcore.bos.health.v1.HealthCheck.Bounds.normal_range:type_name -> smartcore.bos.health.v1.HealthCheck.ValueRange
+	19, // 37: smartcore.bos.health.v1.HealthCheck.Bounds.normal_values:type_name -> smartcore.bos.health.v1.HealthCheck.Values
+	19, // 38: smartcore.bos.health.v1.HealthCheck.Bounds.abnormal_values:type_name -> smartcore.bos.health.v1.HealthCheck.Values
+	15, // 39: smartcore.bos.health.v1.HealthCheck.Faults.current_faults:type_name -> smartcore.bos.health.v1.HealthCheck.Error
+	15, // 40: smartcore.bos.health.v1.HealthCheck.Reliability.Cause.error:type_name -> smartcore.bos.health.v1.HealthCheck.Error
+	31, // 41: smartcore.bos.health.v1.PullHealthChecksResponse.Change.type:type_name -> smartcore.bos.types.v1.ChangeType
+	6,  // 42: smartcore.bos.health.v1.PullHealthChecksResponse.Change.new_value:type_name -> smartcore.bos.health.v1.HealthCheck
+	6,  // 43: smartcore.bos.health.v1.PullHealthChecksResponse.Change.old_value:type_name -> smartcore.bos.health.v1.HealthCheck
+	28, // 44: smartcore.bos.health.v1.PullHealthChecksResponse.Change.change_time:type_name -> google.protobuf.Timestamp
+	6,  // 45: smartcore.bos.health.v1.PullHealthCheckResponse.Change.health_check:type_name -> smartcore.bos.health.v1.HealthCheck
+	28, // 46: smartcore.bos.health.v1.PullHealthCheckResponse.Change.change_time:type_name -> google.protobuf.Timestamp
+	7,  // 47: smartcore.bos.health.v1.HealthApi.ListHealthChecks:input_type -> smartcore.bos.health.v1.ListHealthChecksRequest
+	9,  // 48: smartcore.bos.health.v1.HealthApi.PullHealthChecks:input_type -> smartcore.bos.health.v1.PullHealthChecksRequest
+	11, // 49: smartcore.bos.health.v1.HealthApi.GetHealthCheck:input_type -> smartcore.bos.health.v1.GetHealthCheckRequest
+	12, // 50: smartcore.bos.health.v1.HealthApi.PullHealthCheck:input_type -> smartcore.bos.health.v1.PullHealthCheckRequest
+	8,  // 51: smartcore.bos.health.v1.HealthApi.ListHealthChecks:output_type -> smartcore.bos.health.v1.ListHealthChecksResponse
+	10, // 52: smartcore.bos.health.v1.HealthApi.PullHealthChecks:output_type -> smartcore.bos.health.v1.PullHealthChecksResponse
+	6,  // 53: smartcore.bos.health.v1.HealthApi.GetHealthCheck:output_type -> smartcore.bos.health.v1.HealthCheck
+	13, // 54: smartcore.bos.health.v1.HealthApi.PullHealthCheck:output_type -> smartcore.bos.health.v1.PullHealthCheckResponse
+	51, // [51:55] is the sub-list for method output_type
+	47, // [47:51] is the sub-list for method input_type
+	47, // [47:47] is the sub-list for extension type_name
+	47, // [47:47] is the sub-list for extension extendee
+	0,  // [0:47] is the sub-list for field type_name
 }
 
 func init() { file_smartcore_bos_health_v1_health_proto_init() }
@@ -2427,7 +2504,7 @@ func file_smartcore_bos_health_v1_health_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_smartcore_bos_health_v1_health_proto_rawDesc), len(file_smartcore_bos_health_v1_health_proto_rawDesc)),
-			NumEnums:      5,
+			NumEnums:      6,
 			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/pkg/proto/healthpb/value.go
+++ b/pkg/proto/healthpb/value.go
@@ -77,3 +77,29 @@ func AddValues(val, delta *HealthCheck_Value) *HealthCheck_Value {
 	}
 	return val
 }
+
+// valueAsFloat converts an ordered value to a float64 for magnitude calculations.
+// It returns ok=false for bool and string values, which have no meaningful
+// numeric magnitude. Timestamps use Unix nanoseconds; durations use nanoseconds.
+func valueAsFloat(v *HealthCheck_Value) (float64, bool) {
+	switch x := v.GetValue().(type) {
+	case *HealthCheck_Value_IntValue:
+		return float64(x.IntValue), true
+	case *HealthCheck_Value_UintValue:
+		return float64(x.UintValue), true
+	case *HealthCheck_Value_FloatValue:
+		return x.FloatValue, true
+	case *HealthCheck_Value_TimestampValue:
+		return float64(x.TimestampValue.AsTime().UnixNano()), true
+	case *HealthCheck_Value_DurationValue:
+		return float64(x.DurationValue.AsDuration().Nanoseconds()), true
+	}
+	return 0, false
+}
+
+// isTimestampValue reports whether v holds a timestamp. Timestamps are measured
+// from an arbitrary epoch, so their absolute magnitude is not a meaningful scale.
+func isTimestampValue(v *HealthCheck_Value) bool {
+	_, ok := v.GetValue().(*HealthCheck_Value_TimestampValue)
+	return ok
+}

--- a/proto/smartcore/bos/health/v1/health.proto
+++ b/proto/smartcore/bos/health/v1/health.proto
@@ -306,6 +306,23 @@ message HealthCheck {
   // The time when normality last entered a non-NORMAL state.
   google.protobuf.Timestamp abnormal_time = 23;
 
+  // Deviation describes how far a measured value is from its expected range,
+  // bucketed so it can be filtered without exposing the measured value itself.
+  // It is only meaningful for range (normal_range) bounds checks; it is
+  // DEVIATION_UNSPECIFIED when the value is within range, or for equality and
+  // value-set checks, which have no magnitude.
+  enum Deviation {
+    DEVIATION_UNSPECIFIED = 0;
+    // The value is only slightly outside its expected range.
+    MINOR = 1;
+    // The value is moderately outside its expected range.
+    MODERATE = 2;
+    // The value is far outside its expected range.
+    MAJOR = 3;
+  }
+  // Deviation is the bucketed magnitude of a range-check excursion.
+  Deviation deviation = 24;
+
   // Bounds describes a check that compares a measured value against expected values or ranges.
   message Bounds {
     // The measured value.

--- a/ui/ops/src/traits/health/DeviationText.vue
+++ b/ui/ops/src/traits/health/DeviationText.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-chip
+      v-if="label"
+      :color="color"
+      size="x-small"
+      variant="tonal"
+      label>
+    {{ label }}
+  </v-chip>
+</template>
+
+<script setup>
+import {HealthCheck} from '@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/health/v1/health_pb';
+import {computed} from 'vue';
+
+const props = defineProps({
+  modelValue: {
+    /** @type {import('vue').PropType<import('@smart-core-os/sc-bos-ui-gen/proto/smartcore/bos/health/v1/health_pb').HealthCheck.AsObject>} */
+    type: Object,
+    default: null
+  }
+});
+
+const label = computed(() => {
+  switch (props.modelValue?.deviation ?? 0) {
+    case HealthCheck.Deviation.MINOR:
+      return 'Minor';
+    case HealthCheck.Deviation.MODERATE:
+      return 'Moderate';
+    case HealthCheck.Deviation.MAJOR:
+      return 'Major';
+    default:
+      return '';
+  }
+});
+
+const color = computed(() => {
+  switch (props.modelValue?.deviation ?? 0) {
+    case HealthCheck.Deviation.MINOR:
+      return 'info';
+    case HealthCheck.Deviation.MODERATE:
+      return 'warning';
+    case HealthCheck.Deviation.MAJOR:
+      return 'error';
+    default:
+      return undefined;
+  }
+});
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/ops/src/traits/health/HealthCheckRow.vue
+++ b/ui/ops/src/traits/health/HealthCheckRow.vue
@@ -8,7 +8,10 @@
       <reliability-time-text :model-value="props.modelValue"/>
     </td>
     <td>
-      <bounds-text v-if="hasBounds" :model-value="props.modelValue" class="ml-1"/>
+      <template v-if="hasBounds">
+        <bounds-text :model-value="props.modelValue" class="ml-1"/>
+        <deviation-text :model-value="props.modelValue" class="ml-2"/>
+      </template>
       <faults-text v-else-if="hasFaults" :model-value="props.modelValue"/>
       <template v-else-if="lastErrorSummary">
         <div class="text-caption text-medium-emphasis">{{ lastErrorSummary }}</div>
@@ -23,6 +26,7 @@
 
 <script setup>
 import BoundsText from '@/traits/health/BoundsText.vue';
+import DeviationText from '@/traits/health/DeviationText.vue';
 import FaultsText from '@/traits/health/FaultsText.vue';
 import ImpactsText from '@/traits/health/ImpactsText.vue';
 import NormalityTimeText from '@/traits/health/NormalityTimeText.vue';

--- a/ui/ops/src/traits/health/health.js
+++ b/ui/ops/src/traits/health/health.js
@@ -247,6 +247,22 @@ export function useHealthCheckFilters(forcedFilters) {
       });
     }
 
+    if (!Object.hasOwn(forced, 'health_checks.deviation')) {
+      // The chosen bucket is treated as a minimum: selecting Moderate also matches
+      // Major (see toCondition), so users can hide barely-out-of-range checks.
+      filters.push({
+        key: 'health_checks.deviation',
+        icon: 'mdi-arrow-expand-vertical',
+        title: 'Deviation',
+        type: 'list',
+        items: [
+          {title: 'Minor', value: HealthCheck.Deviation.MINOR},
+          {title: 'Moderate', value: HealthCheck.Deviation.MODERATE},
+          {title: 'Major', value: HealthCheck.Deviation.MAJOR}
+        ]
+      });
+    }
+
     return {filters, defaults};
   });
 
@@ -270,6 +286,31 @@ export function useHealthCheckFilters(forcedFilters) {
         const numVal = value?.value ?? value;
         const enumName = enumValueToName(HealthCheck.EquipmentImpact, numVal);
         return {field: 'health_checks.equipment_impact', stringEqual: enumName};
+      }
+      case 'health_checks.deviation': {
+        // Minimum deviation: match the chosen bucket and every more-severe one.
+        const numVal = value?.value ?? value;
+        const stringsList = [
+          HealthCheck.Deviation.MINOR,
+          HealthCheck.Deviation.MODERATE,
+          HealthCheck.Deviation.MAJOR
+        ]
+            .filter(v => v >= numVal)
+            .map(v => enumValueToName(HealthCheck.Deviation, v));
+        // Deviation only exists for range checks, which report HIGH/LOW; equality
+        // and value-set faults report ABNORMAL with no deviation. Match, per health
+        // check, either a sufficient range excursion OR a hard ABNORMAL fault, so
+        // filtering by deviation narrows the range excursions shown without ever
+        // hiding a genuinely-abnormal device that has no range check.
+        return {
+          field: 'health_checks',
+          anyOf: {
+            queriesList: [
+              {conditionsList: [{field: 'deviation', stringIn: {stringsList}}]},
+              {conditionsList: [{field: 'normality', stringEqual: 'ABNORMAL'}]}
+            ]
+          }
+        };
       }
       default:
         return {field: field, stringEqualFold: value};

--- a/ui/ui-gen/proto/smartcore/bos/health/v1/health_pb.d.ts
+++ b/ui/ui-gen/proto/smartcore/bos/health/v1/health_pb.d.ts
@@ -50,6 +50,9 @@ export class HealthCheck extends jspb.Message {
   hasAbnormalTime(): boolean;
   clearAbnormalTime(): HealthCheck;
 
+  getDeviation(): HealthCheck.Deviation;
+  setDeviation(value: HealthCheck.Deviation): HealthCheck;
+
   getBounds(): HealthCheck.Bounds | undefined;
   setBounds(value?: HealthCheck.Bounds): HealthCheck;
   hasBounds(): boolean;
@@ -83,6 +86,7 @@ export namespace HealthCheck {
     normality: HealthCheck.Normality;
     normalTime?: google_protobuf_timestamp_pb.Timestamp.AsObject;
     abnormalTime?: google_protobuf_timestamp_pb.Timestamp.AsObject;
+    deviation: HealthCheck.Deviation;
     bounds?: HealthCheck.Bounds.AsObject;
     faults?: HealthCheck.Faults.AsObject;
   };
@@ -550,6 +554,13 @@ export namespace HealthCheck {
     ABNORMAL = 2,
     LOW = 3,
     HIGH = 4,
+  }
+
+  export enum Deviation {
+    DEVIATION_UNSPECIFIED = 0,
+    MINOR = 1,
+    MODERATE = 2,
+    MAJOR = 3,
   }
 
   export enum CheckCase {

--- a/ui/ui-gen/proto/smartcore/bos/health/v1/health_pb.js
+++ b/ui/ui-gen/proto/smartcore/bos/health/v1/health_pb.js
@@ -31,6 +31,7 @@ goog.exportSymbol('proto.smartcore.bos.health.v1.HealthCheck.CheckCase', null, g
 goog.exportSymbol('proto.smartcore.bos.health.v1.HealthCheck.ComplianceImpact', null, global);
 goog.exportSymbol('proto.smartcore.bos.health.v1.HealthCheck.ComplianceImpact.Contribution', null, global);
 goog.exportSymbol('proto.smartcore.bos.health.v1.HealthCheck.ComplianceImpact.Standard', null, global);
+goog.exportSymbol('proto.smartcore.bos.health.v1.HealthCheck.Deviation', null, global);
 goog.exportSymbol('proto.smartcore.bos.health.v1.HealthCheck.EquipmentImpact', null, global);
 goog.exportSymbol('proto.smartcore.bos.health.v1.HealthCheck.Error', null, global);
 goog.exportSymbol('proto.smartcore.bos.health.v1.HealthCheck.Error.Code', null, global);
@@ -592,6 +593,7 @@ reliability: (f = msg.getReliability()) && proto.smartcore.bos.health.v1.HealthC
 normality: jspb.Message.getFieldWithDefault(msg, 21, 0),
 normalTime: (f = msg.getNormalTime()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
 abnormalTime: (f = msg.getAbnormalTime()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
+deviation: jspb.Message.getFieldWithDefault(msg, 24, 0),
 bounds: (f = msg.getBounds()) && proto.smartcore.bos.health.v1.HealthCheck.Bounds.toObject(includeInstance, f),
 faults: (f = msg.getFaults()) && proto.smartcore.bos.health.v1.HealthCheck.Faults.toObject(includeInstance, f)
   };
@@ -678,6 +680,10 @@ proto.smartcore.bos.health.v1.HealthCheck.deserializeBinaryFromReader = function
       var value = new google_protobuf_timestamp_pb.Timestamp;
       reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
       msg.setAbnormalTime(value);
+      break;
+    case 24:
+      var value = /** @type {!proto.smartcore.bos.health.v1.HealthCheck.Deviation} */ (reader.readEnum());
+      msg.setDeviation(value);
       break;
     case 30:
       var value = new proto.smartcore.bos.health.v1.HealthCheck.Bounds;
@@ -800,6 +806,13 @@ proto.smartcore.bos.health.v1.HealthCheck.serializeBinaryToWriter = function(mes
       google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
     );
   }
+  f = message.getDeviation();
+  if (f !== 0.0) {
+    writer.writeEnum(
+      24,
+      f
+    );
+  }
   f = message.getBounds();
   if (f != null) {
     writer.writeMessage(
@@ -851,6 +864,16 @@ proto.smartcore.bos.health.v1.HealthCheck.Normality = {
   ABNORMAL: 2,
   LOW: 3,
   HIGH: 4
+};
+
+/**
+ * @enum {number}
+ */
+proto.smartcore.bos.health.v1.HealthCheck.Deviation = {
+  DEVIATION_UNSPECIFIED: 0,
+  MINOR: 1,
+  MODERATE: 2,
+  MAJOR: 3
 };
 
 
@@ -4209,6 +4232,24 @@ proto.smartcore.bos.health.v1.HealthCheck.prototype.clearAbnormalTime = function
  */
 proto.smartcore.bos.health.v1.HealthCheck.prototype.hasAbnormalTime = function() {
   return jspb.Message.getField(this, 23) != null;
+};
+
+
+/**
+ * optional Deviation deviation = 24;
+ * @return {!proto.smartcore.bos.health.v1.HealthCheck.Deviation}
+ */
+proto.smartcore.bos.health.v1.HealthCheck.prototype.getDeviation = function() {
+  return /** @type {!proto.smartcore.bos.health.v1.HealthCheck.Deviation} */ (jspb.Message.getFieldWithDefault(this, 24, 0));
+};
+
+
+/**
+ * @param {!proto.smartcore.bos.health.v1.HealthCheck.Deviation} value
+ * @return {!proto.smartcore.bos.health.v1.HealthCheck} returns this
+ */
+proto.smartcore.bos.health.v1.HealthCheck.prototype.setDeviation = function(value) {
+  return jspb.Message.setProto3EnumField(this, 24, value);
 };
 
 


### PR DESCRIPTION
Small range-check infractions — a humidity reading of 60.2% against a 30–60% band, a temperature a fraction over 24°C — flooded the health dashboard and drowned out the excursions operators actually care about. There was no way to filter by *how far* out of range a check sits, and because the measured value is deliberately stripped from embedded device health checks (and the device query engine has no numeric comparison), the magnitude has to be precomputed and bucketed into something the string query can match.

This adds a top-level `HealthCheck.Deviation` enum (`MINOR`/`MODERATE`/`MAJOR`), computed in the shared `healthpb` bounds engine alongside `normality`: the overshoot past the crossed bound as a fraction of the range width (or the bound's own magnitude for open-ended ranges), bucketed at 10% / 25%. Deadband-held states and values that have returned inside the range report `UNSPECIFIED`; open-ended *timestamp* ranges have no meaningful scale so stay unbucketed. The ops dashboard gains a "Deviation" filter — treated as a minimum severity, and OR'd with hard `ABNORMAL` faults so non-range faults are never hidden — plus a severity chip in the check row.

Two deliberate departures from the SCB-1382 sketch: the field is named `Deviation` rather than `Severity`, and the 10%/25% thresholds are fixed in code rather than per-automation config (simpler; easy to revisit). Computing it in `healthpb` rather than the `healthbounds` factory means every bounds producer gets it for free, and the field survives both `removeMeasuredValues` and the history `splitCheck`. The deferred UI unit test is tracked in SCB-1403 (blocked on the vitest harness, SCB-1400).

Verified by `go test ./pkg/proto/healthpb/...` (new deadband + timestamp cases), `go build ./...` + `go vet`, proto regenerated via WSL, ops UI `lint:nofix` clean, and the chip + filter rendered end-to-end in a Vuetify harness (all four chip states plus the filter dropdown).

#SCB-1382 State Done
