### PR TITLE
auth/policy: audit in-process gRPC writes (SCB-1411)

### DIFF
--- a/internal/node/nodeopts/options.go
+++ b/internal/node/nodeopts/options.go
@@ -4,6 +4,8 @@ package nodeopts
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	"github.com/smart-core-os/sc-bos/internal/router"
 	"github.com/smart-core-os/sc-bos/pkg/proto/devicespb"
 	"github.com/smart-core-os/sc-bos/pkg/resource"
@@ -33,6 +35,15 @@ func WithRouter(r *router.Router) Option {
 	})
 }
 
+// WithClientConnWrapper sets a decorator applied to the connection returned by Node.ClientConn.
+// Every in-process caller obtains its connection from that method, so the wrapper sees all
+// in-process traffic. Used to audit writes that never reach the gRPC server's interceptors.
+func WithClientConnWrapper(wrapper func(grpc.ClientConnInterface) grpc.ClientConnInterface) Option {
+	return optionFunc(func(o *Struct) {
+		o.ClientConnWrapper = wrapper
+	})
+}
+
 // Join combines multiple options into a single struct.
 func Join(opts ...Option) Struct {
 	var o Struct
@@ -44,13 +55,17 @@ func Join(opts ...Option) Struct {
 
 // Struct contains all options for a Node as a struct for easy access.
 type Struct struct {
-	Store  Store
-	Router *router.Router
+	Store             Store
+	Router            *router.Router
+	ClientConnWrapper func(grpc.ClientConnInterface) grpc.ClientConnInterface
 }
 
 func (s Struct) apply(o *Struct) {
 	if s.Store != nil {
 		o.Store = s.Store
+	}
+	if s.ClientConnWrapper != nil {
+		o.ClientConnWrapper = s.ClientConnWrapper
 	}
 }
 

--- a/pkg/app/controller.go
+++ b/pkg/app/controller.go
@@ -115,9 +115,20 @@ func Bootstrap(ctx context.Context, config sysconf.Config) (*Controller, error) 
 	nodeRouter := router.New(router.WithKeyInterceptor(func(key string) (string, error) {
 		return idOrNodeName(key), nil
 	}))
+	// initAuth runs before rootNode is created so the audit interceptor can be installed on the
+	// node's in-process connection; it depends only on config and logger.
+	ai := initAuth(config, logger)
+
 	// rootNode grants both local (in-process) and networked (via grpc.Server) access to controller APIs.
 	// Announce devices on rootNode to expose them via Smart Core APIs; use rootNode.Clients to call them.
-	rootNode := node.New(cName, nodeopts.WithStore(deviceStore), nodeopts.WithRouter(nodeRouter))
+	nodeOpts := []node.Option{nodeopts.WithStore(deviceStore), nodeopts.WithRouter(nodeRouter)}
+	// In-process calls bypass the grpc.Server interceptors, so audit them on the way out of the
+	// node's loopback connection instead. Writes arriving over MQTT (the UDMI automation calling
+	// UdmiService.OnMessage) take this path and would otherwise go unrecorded.
+	if ai.Interceptor != nil {
+		nodeOpts = append(nodeOpts, nodeopts.WithClientConnWrapper(ai.Interceptor.AuditClientConn))
+	}
+	rootNode := node.New(cName, nodeOpts...)
 	rootNode.Logger = logger.Named("node")
 
 	var accountStore *account.Store
@@ -162,8 +173,6 @@ func Bootstrap(ctx context.Context, config sysconf.Config) (*Controller, error) 
 	// once enrolled as the manager address is updated automatically.
 	manager := node.DialChan(ctx, pi.EnrollServer.ManagerAddress(ctx),
 		grpc.WithTransportCredentials(credentials.NewTLS(pi.GRPCClient)))
-
-	ai := initAuth(config, logger)
 
 	grpcServer, reflectionServer := buildGRPCServer(rootNode, nodeRouter, pi, ai)
 

--- a/pkg/auth/policy/interceptor.go
+++ b/pkg/auth/policy/interceptor.go
@@ -226,9 +226,9 @@ func (i *Interceptor) checkPolicyGrpc(ctx context.Context, creds *verifiedCreds,
 	}
 	// Only audit once per RPC, not for every message on an open client/bidirectional stream.
 	if isWriteMethod(method) && !isAuditExcluded(service, method) && !stream.Open {
-		outcome := "allowed"
+		outcome := outcomeAllowed
 		if err != nil {
-			outcome = "denied"
+			outcome = outcomeDenied
 		}
 		i.writeAuditEntry(outcome, creds, addr,
 			auditField{"service", service},
@@ -283,9 +283,9 @@ func (i *Interceptor) checkPolicyHTTP(r *http.Request) (*verifiedCreds, error) {
 		)
 	}
 	if isHTTPWriteMethod(r.Method) {
-		outcome := "allowed"
+		outcome := outcomeAllowed
 		if err != nil {
-			outcome = "denied"
+			outcome = outcomeDenied
 		}
 		i.writeAuditEntry(outcome, creds, addr,
 			auditField{"path", r.URL.Path},
@@ -293,6 +293,69 @@ func (i *Interceptor) checkPolicyHTTP(r *http.Request) (*verifiedCreds, error) {
 		)
 	}
 	return creds, err
+}
+
+// AuditClientConn wraps cc so that write RPCs issued through it are audited.
+//
+// In-process calls originate from a loopback connection and never pass through the gRPC server
+// interceptor chain, so this is their only audit point. External traffic reaches routed services
+// via a different path (the server's unknown-service handler), so wrapping a loopback conn here
+// does not double-audit anything.
+//
+// No principal is known for an in-process call, so entries carry no subject, certificate or token.
+// Returns cc unchanged when no audit sink is configured.
+func (i *Interceptor) AuditClientConn(cc grpc.ClientConnInterface) grpc.ClientConnInterface {
+	if i == nil || i.auditQueue == nil {
+		return cc
+	}
+	return &auditingClientConn{ClientConnInterface: cc, i: i}
+}
+
+// auditingClientConn writes an audit entry for each write RPC sent through it.
+type auditingClientConn struct {
+	grpc.ClientConnInterface
+	i *Interceptor
+}
+
+func (c *auditingClientConn) Invoke(ctx context.Context, method string, args, reply any, opts ...grpc.CallOption) error {
+	err := c.ClientConnInterface.Invoke(ctx, method, args, reply, opts...)
+	c.audit(method, err)
+	return err
+}
+
+// NewStream audits at stream open. isWriteMethod filters out the Pull* streams that make up
+// almost all in-process stream traffic, so this rarely records anything, but it stops streaming
+// writes being a blind spot.
+func (c *auditingClientConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	stream, err := c.ClientConnInterface.NewStream(ctx, desc, method, opts...)
+	c.audit(method, err)
+	return stream, err
+}
+
+// audit records the outcome of an in-process call to method, if it is an audited write.
+// method is a full gRPC method path, e.g. "/smartcore.bos.udmi.v1.UdmiService/OnMessage".
+func (c *auditingClientConn) audit(method string, err error) {
+	// This runs on every in-process call and nearly all of them are reads, so reject those with a
+	// byte scan before paying for the regex-backed split.
+	slash := strings.LastIndexByte(method, '/')
+	if slash < 0 || !isWriteMethod(method[slash+1:]) {
+		return
+	}
+	service, name, ok := rpcutil.SplitMethodPath(method)
+	if !ok || isAuditExcluded(service, name) {
+		return
+	}
+	// Unlike the server interceptor there is no policy decision to report, so the outcome
+	// describes whether the call itself succeeded.
+	outcome := outcomeOK
+	if err != nil {
+		outcome = outcomeFailed
+	}
+	c.i.writeAuditEntry(outcome, nil, loopback,
+		auditField{"service", service},
+		auditField{"method", name},
+		auditField{"ingress", loopback},
+	)
 }
 
 type InterceptorOption func(interceptor *Interceptor)
@@ -358,6 +421,20 @@ func httpPeerCert(r *http.Request) *x509.Certificate {
 	return r.TLS.VerifiedChains[0][0]
 }
 
+// Audit entry outcomes. allowed/denied report a policy decision and are used for calls that
+// pass through the server interceptors. ok/failed report the result of the call itself and are
+// used for in-process calls, where no policy is evaluated.
+const (
+	outcomeAllowed = "allowed"
+	outcomeDenied  = "denied"
+	outcomeOK      = "ok"
+	outcomeFailed  = "failed"
+)
+
+// loopback is the ingress of an audit entry for an in-process call, and stands in for its peer
+// address, which does not exist. It lets consumers tell machine-originated writes from human ones.
+const loopback = "loopback"
+
 // auditField is a protocol-specific key/value pair appended to every audit entry.
 type auditField struct {
 	key   string
@@ -407,7 +484,7 @@ func (i *Interceptor) writeAuditEntry(outcome string, creds *verifiedCreds, addr
 // Called only from the background worker goroutine.
 func (i *Interceptor) doWriteAuditEntry(rec auditRecord) {
 	lvl := logpb.Level_LEVEL_INFO
-	if rec.outcome == "denied" {
+	if rec.outcome == outcomeDenied || rec.outcome == outcomeFailed {
 		lvl = logpb.Level_LEVEL_WARN
 	}
 	fields := make(map[string]string, 7+len(rec.extra))

--- a/pkg/auth/policy/interceptor_test.go
+++ b/pkg/auth/policy/interceptor_test.go
@@ -346,3 +346,149 @@ allow if input.method == "GET"
 allow if input.path == "/foo"
 `,
 }
+
+// stubConn is a ClientConnInterface that ignores the call and returns a fixed error.
+type stubConn struct{ err error }
+
+func (c stubConn) Invoke(context.Context, string, any, any, ...grpc.CallOption) error {
+	return c.err
+}
+
+func (c stubConn) NewStream(context.Context, *grpc.StreamDesc, string, ...grpc.CallOption) (grpc.ClientStream, error) {
+	return nil, c.err
+}
+
+// In-process calls never reach the server interceptors, so AuditClientConn is their only audit
+// point. It must apply the same write/exclusion filtering the server path does.
+func TestInterceptor_AuditClientConn_Filtering(t *testing.T) {
+	tests := []struct {
+		name       string
+		methodPath string
+		wantEntry  bool
+	}{
+		{"read method", "/smartcore.bos.onoff.v1.OnOffApi/GetOnOff", false},
+		{"pull method", "/smartcore.bos.onoff.v1.OnOffApi/PullOnOff", false},
+		{"write method", "/smartcore.bos.onoff.v1.OnOffApi/UpdateOnOff", true},
+		// OnMessage is the MQTT ingress this audit point exists for; it must be treated as a write.
+		{"udmi OnMessage", "/smartcore.bos.udmi.v1.UdmiService/OnMessage", true},
+		{"excluded method", "/smartcore.bos.hub.v1.HubApi/TestHubNode", false},
+		{"excluded telemetry", "/smartcore.bos.history.v1.HistoryAdminApi/CreateHistoryRecord", false},
+		{"unparseable path", "not-a-method-path", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sink := &captureSink{}
+			interceptor := NewInterceptor(AllowAll, WithAuditSink(sink))
+			cc := interceptor.AuditClientConn(stubConn{})
+
+			if err := cc.Invoke(context.Background(), tt.methodPath, nil, nil); err != nil {
+				t.Fatalf("Invoke: %v", err)
+			}
+			interceptor.Close() // drain the async audit queue before asserting
+
+			want := 0
+			if tt.wantEntry {
+				want = 1
+			}
+			if got := len(sink.all()); got != want {
+				t.Errorf("got %d audit entries, want %d", got, want)
+			}
+		})
+	}
+}
+
+// The entry must record the call as in-process and must not invent a principal.
+func TestInterceptor_AuditClientConn_Fields(t *testing.T) {
+	sink := &captureSink{}
+	interceptor := NewInterceptor(AllowAll, WithAuditSink(sink))
+	cc := interceptor.AuditClientConn(stubConn{})
+
+	if err := cc.Invoke(context.Background(), "/smartcore.bos.udmi.v1.UdmiService/OnMessage", nil, nil); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	interceptor.Close()
+
+	msgs := sink.all()
+	if len(msgs) != 1 {
+		t.Fatalf("got %d audit entries, want 1", len(msgs))
+	}
+	msg := msgs[0]
+	if msg.Level != logpb.Level_LEVEL_INFO {
+		t.Errorf("level = %v, want INFO", msg.Level)
+	}
+	for key, want := range map[string]string{
+		"service": "smartcore.bos.udmi.v1.UdmiService",
+		"method":  "OnMessage",
+		"ingress": "loopback",
+		"peer":    "loopback",
+		"outcome": "ok",
+		// no principal is knowable for an in-process call
+		"subject": "",
+		"name":    "",
+		"cert":    "false",
+		"token":   "false",
+	} {
+		if got := msg.Fields[key]; got != want {
+			t.Errorf("field %q = %q, want %q", key, got, want)
+		}
+	}
+}
+
+// A failed in-process write is still recorded, and at WARN so it stands out.
+func TestInterceptor_AuditClientConn_Failed(t *testing.T) {
+	sink := &captureSink{}
+	interceptor := NewInterceptor(AllowAll, WithAuditSink(sink))
+	cc := interceptor.AuditClientConn(stubConn{err: status.Error(codes.Internal, "boom")})
+
+	if err := cc.Invoke(context.Background(), "/smartcore.bos.udmi.v1.UdmiService/OnMessage", nil, nil); err == nil {
+		t.Fatal("Invoke: expected an error")
+	}
+	interceptor.Close()
+
+	msgs := sink.all()
+	if len(msgs) != 1 {
+		t.Fatalf("got %d audit entries, want 1", len(msgs))
+	}
+	if got := msgs[0].Fields["outcome"]; got != "failed" {
+		t.Errorf("outcome = %q, want %q", got, "failed")
+	}
+	if msgs[0].Level != logpb.Level_LEVEL_WARN {
+		t.Errorf("level = %v, want WARN", msgs[0].Level)
+	}
+}
+
+// Streaming writes are audited at stream open; the common Pull* streams are not.
+func TestInterceptor_AuditClientConn_Streams(t *testing.T) {
+	sink := &captureSink{}
+	interceptor := NewInterceptor(AllowAll, WithAuditSink(sink))
+	cc := interceptor.AuditClientConn(stubConn{})
+	ctx := context.Background()
+
+	if _, err := cc.NewStream(ctx, &grpc.StreamDesc{}, "/smartcore.bos.onoff.v1.OnOffApi/PullOnOff"); err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	if n := len(sink.all()); n != 0 {
+		t.Errorf("PullOnOff: got %d audit entries, want 0", n)
+	}
+
+	if _, err := cc.NewStream(ctx, &grpc.StreamDesc{}, "/smartcore.bos.onoff.v1.OnOffApi/UpdateOnOffStream"); err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	interceptor.Close()
+	if n := len(sink.all()); n != 1 {
+		t.Errorf("UpdateOnOffStream: got %d audit entries, want 1", n)
+	}
+}
+
+// Without an audit sink there is nothing to write to, so the connection is handed back untouched
+// rather than paying for a wrapper on every in-process call.
+func TestInterceptor_AuditClientConn_NoSink(t *testing.T) {
+	cc := stubConn{}
+	if got := NewInterceptor(AllowAll).AuditClientConn(cc); got != grpc.ClientConnInterface(cc) {
+		t.Errorf("AuditClientConn wrapped the conn despite having no sink")
+	}
+	var nilInterceptor *Interceptor
+	if got := nilInterceptor.AuditClientConn(cc); got != grpc.ClientConnInterface(cc) {
+		t.Errorf("AuditClientConn on a nil Interceptor wrapped the conn")
+	}
+}

--- a/pkg/node/client.go
+++ b/pkg/node/client.go
@@ -7,8 +7,16 @@ import (
 )
 
 // ClientConn returns a connection to the Node's router.
+//
+// Calls made through this connection are dispatched in-process and so do not pass through any
+// interceptors registered on a grpc.Server. Configure the Node with
+// nodeopts.WithClientConnWrapper to observe them.
 func (n *Node) ClientConn() grpc.ClientConnInterface {
-	return router.NewLoopback(n.router)
+	cc := grpc.ClientConnInterface(router.NewLoopback(n.router))
+	if n.ccWrapper != nil {
+		cc = n.ccWrapper(cc)
+	}
+	return cc
 }
 
 // ClientConner represents a type that can return a gRPC client connection.

--- a/pkg/node/client_test.go
+++ b/pkg/node/client_test.go
@@ -1,0 +1,175 @@
+package node
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/smart-core-os/sc-bos/internal/node/nodeopts"
+	"github.com/smart-core-os/sc-bos/internal/util/grpc/interceptors"
+	"github.com/smart-core-os/sc-bos/pkg/auth/policy"
+	"github.com/smart-core-os/sc-bos/pkg/proto/logpb"
+	"github.com/smart-core-os/sc-bos/pkg/proto/udmipb"
+)
+
+// udmiStub stands in for a driver's UdmiService, which actuates real hardware in OnMessage.
+type udmiStub struct {
+	udmipb.UnimplementedUdmiServiceServer
+	mu       sync.Mutex
+	messages []*udmipb.MqttMessage
+}
+
+func (s *udmiStub) OnMessage(_ context.Context, req *udmipb.OnMessageRequest) (*udmipb.OnMessageResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, req.Message)
+	return &udmipb.OnMessageResponse{Name: req.Name}, nil
+}
+
+func (s *udmiStub) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+type captureSink struct {
+	mu   sync.Mutex
+	msgs []*logpb.LogMessage
+}
+
+func (s *captureSink) Write(msg *logpb.LogMessage) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.msgs = append(s.msgs, msg)
+}
+
+func (s *captureSink) all() []*logpb.LogMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*logpb.LogMessage(nil), s.msgs...)
+}
+
+// auditedNode returns a Node whose in-process connection is audited, plus the sink and the
+// interceptor (Close it to drain the async audit queue before asserting).
+func auditedNode(t *testing.T, name string, srv udmipb.UdmiServiceServer) (*Node, *captureSink, *policy.Interceptor) {
+	t.Helper()
+	sink := &captureSink{}
+	interceptor := policy.NewInterceptor(policy.AllowAll, policy.WithAuditSink(sink))
+	n := New("test", nodeopts.WithClientConnWrapper(interceptor.AuditClientConn))
+	n.Announce(name, HasServer(udmipb.RegisterUdmiServiceServer, srv))
+	return n, sink, interceptor
+}
+
+// A write arriving over MQTT reaches the driver through the node's in-process connection, which
+// bypasses the gRPC server's interceptor chain. It must still be audited: the broker supplies no
+// smart-core identity, so these are the writes we can least otherwise account for.
+func TestNode_ClientConn_AuditsInProcessWrite(t *testing.T) {
+	srv := &udmiStub{}
+	n, sink, interceptor := auditedNode(t, "dev-1", srv)
+	client := udmipb.NewUdmiServiceClient(n.ClientConn())
+	ctx := context.Background()
+
+	_, err := client.OnMessage(ctx, &udmipb.OnMessageRequest{
+		Name:    "dev-1",
+		Message: &udmipb.MqttMessage{Topic: "site/dev-1/config", Payload: `{"pointset":{"points":{}}}`},
+	})
+	if err != nil {
+		t.Fatalf("OnMessage: %v", err)
+	}
+	// the write really did reach the service; we are not just auditing a rejected call
+	if got := srv.count(); got != 1 {
+		t.Fatalf("service saw %d messages, want 1", got)
+	}
+	interceptor.Close()
+
+	msgs := sink.all()
+	if len(msgs) != 1 {
+		t.Fatalf("got %d audit entries, want 1", len(msgs))
+	}
+	fields := msgs[0].Fields
+	if got := fields["method"]; got != "OnMessage" {
+		t.Errorf("method = %q, want %q", got, "OnMessage")
+	}
+	if got := fields["ingress"]; got != "loopback" {
+		t.Errorf("ingress = %q, want %q", got, "loopback")
+	}
+	// the broker gives us no principal, so the entry must not imply one
+	if got := fields["subject"]; got != "" {
+		t.Errorf("subject = %q, want empty", got)
+	}
+}
+
+// Reads over the in-process connection are the bulk of its traffic and must not be audited.
+func TestNode_ClientConn_IgnoresInProcessRead(t *testing.T) {
+	n, sink, interceptor := auditedNode(t, "dev-1", &udmiStub{})
+	client := udmipb.NewUdmiServiceClient(n.ClientConn())
+
+	// GetExportMessage is unimplemented by the stub; the call fails, but classification as a
+	// read happens regardless of outcome, so nothing should be recorded either way.
+	_, _ = client.GetExportMessage(context.Background(), &udmipb.GetExportMessageRequest{Name: "dev-1"})
+	interceptor.Close()
+
+	if got := len(sink.all()); got != 0 {
+		t.Errorf("got %d audit entries, want 0", got)
+	}
+}
+
+// External calls reach routed services through the server's unknown-service handler, not through
+// ClientConn, so the two audit points must not both fire for one call.
+func TestNode_ClientConn_NoDoubleAuditForExternalCall(t *testing.T) {
+	srv := &udmiStub{}
+	n, sink, interceptor := auditedNode(t, "dev-1", srv)
+
+	lis := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer(
+		grpc.ChainStreamInterceptor(
+			interceptors.CorrectStreamInfo(n),
+			interceptor.GRPCStreamingInterceptor(),
+		),
+		grpc.ChainUnaryInterceptor(interceptor.GRPCUnaryInterceptor()),
+		grpc.UnknownServiceHandler(n.ServerHandler()),
+	)
+	go func() {
+		if err := server.Serve(lis); err != nil {
+			t.Logf("server stopped: %v", err)
+		}
+	}()
+	t.Cleanup(func() { lis.Close(); server.Stop() })
+
+	conn, err := grpc.NewClient("localhost:0",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	_, err = udmipb.NewUdmiServiceClient(conn).OnMessage(context.Background(), &udmipb.OnMessageRequest{
+		Name:    "dev-1",
+		Message: &udmipb.MqttMessage{Topic: "site/dev-1/config", Payload: "{}"},
+	})
+	if err != nil {
+		t.Fatalf("OnMessage: %v", err)
+	}
+	interceptor.Close()
+
+	msgs := sink.all()
+	if len(msgs) != 1 {
+		t.Fatalf("got %d audit entries, want 1", len(msgs))
+	}
+	// the entry came from the server interceptor, which knows the peer, not from the loopback wrapper
+	if got := msgs[0].Fields["ingress"]; got != "" {
+		t.Errorf("ingress = %q, want empty (server-path entry)", got)
+	}
+	if got := msgs[0].Fields["outcome"]; got != "allowed" {
+		t.Errorf("outcome = %q, want %q", got, "allowed")
+	}
+}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -41,6 +41,9 @@ type Node struct {
 	devices nodeopts.Store
 	mlLists map[string]*metadataList
 
+	// ccWrapper decorates the connection returned by ClientConn. May be nil.
+	ccWrapper func(grpc.ClientConnInterface) grpc.ClientConnInterface
+
 	Logger *zap.Logger
 }
 
@@ -65,11 +68,12 @@ func New(name string, opts ...Option) *Node {
 	}
 
 	node := &Node{
-		name:    name,
-		router:  cfg.Router,
-		devices: cfg.Store,
-		mlLists: make(map[string]*metadataList),
-		Logger:  zap.NewNop(),
+		name:      name,
+		router:    cfg.Router,
+		devices:   cfg.Store,
+		mlLists:   make(map[string]*metadataList),
+		ccWrapper: cfg.ClientConnWrapper,
+		Logger:    zap.NewNop(),
 	}
 
 	// nodes implement the MetadataApi without using the router,


### PR DESCRIPTION
The audit log from SCB-422 exists to answer "who turned the temp up to 30", but it's a policy interceptor on the external gRPC/HTTP servers, so it only ever saw writes that arrived over the network. Writes originating in-process go out through `Node.ClientConn()` — a router loopback that dispatches straight to the resolved conn — and never reach that chain.

Writes arriving over MQTT take exactly that path. The UDMI automation subscribes to each device's `/config` topic and forwards the payload to `UdmiService.OnMessage`, where the BACnet driver turns it into a real `WriteProperty` per configured point. Those are the least authenticated writes in the system — the broker supplies no smart-core identity — and they produced no audit entry and no log line at the default level.

The ticket proposed threading an `AuditSink` into `driver.Services` and auditing inside `udmiMerge.OnMessage`. This does it at the loopback instead, because downstream drivers implement the UDMI trait and actuate in their own `OnMessage`, and a driver-level fix would have left exactly the drivers we can't inspect unaudited until each one opted in. The two ingress paths are disjoint — external traffic reaches routed services via the server's unknown-service handler — so a decorator on the loopback conn is complementary to the existing interceptor, not a duplicate of it. No driver, automation or `Services` struct changes.

Two things worth a reviewer's attention. Audit-log content changes system-wide: every in-process write now appears, including `bms` `UpdateAirTemperature`/`UpdateModeValues`. Volume is bounded — `isWriteMethod` filters reads, `CacheWriteAction` suppresses unchanged writes, `CreateHistoryRecord` is already excluded — and entries are tagged `ingress=loopback` so consumers can filter. And `writeAuditEntry` still blocks when its 1024-entry queue fills; I kept that consistent with the external path deliberately, since silently dropping entries from a security audit log is the worse failure mode.

Per-point detail — which configured points were actually written, the resolved BACnet priority, per-point outcome — is only knowable inside the driver, so it's left for a follow-up along with `pestsense`, which mutates its resource model directly and so is out of reach of any gRPC-layer fix.

Verified by `go test ./pkg/auth/policy/ ./pkg/node/`, including a regression test that drives real router dispatch through the loopback and fails with `got 0 audit entries, want 1` when the wrapper is disabled, plus a test asserting an external call still yields exactly one entry. Full `go build`, `go vet`, `staticcheck` and `go test ./...` clean against this host's pre-existing baseline.

#SCB-1411 State Done
