### PR TITLE
ci: check that generated Protobuf code is up to date

### DIFF
--- a/.github/workflows/proto-check.yml
+++ b/.github/workflows/proto-check.yml
@@ -1,0 +1,64 @@
+name: Protobuf Generated Code Check
+on:
+  # check generated proto code on any commit that touches the generator or its inputs
+  pull_request:
+    paths:
+      - 'proto/**'
+      - 'pkg/proto/**'
+      - 'ui/ui-gen/proto/**'
+      - 'cmd/tools/genproto/**'
+      - 'cmd/tools/protoc-gen-router/**'
+      - 'cmd/tools/protoc-gen-wrapper/**'
+      - 'scripts/gen-proto.sh'
+      - 'scripts/dev-container/install-protoc.sh'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/proto-check.yml'
+
+jobs:
+  gen-proto:
+    runs-on: ubuntu-latest
+    # keep in step with cmd/tools/genproto/internal/toolchain/versions.go, which rejects
+    # any other version, and with dev.Dockerfile
+    env:
+      PROTOC_VERSION: '35.1'
+      PROTOC_GEN_JS_VERSION: '4.0.2'
+      PROTOC_GEN_GRPC_WEB_VERSION: '2.0.2'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          cache: true
+          go-version: '^1.26.x'
+
+      # the go plugins come from the go.mod tool directives, so only the native tools
+      # need installing. the script writes to /opt and /usr/local/bin, hence sudo.
+      - name: Install protoc toolchain
+        run: |
+          sudo bash scripts/dev-container/install-protoc.sh \
+            --protoc "$PROTOC_VERSION" \
+            --protoc-gen-js "$PROTOC_GEN_JS_VERSION" \
+            --protoc-gen-grpc-web "$PROTOC_GEN_GRPC_WEB_VERSION"
+
+      - name: Generate
+        run: bash scripts/gen-proto.sh
+
+      - name: Check generated code is up to date
+        run: |
+          git add -A
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+          echo "::error::Generated proto code is out of date. Run 'bash scripts/gen-proto.sh' with the pinned toolchain and commit the result."
+          git diff --cached --stat
+          git diff --cached
+          git diff --cached > proto-gen.patch
+          exit 1
+
+      - name: Upload patch
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: proto-gen-patch
+          path: proto-gen.patch
+          if-no-files-found: ignore

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -31,8 +31,8 @@ RUN chmod +x install-node.sh && \
 
 # Install protobuf tools
 COPY scripts/dev-container/install-protoc.sh install-protoc.sh
-RUN chmod +x install-protoc.sh && ./install-protoc.sh --protoc 34.0
-RUN ./install-protoc.sh --protoc-gen-js 4.0.1
+RUN chmod +x install-protoc.sh && ./install-protoc.sh --protoc 35.1
+RUN ./install-protoc.sh --protoc-gen-js 4.0.2
 RUN ./install-protoc.sh --protoc-gen-grpc-web 2.0.2
 RUN ./install-protoc.sh --protoc-gen-go 1.36.11
 RUN ./install-protoc.sh --protoc-gen-go-grpc 1.5.1


### PR DESCRIPTION
We occasionally forget to update all the generated Protobuf code when making changes. For example, PR #929 fixed some generated Protobuf code that was introduced in a previous PR.

Add a new CI workflow 'Protobuf Generated Code Check' triggered on any PR that modifies Protobuf source or generated code. It verifies that the contents of generated files is as expected. This will help us catch these problems before merge.

Modified tool versions in dev.Dockerfile to match those expected by the genproto tests, which I have taken as the source of truth.