### PR TITLE
auth/accesstoken: default SignatureAlgorithms when unset (SCB-1393)

### DIFF
--- a/internal/auth/accesstoken/accesstoken.go
+++ b/internal/auth/accesstoken/accesstoken.go
@@ -61,11 +61,35 @@ func (pa permissionAssignment) ToTokenPermissionAssignment() token.PermissionAss
 	}
 }
 
+// DefaultSignatureAlgorithms lists the signature algorithms a Source permits when
+// SignatureAlgorithms is not set.
+//
+// It contains only HS256 because that is the only algorithm this package ever signs with:
+// generateKey and LoadOrGenerateSigningKey both produce HS256 keys, and WithSigningKey rejects
+// anything that isn't the []byte an HMAC key needs. A Source therefore only ever verifies its
+// own HS256 tokens, so this is the narrowest list that still works rather than a lax fallback.
+//
+// jwt.ParseSigned takes the permitted algorithms as a required argument and fails when handed an
+// empty list, so without this default a Source built without WithPermittedSignatureAlgorithms
+// would issue tokens happily and then reject every single one of them.
+var DefaultSignatureAlgorithms = []string{string(jose.HS256)}
+
 type Source struct {
-	Key                 jose.SigningKey
-	Issuer              string
-	Now                 func() time.Time
+	Key    jose.SigningKey
+	Issuer string
+	Now    func() time.Time
+	// SignatureAlgorithms are the signature algorithms permitted when validating tokens.
+	// When empty, DefaultSignatureAlgorithms is used.
 	SignatureAlgorithms []string
+}
+
+// permittedAlgorithms returns the signature algorithms to accept when validating a token,
+// falling back to DefaultSignatureAlgorithms when none were configured.
+func (ts *Source) permittedAlgorithms() []string {
+	if len(ts.SignatureAlgorithms) == 0 {
+		return DefaultSignatureAlgorithms
+	}
+	return ts.SignatureAlgorithms
 }
 
 func (ts *Source) GenerateAccessToken(data SecretData, validity time.Duration) (token string, err error) {
@@ -108,7 +132,7 @@ func (ts *Source) GenerateAccessToken(data SecretData, validity time.Duration) (
 }
 
 func (ts *Source) ValidateAccessToken(_ context.Context, tokenStr string) (*token.Claims, error) {
-	tok, err := jwt.ParseSigned(tokenStr, joseUtils.ConvertToNativeJose(ts.SignatureAlgorithms))
+	tok, err := jwt.ParseSigned(tokenStr, joseUtils.ConvertToNativeJose(ts.permittedAlgorithms()))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/accesstoken/accesstoken.go
+++ b/internal/auth/accesstoken/accesstoken.go
@@ -17,7 +17,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/smart-core-os/sc-bos/internal/auth/permission"
-	joseUtils "github.com/smart-core-os/sc-bos/internal/util/jose"
 	"github.com/smart-core-os/sc-bos/pkg/auth/token"
 	"github.com/smart-core-os/sc-bos/pkg/proto/accountpb"
 )
@@ -61,35 +60,19 @@ func (pa permissionAssignment) ToTokenPermissionAssignment() token.PermissionAss
 	}
 }
 
-// DefaultSignatureAlgorithms lists the signature algorithms a Source permits when
-// SignatureAlgorithms is not set.
+// Source issues and validates access tokens, both signed with Key.
 //
-// It contains only HS256 because that is the only algorithm this package ever signs with:
-// generateKey and LoadOrGenerateSigningKey both produce HS256 keys, and WithSigningKey rejects
-// anything that isn't the []byte an HMAC key needs. A Source therefore only ever verifies its
-// own HS256 tokens, so this is the narrowest list that still works rather than a lax fallback.
+// Key must hold a []byte secret and an HMAC algorithm it is long enough for: a []byte is the only
+// key type go-jose signs symmetrically with. generateKey and LoadOrGenerateSigningKey both produce
+// HS256, and NewServer requires HS256 specifically.
 //
