### PR TITLE
app,cloud: fix Windows-only path handling and database cleanup (SCB-1407, SCB-1415)

### DIFF
--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -172,7 +172,7 @@ var testdata embed.FS
 
 func readTestData(t *testing.T, name string) []byte {
 	t.Helper()
-	data, err := testdata.ReadFile(filepath.Join("testdata", name))
+	data, err := testdata.ReadFile(path.Join("testdata", name))
 	if err != nil {
 		t.Fatalf("read test data %q: %v", name, err)
 	}

--- a/pkg/app/appconf/config.go
+++ b/pkg/app/appconf/config.go
@@ -72,10 +72,14 @@ func (c *Config) mergeWith(other *Config) {
 		}
 	}
 	// Includes are merged in a special way, we use the FilePath relative to c as the include.
+	// mergeWith serves both loadIncludes (OS paths) and loadIncludesFS (fs.FS paths, always
+	// forward-slash), so normalise to slashes: includes are written that way in config files, and
+	// filepath.Rel would otherwise record `dir\1.json` for an fs.FS load on Windows.
 	relInc, err := filepath.Rel(filepath.Dir(c.FilePath), other.FilePath)
 	if err != nil {
 		return
 	}
+	relInc = filepath.ToSlash(relInc)
 	if !slices.Contains(c.Includes, relInc) {
 		c.Includes = append(c.Includes, relInc)
 	}

--- a/pkg/app/appconf/config_test.go
+++ b/pkg/app/appconf/config_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"testing"
 	"testing/fstest"
 
