### PR TITLE
docs: record review voice conventions

### DIFF
--- a/.claude/review-voice.md
+++ b/.claude/review-voice.md
@@ -1,0 +1,43 @@
+# Review voice
+
+How to write anything a reviewer will read: PR review bodies, line comments, and
+replies to review comments.
+
+Not PR descriptions — those carry reasoning a reviewer needs up front and are
+deliberately out of scope.
+
+## Length follows the diff
+
+- Scale the review to the PR's impact, not to how much there is to say. Internal
+  docs, cleanup, dep bumps: shorter than normal.
+- A review longer than the diff it reviews is almost always wasted effort.
+- Bullets, fragments, abbreviations. No essays, no preamble, no closing paragraph
+  restating the change.
+
+## Say it once
+
+- A point goes in the main body **or** a line comment, never both.
+- Don't list what changed since the last review.
+- Don't recap previous points that are now resolved. Raise a previous point only if
+  it's unresolved or resolved badly.
+- If you're asking for a block to be rewritten, don't also leave nits on code inside
+  it — they'll never be actioned.
+
+## Earn each request
+
+- Weigh the cost of a change against its benefit before asking. If rewording a
+  comment costs more than it's worth, don't raise it at all.
+- Good code is the bar, not perfect code.
+- Reviewing prose (docs, comments): correctness and clarity only. Style varies
+  between people; leave it alone.
+- Praise: one short sentence at most, only for something genuinely worth noting. No
+  flattery, no opening compliment.
+
+## Replies to review comments
+
+- One or two lines. What was done, or why the current approach stands.
+- Don't restate the reviewer's point back at them. No thanks-for-catching-this, no
+  summary of the wider change.
+- Disagreeing is fine — give the concrete reason in a sentence.
+
+Source: review feedback from @hexaglow, August 2026.

--- a/.claude/skills/read-pr-feedback/SKILL.md
+++ b/.claude/skills/read-pr-feedback/SKILL.md
@@ -97,7 +97,7 @@ The `COMMENT_ID` is the `id` of the review comment being replied to (from the `/
 gh api repos/{owner}/{repo}/issues/<number>/comments -f body="Reply text"
 ```
 
-Keep replies concise: what was done (with commit ref if applicable), or why the current approach is preferred.
+Replies follow `.claude/review-voice.md` — read it before writing the first one. In short: one or two lines, what was done (with commit ref if applicable) or why the current approach stands.
 
 ## Phase 5b — Integration pass
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# sc-bos
+
+## Review voice
+
+Before writing anything a reviewer will read — PR review bodies, line comments, or
+replies to review comments — read `.claude/review-voice.md` and follow it. Applies
+to `/code-review`, `/review` and `/read-pr-feedback` alike.


### PR DESCRIPTION
Reviews and review replies written by Claude have been costing @hexaglow time: change-lists since the last round, recaps of points already resolved, opening compliments, the same point made in both the review body and a line comment, and nits whose cost to action exceeds their value. He gave the list; this records it so it binds every session instead of being pasted in as a one-off prompt argument.

The pointer sits in a new root `CLAUDE.md` rather than a skill, because the biggest producers of this prose are the built-in `/code-review` and `/review`, which can't be edited from the repo. `.claude/CLAUDE.md` would have been the natural home but it's git-excluded and machine-local, so the team would never have seen it. PR descriptions are deliberately out of scope — they carry reasoning a reviewer needs up front, and the doc says so to stop a future session over-applying the rules.

Verified by confirming both new files are trackable (`git check-ignore` clean) and that the pointer resolves; the real test is behavioural, on the next `/code-review` run in a fresh session.