-// jwt.ParseSigned takes the permitted algorithms as a required argument and fails when handed an
-// empty list, so without this default a Source built without WithPermittedSignatureAlgorithms
-// would issue tokens happily and then reject every single one of them.
-var DefaultSignatureAlgorithms = []string{string(jose.HS256)}
-
+// Key.Algorithm is the single source of truth for both operations: GenerateAccessToken signs with
+// it and ValidateAccessToken permits it and nothing else. A Source therefore cannot be configured
+// to accept an algorithm it could never issue, nor to reject its own tokens.
 type Source struct {
 	Key    jose.SigningKey
 	Issuer string
 	Now    func() time.Time
-	// SignatureAlgorithms are the signature algorithms permitted when validating tokens.
-	// When empty, DefaultSignatureAlgorithms is used.
-	SignatureAlgorithms []string
-}
-
-// permittedAlgorithms returns the signature algorithms to accept when validating a token,
-// falling back to DefaultSignatureAlgorithms when none were configured.
-func (ts *Source) permittedAlgorithms() []string {
-	if len(ts.SignatureAlgorithms) == 0 {
-		return DefaultSignatureAlgorithms
-	}
-	return ts.SignatureAlgorithms
 }
 
 func (ts *Source) GenerateAccessToken(data SecretData, validity time.Duration) (token string, err error) {
@@ -132,7 +115,7 @@ func (ts *Source) GenerateAccessToken(data SecretData, validity time.Duration) (
 }
 
 func (ts *Source) ValidateAccessToken(_ context.Context, tokenStr string) (*token.Claims, error) {
-	tok, err := jwt.ParseSigned(tokenStr, joseUtils.ConvertToNativeJose(ts.permittedAlgorithms()))
+	tok, err := jwt.ParseSigned(tokenStr, []jose.SignatureAlgorithm{ts.Key.Algorithm})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/accesstoken/accesstoken.go
+++ b/internal/auth/accesstoken/accesstoken.go
@@ -61,15 +61,9 @@ func (pa permissionAssignment) ToTokenPermissionAssignment() token.PermissionAss
 }
 
 // Source issues and validates access tokens, both signed with Key.
-//
-// Key must hold a []byte secret and an HMAC algorithm it is long enough for: a []byte is the only
-// key type go-jose signs symmetrically with. generateKey and LoadOrGenerateSigningKey both produce
-// HS256, and NewServer requires HS256 specifically.
-//
-// Key.Algorithm is the single source of truth for both operations: GenerateAccessToken signs with
-// it and ValidateAccessToken permits it and nothing else. A Source therefore cannot be configured
-// to accept an algorithm it could never issue, nor to reject its own tokens.
 type Source struct {
+	// Key.Algorithm is the only algorithm Source will issue with or accept, so a Source can
+	// neither be configured to permit an algorithm it could never issue nor to reject its own tokens.
 	Key    jose.SigningKey
 	Issuer string
 	Now    func() time.Time

--- a/internal/auth/accesstoken/accesstoken_test.go
+++ b/internal/auth/accesstoken/accesstoken_test.go
@@ -1,6 +1,7 @@
 package accesstoken
 
 import (
+	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"os"
@@ -25,9 +26,14 @@ func TestTokenSource_createAndVerify(t *testing.T) {
 	}
 }
 
-func TestTokenSource_createAndVerifyWithoutSignatureAlgorithms(t *testing.T) {
-	ts := newTestSource(t)
-	ts.SignatureAlgorithms = nil // fall back to DefaultSignatureAlgorithms
+// A Source needs no algorithm configuration beyond its key: the permitted algorithm is read off
+// Key.Algorithm, so there is no list to leave empty and no way to reject its own tokens (SCB-1393).
+func TestTokenSource_createAndVerifyNeedsNoAlgorithmConfig(t *testing.T) {
+	key, err := generateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := &Source{Key: key, Issuer: "test", Now: time.Now}
 
 	token, err := ts.GenerateAccessToken(SecretData{TenantID: "Foo"}, 10*time.Minute)
 	if err != nil {
@@ -38,27 +44,37 @@ func TestTokenSource_createAndVerifyWithoutSignatureAlgorithms(t *testing.T) {
 	}
 }
 
-// The default must only fill an absent list, never widen a configured one.
-func TestTokenSource_configuredSignatureAlgorithmsArePreserved(t *testing.T) {
+// A Source only ever permits the algorithm it signs with, so a token carrying any other algorithm
+// is refused even though the key itself would verify the signature.
+func TestTokenSource_rejectsForeignAlgorithm(t *testing.T) {
 	ts := newTestSource(t)
-	// this Source signs with HS256, so restricting it to RS256 makes its own tokens unacceptable
-	ts.SignatureAlgorithms = []string{string(jose.RS256)}
-
-	token, err := ts.GenerateAccessToken(SecretData{TenantID: "Foo"}, 10*time.Minute)
+	// HS512 needs a 64-byte secret, so this signer carries its own key; the algorithm is rejected
+	// during parsing, before the signature is ever checked, so the differing key is immaterial
+	secret := make([]byte, 64)
+	if _, err := rand.Read(secret); err != nil {
+		t.Fatal(err)
+	}
+	foreign := &Source{
+		Key:    jose.SigningKey{Algorithm: jose.HS512, Key: secret},
+		Issuer: ts.Issuer,
+		Now:    ts.Now,
+	}
+	token, err := foreign.GenerateAccessToken(SecretData{TenantID: "Foo"}, 10*time.Minute)
 	if err != nil {
 		t.Fatalf("GenerateAccessToken %v", err)
 	}
+
 	_, err = ts.ValidateAccessToken(t.Context(), token)
 	if err == nil {
-		t.Fatal("ValidateAccessToken accepted an HS256 token from a source permitting only RS256")
+		t.Fatal("ValidateAccessToken accepted an HS512 token from an HS256 source")
 	}
 	// pin the reason, so the test can't pass because validation failed for some unrelated cause
 	var algErr *jose.ErrUnexpectedSignatureAlgorithm
 	if !errors.As(err, &algErr) {
 		t.Fatalf("error = %v, want ErrUnexpectedSignatureAlgorithm", err)
 	}
-	if algErr.Got != jose.HS256 {
-		t.Errorf("rejected algorithm = %q, want %q", algErr.Got, jose.HS256)
+	if algErr.Got != jose.HS512 {
+		t.Errorf("rejected algorithm = %q, want %q", algErr.Got, jose.HS512)
 	}
 }
 
@@ -218,9 +234,8 @@ func newTestSource(t *testing.T) *Source {
 		t.Fatal(err)
 	}
 	return &Source{
-		Key:                 key,
-		Issuer:              "test",
-		Now:                 time.Now,
-		SignatureAlgorithms: []string{string(jose.HS256)},
+		Key:    key,
+		Issuer: "test",
+		Now:    time.Now,
 	}
 }

--- a/internal/auth/accesstoken/accesstoken_test.go
+++ b/internal/auth/accesstoken/accesstoken_test.go
@@ -26,24 +26,6 @@ func TestTokenSource_createAndVerify(t *testing.T) {
 	}
 }
 
-// A Source needs no algorithm configuration beyond its key: the permitted algorithm is read off
-// Key.Algorithm, so there is no list to leave empty and no way to reject its own tokens (SCB-1393).
-func TestTokenSource_createAndVerifyNeedsNoAlgorithmConfig(t *testing.T) {
-	key, err := generateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	ts := &Source{Key: key, Issuer: "test", Now: time.Now}
-
-	token, err := ts.GenerateAccessToken(SecretData{TenantID: "Foo"}, 10*time.Minute)
-	if err != nil {
-		t.Fatalf("GenerateAccessToken %v", err)
-	}
-	if _, err := ts.ValidateAccessToken(t.Context(), token); err != nil {
-		t.Fatalf("ValidateAccessToken %v", err)
-	}
-}
-
 // A Source only ever permits the algorithm it signs with, so a token carrying any other algorithm
 // is refused even though the key itself would verify the signature.
 func TestTokenSource_rejectsForeignAlgorithm(t *testing.T) {

--- a/internal/auth/accesstoken/accesstoken_test.go
+++ b/internal/auth/accesstoken/accesstoken_test.go
@@ -2,6 +2,7 @@ package accesstoken
 
 import (
 	"encoding/hex"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,6 +22,43 @@ func TestTokenSource_createAndVerify(t *testing.T) {
 	_, err = ts.ValidateAccessToken(t.Context(), token)
 	if err != nil {
 		t.Fatalf("ValidateAccessToken %v", err)
+	}
+}
+
+func TestTokenSource_createAndVerifyWithoutSignatureAlgorithms(t *testing.T) {
+	ts := newTestSource(t)
+	ts.SignatureAlgorithms = nil // fall back to DefaultSignatureAlgorithms
+
+	token, err := ts.GenerateAccessToken(SecretData{TenantID: "Foo"}, 10*time.Minute)
+	if err != nil {
+		t.Fatalf("GenerateAccessToken %v", err)
+	}
+	if _, err := ts.ValidateAccessToken(t.Context(), token); err != nil {
+		t.Fatalf("ValidateAccessToken %v", err)
+	}
+}
+
+// The default must only fill an absent list, never widen a configured one.
+func TestTokenSource_configuredSignatureAlgorithmsArePreserved(t *testing.T) {
+	ts := newTestSource(t)
+	// this Source signs with HS256, so restricting it to RS256 makes its own tokens unacceptable
+	ts.SignatureAlgorithms = []string{string(jose.RS256)}
+
+	token, err := ts.GenerateAccessToken(SecretData{TenantID: "Foo"}, 10*time.Minute)
+	if err != nil {
+		t.Fatalf("GenerateAccessToken %v", err)
+	}
+	_, err = ts.ValidateAccessToken(t.Context(), token)
+	if err == nil {
+		t.Fatal("ValidateAccessToken accepted an HS256 token from a source permitting only RS256")
+	}
+	// pin the reason, so the test can't pass because validation failed for some unrelated cause
+	var algErr *jose.ErrUnexpectedSignatureAlgorithm
+	if !errors.As(err, &algErr) {
+		t.Fatalf("error = %v, want ErrUnexpectedSignatureAlgorithm", err)
+	}
+	if algErr.Got != jose.HS256 {
+		t.Errorf("rejected algorithm = %q, want %q", algErr.Got, jose.HS256)
 	}
 }
 

--- a/internal/auth/accesstoken/token_server.go
+++ b/internal/auth/accesstoken/token_server.go
@@ -58,7 +58,10 @@ func NewServer(name string, opts ...ServerOption) (*Server, error) {
 	} else {
 		keyBytes, ok := s.tokens.Key.Key.([]byte)
 		if !ok || len(keyBytes) == 0 {
-			return nil, fmt.Errorf("WithSigningKey: key must be a non-empty []byte (HS256), got %T", s.tokens.Key.Key)
+			return nil, fmt.Errorf("WithSigningKey: key must be a non-empty []byte, got %T", s.tokens.Key.Key)
+		}
+		if s.tokens.Key.Algorithm != jose.HS256 {
+			return nil, fmt.Errorf("WithSigningKey: algorithm must be %s, got %q", jose.HS256, s.tokens.Key.Algorithm)
 		}
 	}
 
@@ -88,21 +91,13 @@ func WithPasswordFlow(v Verifier, validity time.Duration) ServerOption {
 }
 
 // WithSigningKey sets the signing key used to issue and validate access tokens.
+// The key must be an HS256 algorithm over a non-empty []byte secret; NewServer rejects anything else.
 // When not set, a random ephemeral key is generated at startup.
 // Use LoadOrGenerateSigningKey to load a persistent key from a file that can be shared
 // across multiple server instances so they all accept each other's tokens.
 func WithSigningKey(key jose.SigningKey) ServerOption {
 	return func(ts *Server) {
 		ts.tokens.Key = key
-	}
-}
-
-// WithPermittedSignatureAlgorithms sets the signature algorithms accepted when validating tokens.
-// When not set, DefaultSignatureAlgorithms is used, which covers every key this server can sign with.
-// Pass a wider list only to accept tokens signed elsewhere.
-func WithPermittedSignatureAlgorithms(algs []string) ServerOption {
-	return func(ts *Server) {
-		ts.tokens.SignatureAlgorithms = algs
 	}
 }
 

--- a/internal/auth/accesstoken/token_server.go
+++ b/internal/auth/accesstoken/token_server.go
@@ -97,6 +97,9 @@ func WithSigningKey(key jose.SigningKey) ServerOption {
 	}
 }
 
+// WithPermittedSignatureAlgorithms sets the signature algorithms accepted when validating tokens.
+// When not set, DefaultSignatureAlgorithms is used, which covers every key this server can sign with.
+// Pass a wider list only to accept tokens signed elsewhere.
 func WithPermittedSignatureAlgorithms(algs []string) ServerOption {
 	return func(ts *Server) {
 		ts.tokens.SignatureAlgorithms = algs

--- a/internal/auth/accesstoken/token_server.go
+++ b/internal/auth/accesstoken/token_server.go
@@ -56,6 +56,8 @@ func NewServer(name string, opts ...ServerOption) (*Server, error) {
 		}
 		s.tokens.Key = key
 	} else {
+		// go-jose signs symmetrically only with a []byte secret, and BOS has no use for the larger
+		// HMAC sizes or the asymmetric families, so a Server is pinned to HS256.
 		keyBytes, ok := s.tokens.Key.Key.([]byte)
 		if !ok || len(keyBytes) == 0 {
 			return nil, fmt.Errorf("WithSigningKey: key must be a non-empty []byte, got %T", s.tokens.Key.Key)

--- a/internal/auth/accesstoken/token_server_test.go
+++ b/internal/auth/accesstoken/token_server_test.go
@@ -1,6 +1,7 @@
 package accesstoken
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"go.uber.org/zap"
 
 	"github.com/smart-core-os/sc-bos/pkg/auth/token"
@@ -173,15 +175,14 @@ func TestTokenServer(t *testing.T) {
 	}
 }
 
-// A Server built without WithPermittedSignatureAlgorithms must still accept the tokens it issues.
-// jwt.ParseSigned rejects everything when handed an empty algorithm list, so before
-// DefaultSignatureAlgorithms existed this server would hand out a token over HTTP and then refuse
-// that very token — see SCB-1393.
-func TestTokenServer_validatesOwnTokensWithoutPermittedAlgorithms(t *testing.T) {
+// A Server must accept the tokens it issues. jwt.ParseSigned rejects everything when handed an
+// empty algorithm list, so while the permitted algorithms were configured separately from the key
+// a caller could build a server that handed out a token over HTTP and then refused that very
+// token — see SCB-1393.
+func TestTokenServer_validatesOwnTokens(t *testing.T) {
 	var services testMemoryVerifier
 	services.add(t, SecretData{TenantID: "service1", SystemRoles: []string{"admin"}}, "secret1")
 
-	// deliberately no WithPermittedSignatureAlgorithms
 	server, err := NewServer("test",
 		WithLogger(zap.NewNop()),
 		WithClientCredentialFlow(&services, 10*time.Minute),
@@ -215,6 +216,40 @@ func TestTokenServer_validatesOwnTokensWithoutPermittedAlgorithms(t *testing.T) 
 	}
 	if claims.Subject != "service1" {
 		t.Errorf("Subject = %q, want %q", claims.Subject, "service1")
+	}
+}
+
+// The signing key decides which algorithm tokens are issued and validated with, so NewServer only
+// accepts a key it can actually use: a non-empty []byte secret carrying HS256.
+func TestNewServer_rejectsUnusableSigningKey(t *testing.T) {
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, key := range map[string]jose.SigningKey{
+		"asymmetric algorithm": {Algorithm: jose.RS256, Key: secret},
+		"other hmac algorithm": {Algorithm: jose.HS512, Key: secret},
+		"missing algorithm":    {Key: secret},
+		"wrong key type":       {Algorithm: jose.HS256, Key: "not-bytes"},
+		"empty key":            {Algorithm: jose.HS256, Key: []byte{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := NewServer("test", WithSigningKey(key)); err == nil {
+				t.Error("NewServer accepted a signing key it cannot issue tokens with")
+			}
+		})
+	}
+}
+
+// The generated fallback key must satisfy the same validation the caller's key is held to.
+func TestNewServer_generatesUsableKeyWhenUnset(t *testing.T) {
+	server, err := NewServer("test")
+	if err != nil {
+		t.Fatalf("NewServer %v", err)
+	}
+	if got := server.tokens.Key.Algorithm; got != jose.HS256 {
+		t.Errorf("generated key algorithm = %q, want %q", got, jose.HS256)
 	}
 }
 

--- a/internal/auth/accesstoken/token_server_test.go
+++ b/internal/auth/accesstoken/token_server_test.go
@@ -175,10 +175,8 @@ func TestTokenServer(t *testing.T) {
 	}
 }
 
-// A Server must accept the tokens it issues. jwt.ParseSigned rejects everything when handed an
-// empty algorithm list, so while the permitted algorithms were configured separately from the key
-// a caller could build a server that handed out a token over HTTP and then refused that very
-// token — see SCB-1393.
+// A Server must accept the tokens it issues: the permitted algorithm is read off the signing key,
+// so issuing and validation cannot drift apart (SCB-1393).
 func TestTokenServer_validatesOwnTokens(t *testing.T) {
 	var services testMemoryVerifier
 	services.add(t, SecretData{TenantID: "service1", SystemRoles: []string{"admin"}}, "secret1")

--- a/internal/auth/accesstoken/token_server_test.go
+++ b/internal/auth/accesstoken/token_server_test.go
@@ -173,6 +173,51 @@ func TestTokenServer(t *testing.T) {
 	}
 }
 
+// A Server built without WithPermittedSignatureAlgorithms must still accept the tokens it issues.
+// jwt.ParseSigned rejects everything when handed an empty algorithm list, so before
+// DefaultSignatureAlgorithms existed this server would hand out a token over HTTP and then refuse
+// that very token — see SCB-1393.
+func TestTokenServer_validatesOwnTokensWithoutPermittedAlgorithms(t *testing.T) {
+	var services testMemoryVerifier
+	services.add(t, SecretData{TenantID: "service1", SystemRoles: []string{"admin"}}, "secret1")
+
+	// deliberately no WithPermittedSignatureAlgorithms
+	server, err := NewServer("test",
+		WithLogger(zap.NewNop()),
+		WithClientCredentialFlow(&services, 10*time.Minute),
+	)
+	if err != nil {
+		t.Fatalf("NewServer %v", err)
+	}
+	httpServer := httptest.NewServer(server)
+	defer httpServer.Close()
+
+	resp, err := httpServer.Client().PostForm(httpServer.URL, url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {"service1"},
+		"client_secret": {"secret1"},
+	})
+	if err != nil {
+		t.Fatalf("PostForm %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+	var issued tokenSuccessResponse
+	if err := json.NewDecoder(resp.Body).Decode(&issued); err != nil {
+		t.Fatalf("Decode success response %v", err)
+	}
+
+	claims, err := server.TokenValidator().ValidateAccessToken(t.Context(), issued.AccessToken)
+	if err != nil {
+		t.Fatalf("ValidateAccessToken rejected a token this server issued: %v", err)
+	}
+	if claims.Subject != "service1" {
+		t.Errorf("Subject = %q, want %q", claims.Subject, "service1")
+	}
+}
+
 type testMemoryVerifier struct {
 	MemoryVerifier
 }

--- a/pkg/system/authn/factory.go
+++ b/pkg/system/authn/factory.go
@@ -75,7 +75,6 @@ func (s *System) applyConfig(ctx context.Context, cfg config.Root) error {
 	var serveTokenEndpoint bool
 	tokenServerOpts := []accesstoken.ServerOption{
 		accesstoken.WithLogger(s.logger.Named("server")),
-		accesstoken.WithPermittedSignatureAlgorithms(keycloak.DefaultPermittedSignatureAlgorithms),
 	}
 
 	if cfg.System != nil {


### PR DESCRIPTION
`accesstoken.Source` decided which signature algorithms to accept from a field configured separately from the signing key, and `jwt.ParseSigned` treats that list as required — it fails outright when empty. A `Server` built without `WithPermittedSignatureAlgorithms` would hand out tokens over `/oauth2/token` quite happily and then reject every one with `no signature algorithms specified`: login succeeds, everything after it 401s. Nothing hit it, since `pkg/system/authn/factory.go` was the only constructor and always passed the option, but it was a footgun the tests structurally could not catch — `TestTokenServer` already built a `Server` without the option and only ever exercised issuing, never validation.

The fix removes the configuration rather than defaulting it. `NewServer` already required the signing key to be a `[]byte`, and go-jose routes a `[]byte` key to `newSymmetricSigner`, which accepts only HS256/HS384/HS512 and enforces a minimum secret length for each; `LoadOrGenerateSigningKey` mandates exactly 32 bytes, so HS256 was the only algorithm a `Server` could ever reach. The allow-list was unreachable configuration, and permitting the RS/ES/PS families could never match a token this `Server` issued.

So `WithPermittedSignatureAlgorithms` and `Source.SignatureAlgorithms` are gone, and the permitted algorithm is read off `Source.Key.Algorithm`. `GenerateAccessToken` and `ValidateAccessToken` now consult the same field, which is what makes this impossible rather than merely defaulted: a `Source` can no longer be configured to reject the tokens it issues, and `ParseSigned` can no longer receive an empty list. `NewServer` gained an `Algorithm == HS256` check beside the existing key-type check, so a key it cannot issue with is refused at construction rather than failing later at sign time.

`factory.go` stops passing `keycloak.DefaultPermittedSignatureAlgorithms` — required now the option is gone, and the same HS256-only change requested on #916. Whether HS256 should also come *out* of the Keycloak list is left to that PR: it is a behavioural change for any installation whose Keycloak signs with HS256, so it shouldn't ride along here.

Verified by `go test ./internal/auth/accesstoken/... ./pkg/system/authn/...`; the new `NewServer` validation was negative-controlled (its three algorithm cases fail with the check removed, the two key-shape cases still pass on the pre-existing `[]byte` check). `go build ./...`, `go vet`, `staticcheck ./...` and `gofmt` clean, and the full `go test ./...` failing-package set is unchanged.

#SCB-1393 State Done