@@ -82,25 +82,25 @@ func TestLoadLocalConfig(t *testing.T) {
 		{
 			name: "single file",
 			fs: fstest.MapFS{
-				filepath.Join("data", "base.json"): {
+				path.Join("data", "base.json"): {
 					Data: []byte(`{"name": "my-config"}`),
 				},
 			},
 			dir:    "data",
 			file:   "base.json",
-			config: &Config{Name: "my-config", FilePath: filepath.Join("data", "base.json")},
+			config: &Config{Name: "my-config", FilePath: path.Join("data", "base.json")},
 		},
 		{
 			name: "with include",
 			fs: fstest.MapFS{
-				filepath.Join("data", "base.json"): {
+				path.Join("data", "base.json"): {
 					Data: []byte(`{
 						"name": "my-config",
 						"includes": ["part-1.json"],
 						"drivers": [{"name": "driver-1"}]
 					}`),
 				},
-				filepath.Join("data", "part-1.json"): {
+				path.Join("data", "part-1.json"): {
 					Data: []byte(`{
 						"name": "ignored",
 						"drivers": [{"name": "driver-part-1"}]
@@ -116,7 +116,7 @@ func TestLoadLocalConfig(t *testing.T) {
 					driverNamed("driver-1"),
 					driverNamed("driver-part-1"),
 				},
-				FilePath: filepath.Join("data", "base.json"),
+				FilePath: path.Join("data", "base.json"),
 			},
 		},
 		{
@@ -148,27 +148,27 @@ func TestLoadLocalConfig(t *testing.T) {
 					driverNamed("driver-part-2b"),
 					driverNamed("driver-part-3a"),
 				},
-				FilePath: filepath.Join("data", "base.json"),
+				FilePath: path.Join("data", "base.json"),
 			},
 		},
 		{
 			name: "avoids includes loop",
 			fs: fstest.MapFS{
-				filepath.Join("data", "base.json"): {
+				path.Join("data", "base.json"): {
 					Data: []byte(`{
 						"name": "my-config",
 						"includes": ["part-1.json"],
 						"drivers": [{"name": "driver-1"}]
 					}`),
 				},
-				filepath.Join("data", "part-1.json"): {
+				path.Join("data", "part-1.json"): {
 					Data: []byte(`{
 						"name": "ignored",
 						"includes": ["part-1a.json"],
 						"drivers": [{"name": "driver-part-1"}]
 					}`),
 				},
-				filepath.Join("data", "part-1a.json"): {
+				path.Join("data", "part-1a.json"): {
 					Data: []byte(`{
 						"includes": ["part-1.json"],
 						"drivers": [{"name": "driver-part-1a"}]
@@ -188,20 +188,20 @@ func TestLoadLocalConfig(t *testing.T) {
 					driverNamed("driver-part-1"),
 					driverNamed("driver-part-1a"),
 				},
-				FilePath: filepath.Join("data", "base.json"),
+				FilePath: path.Join("data", "base.json"),
 			},
 		},
 		{
 			name: "duplicate driver ignored",
 			fs: fstest.MapFS{
-				filepath.Join("data", "base.json"): {
+				path.Join("data", "base.json"): {
 					Data: []byte(`{
 						"name": "my-config",
 						"includes": ["part-1.json"],
 						"drivers": [{"name": "driver-1", "type": "d-1"}]
 					}`),
 				},
-				filepath.Join("data", "part-1.json"): {
+				path.Join("data", "part-1.json"): {
 					Data: []byte(`{
 						"name": "ignored",
 						"drivers": [{"name": "driver-1", "type": "d-2"}]
@@ -216,26 +216,26 @@ func TestLoadLocalConfig(t *testing.T) {
 				Drivers: []driver.RawConfig{
 					driverWithType("driver-1", "d-1"),
 				},
-				FilePath: filepath.Join("data", "base.json"),
+				FilePath: path.Join("data", "base.json"),
 			},
 		},
 		{
 			name: "first dup driver takes precendence",
 			fs: fstest.MapFS{
-				filepath.Join("data", "base.json"): {
+				path.Join("data", "base.json"): {
 					Data: []byte(`{
 						"name": "my-config",
 						"includes": ["part-1.json","part-2.json"],
 						"drivers": [{"name": "driver-1", "type": "d-1"}]
 					}`),
 				},
-				filepath.Join("data", "part-1.json"): {
+				path.Join("data", "part-1.json"): {
 					Data: []byte(`{
 						"name": "ignored",
 						"drivers": [{"name": "driver-2", "type": "d-1a"}]
 					}`),
 				},
-				filepath.Join("data", "part-2.json"): {
+				path.Join("data", "part-2.json"): {
 					Data: []byte(`{
 						"name": "ignored",
 						"drivers": [{"name": "driver-2", "type": "d-2"}]
@@ -251,7 +251,7 @@ func TestLoadLocalConfig(t *testing.T) {
 					driverWithType("driver-1", "d-1"),
 					driverWithType("driver-2", "d-1a"),
 				},
-				FilePath: filepath.Join("data", "base.json"),
+				FilePath: path.Join("data", "base.json"),
 			},
 		},
 		{
@@ -268,7 +268,7 @@ func TestLoadLocalConfig(t *testing.T) {
 					driverWithType("dir2", "dir2"),
 					driverWithType("dir/more1", "dir/more1"),
 				},
-				FilePath: filepath.Join("data", "base.json"),
+				FilePath: path.Join("data", "base.json"),
 			},
 		},
 		{
@@ -286,16 +286,16 @@ func TestLoadLocalConfig(t *testing.T) {
 					driverWithType("dir2/1", "dir2/1"),
 					driverWithType("file2", "file2"),
 				},
-				FilePath: filepath.Join("data", "base.json"),
+				FilePath: path.Join("data", "base.json"),
 			},
 		},
 		{
 			name: "include non-json file",
 			fs: fstest.MapFS{
-				filepath.Join("data", "base.json"): {
+				path.Join("data", "base.json"): {
 					Data: []byte(`{"name": "base", "include": ["file.txt"]}`),
 				},
-				filepath.Join("data", "file.txt"): {
+				path.Join("data", "file.txt"): {
 					Data: []byte(`this is not a json file`),
 				},
 			},
@@ -303,7 +303,7 @@ func TestLoadLocalConfig(t *testing.T) {
 			file: "base.json",
 			config: &Config{
 				Name:     "base",
-				FilePath: filepath.Join("data", "base.json"),
+				FilePath: path.Join("data", "base.json"),
 			},
 		},
 	}

--- a/pkg/app/controller.go
+++ b/pkg/app/controller.go
@@ -213,6 +213,13 @@ func Bootstrap(ctx context.Context, config sysconf.Config) (*Controller, error) 
 	}
 	c.Defer(manager.Close)
 	c.Defer(store.Close)
+	// db is nil if bolthold.Open failed above, which is only warned about.
+	if db != nil {
+		c.Defer(db.Close)
+	}
+	if accountStore != nil {
+		c.Defer(accountStore.Close)
+	}
 	c.Defer(closeHealthStore)
 	c.Defer(ci.DataRoot.Close)
 	if ai.Interceptor != nil {

--- a/pkg/app/controller_test.go
+++ b/pkg/app/controller_test.go
@@ -3,9 +3,11 @@ package app
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 	"testing"
 
+	bolterrors "go.etcd.io/bbolt/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/test/bufconn"
@@ -15,6 +17,39 @@ import (
 	"github.com/smart-core-os/sc-bos/pkg/proto/devicespb"
 	"github.com/smart-core-os/sc-bos/pkg/proto/meterpb"
 )
+
+// TestController_closesDatabase checks Bootstrap registers the local bolt database for cleanup, so
+// that Run closes it on the way out. A leaked handle is invisible on Linux — it only shows up on
+// Windows, as a TempDir cleanup failure, because Windows won't unlink an open file — so assert the
+// close directly rather than relying on that symptom.
+func TestController_closesDatabase(t *testing.T) {
+	config := sysconf.Default()
+	config.PolicyMode = sysconf.PolicyOff
+	config.DataDir = t.TempDir()
+	// Don't bind real ports while testing.
+	config.ListenGRPC = ""
+	config.ListenHTTPS = ""
+
+	c, err := Bootstrap(t.Context(), config)
+	if err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+	if c.Database == nil {
+		t.Fatal("Bootstrap() left Database nil, nothing to assert on")
+	}
+
+	// Run executes the deferred closers as it returns; cancel immediately, we don't need it to do
+	// any work first.
+	ctx, cancel := context.WithCancel(t.Context())
+	runErr := make(chan error, 1)
+	go func() { runErr <- c.Run(ctx) }()
+	cancel()
+	<-runErr
+
+	if _, err := c.Database.Bolt().Begin(false); !errors.Is(err, bolterrors.ErrDatabaseNotOpen) {
+		t.Errorf("bolt database still open after Run returned: Begin() error = %v, want %v", err, bolterrors.ErrDatabaseNotOpen)
+	}
+}
 
 // TestController_protoPkgCompat tests that both versioned and unversioned proto packages are served.
 // We had a bug where only dynamically registered services (i.e. traits) were served,


### PR DESCRIPTION
`go test ./...` could not pass on a Windows host. Two test packages built paths into a virtual
filesystem (`embed.FS`, `fstest.MapFS`) with `filepath.Join`, but `io/fs` mandates forward slashes, so
on Windows the lookups missed and 42 tests failed across `internal/cloud` and `pkg/app/appconf`. Both
are green on Linux CI, which is why this went unnoticed.

Contrary to the ticket, this was not purely a test problem. `appconf.mergeWith` derived the recorded
include with `filepath.Rel`, but it serves both the OS-path loader and the `fs.FS` loader — and every
load routes through the latter, since `LoadLocalConfig` calls `LoadLocalConfigFS(os.DirFS(dir), …)`. On
Windows that put entries like `dir1\1.json` into `Config.Includes`. Two subtests could not be fixed
test-side because their expected `Includes` are hard-coded slash form, correctly. `filepath.ToSlash` is
a no-op on Linux, and the merged `Includes` is output-only, so it can't affect path resolution.

The third commit is a separate bug found once the first two landed: `Bootstrap` registers every
resource it acquires with `c.Defer` except the bolthold DB and the account store, so both stayed open
until process exit. Impact in production is modest — `cmd/bos` returns `controller.Run(ctx)` and the
process ends — but it leaks a handle for any in-process `Bootstrap` and never closes bolt cleanly.
Windows surfaced it as a `TempDir` cleanup failure. Since Linux hides the leak entirely, the test
asserts the close directly rather than relying on that symptom; I confirmed it fails against the
unfixed code.

A sweep for `filepath.Join` feeding `embed.FS`/`fs.FS`/`fstest.MapFS` found no other offenders. Two
other packages still fail on this host for unrelated reasons (`pkg/history/dataretention` disk-stat
syscalls, `internal/logdownload` mimetype registry) and are out of scope.

Verified by `go build ./...`, `go vet -lostcancel=false ./...`, full-repo `staticcheck ./...`, and
`go test` on the touched packages — green both natively on Windows (17 → 14 failing packages
repo-wide) and on Linux via WSL. The `-race` pass needs cgo/gcc, absent on this host, so it's left to
CI.

#SCB-1407 State Done
#SCB-1415 State Done
